### PR TITLE
fix: source取得における空白処理の修正

### DIFF
--- a/src/wikidot/module/page.py
+++ b/src/wikidot/module/page.py
@@ -477,11 +477,13 @@ class PageCollection(list["Page"]):
 
         for page, responses in zip(pages, responses):
             body = responses.json()["body"]
+            # nbspをスペースに置換
+            body = body.replace("&nbsp;", " ")
             html = BeautifulSoup(body, "lxml")
             source_element = html.select_one("div.page-source")
             if source_element is None:
                 raise exceptions.NoElementException("Cannot find source element")
-            source = source_element.text.strip().removeprefix("\t")
+            source = source_element.get_text().strip().removeprefix("\t")
             page.source = PageSource(page, source)
         return pages
 

--- a/src/wikidot/module/page_revision.py
+++ b/src/wikidot/module/page_revision.py
@@ -111,13 +111,15 @@ class PageRevisionCollection(list["PageRevision"]):
 
         for revision, response in zip(target_revisions, responses):
             body = response.json()["body"]
+            # nbspをスペースに置換
+            body = body.replace("&nbsp;", " ")
             body_html = BeautifulSoup(body, "lxml")
             wiki_text_elem = body_html.select_one("div.page-source")
             if wiki_text_elem is None:
                 raise NoElementException("Wiki text element not found")
             revision.source = PageSource(
                 page=page,
-                wiki_text=wiki_text_elem.text.strip(),
+                wiki_text=wiki_text_elem.get_text().strip(),
             )
 
         return revisions


### PR DESCRIPTION
このプルリクエストは、`_acquire_page_sources` と `_acquire_sources` の2つのメソッドにおけるテキスト処理を改善し、非改行スペース (`&nbsp;`) を適切に処理して、HTML要素からのより正確なテキスト抽出を保証します。

テキスト処理の機能強化:

* [`src/wikidot/module/page.py`](diffhunk://#diff-a2360465a6482fb08115b3f8cc73b8adbf1b967ebce38e558c17e300a1974daeR480-R486): `_acquire_page_sources` を変更し、`&nbsp;` を通常のスペースに置換するようにしました。また、HTMLコンテンツのより良い処理のために、テキスト抽出メソッドを `.text` から `.get_text()` に更新しました。
* [`src/wikidot/module/page_revision.py`](diffhunk://#diff-c2555a327415979e7df9c5f355ac860ee71030868da92aa6a6e772c4f1605134R114-R122): `_acquire_sources` を更新し、`&nbsp;` を通常のスペースに置換するようにしました。また、HTML解析の改善のために、テキスト抽出を `.text` から `.get_text()` に切り替えました。