### PR TITLE
🩹 fix: parsing logic for GuestUser to correctly handle Gravatar URLs

### DIFF
--- a/src/wikidot/module/user.py
+++ b/src/wikidot/module/user.py
@@ -239,8 +239,8 @@ class GuestUser(AbstractUser):
         ユーザー名
     unix_name: None
         ユーザーのUNIX名（ゲストユーザーのためNone）
-    avatar_url: None
-        ユーザーアバターのURL（ゲストユーザーのためNone）
+    avatar_url: str | None
+        ユーザーアバターのURL (Gravatar URL)
     ip: None
         ユーザーのIPアドレス（取得できないためNone）
     """
@@ -249,7 +249,7 @@ class GuestUser(AbstractUser):
     id: None = None
     # name: str | None
     unix_name: None = None
-    avatar_url: None = None
+    avatar_url: str | None = None
     ip: None = None
 
 

--- a/src/wikidot/util/parser/user.py
+++ b/src/wikidot/util/parser/user.py
@@ -44,6 +44,16 @@ def user_parse(client: "Client", elem: bs4.Tag) -> user.AbstractUser:
     #         name=elem.get_text().strip()
     #     )
 
+    # Gravatar URLを持つ場合はGuestUserとする
+    elif elem.find("img") and "gravatar.com" in elem.find("img")["src"]:
+        avatar_url = elem.find("img")["src"]
+        guest_name = elem.get_text().strip().split(" ")[0]
+        return user.GuestUser(
+            client=client,
+            name=guest_name,
+            avatar_url=avatar_url
+        )
+
     elif elem.get_text() == "Wikidot":
         return user.WikidotUser(client=client)
 


### PR DESCRIPTION
Updated user_parse function to correctly parse GuestUser elements by detecting Gravatar URLs. 
If the element contains an image with a Gravatar URL, it is parsed as a GuestUser, and the Gravatar URL is set as the avatar_url attribute.

Wikidot uses Gravatar to display avatars for guest users, as described in the official documentation: 
https://www.wikidot.com/more:explore-features#toc13

Examples of GuestUser:
1. http://scp-jp.wikidot.com/forum/t-2268977/
```html
<span class="printuser avatarhover">
  <a href="javascript:;">
    <img class="small" src="http://www.gravatar.com/avatar.php?gravatar_id=23463b99b62a72f26ed677cc556c44e8&default=http://www.wikidot.com/common--images/avatars/default/a16.png&size=16" alt="">
  </a>guest (ゲスト)
</span>
```

2. http://wikirb.wikidot.com/forum/t-16957468/guest2#post-6679087 (when user icons are disabled)
```html
<span class="printuser avatarhover">
  <a href="javascript:;">
    <img class="small" src="http://www.gravatar.com/avatar.php?gravatar_id=55502f40dc8b7c769880b10874abc9d0&default=http://www.wikidot.com/common--images/avatars/default/a16.png&size=16" alt="">
  </a>guest2 (guest)
</span>
```

In both examples, the presence of a Gravatar URL in the `img` tag is used to identify the user as a `GuestUser`.