### PR TITLE
fix: mypyエラー修正 & actions/checkout v6更新

### DIFF
--- a/.github/workflows/check_code_quality.yml
+++ b/.github/workflows/check_code_quality.yml
@@ -10,7 +10,7 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         ref: ${{ github.head_ref }}
 
@@ -44,7 +44,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         ref: ${{ github.head_ref }}
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v4

--- a/src/wikidot/module/forum_post.py
+++ b/src/wikidot/module/forum_post.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Optional
 
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, Tag
 
 from ..common.exceptions import NoElementException
 from ..util.parser import odate as odate_parser
@@ -117,8 +117,8 @@ class ForumPostCollection(list["ForumPost"]):
             if parent_container is not None:
                 grandparent = parent_container.parent
                 if grandparent is not None and grandparent.name != "body":
-                    grandparent_class = grandparent.get("class", [])
-                    if "post-container" in grandparent_class:
+                    grandparent_class = grandparent.get("class")
+                    if isinstance(grandparent_class, list) and "post-container" in grandparent_class:
                         parent_post = grandparent.find("div", class_="post", recursive=False)
                         if parent_post is not None:
                             parent_id_attr = parent_post.get("id")
@@ -277,7 +277,7 @@ class ForumPost:
         投稿のタイトル
     text : str
         投稿の本文（HTMLテキスト）
-    element : BeautifulSoup
+    element : Tag
         投稿のHTML要素（解析用）
     created_by : AbstractUser
         投稿の作成者
@@ -297,7 +297,7 @@ class ForumPost:
     id: int
     title: str
     text: str
-    element: BeautifulSoup
+    element: Tag
     created_by: "AbstractUser"
     created_at: datetime
     edited_by: Optional["AbstractUser"] = None
@@ -412,7 +412,7 @@ class ForumPost:
         revision_elem = html.select_one("input[name='currentRevisionId']")
         if revision_elem is None:
             raise NoElementException("Current revision ID input is not found.")
-        current_revision_id = int(revision_elem["value"])
+        current_revision_id = int(str(revision_elem["value"]))
 
         # 編集を保存
         self.thread.site.amc_request(

--- a/src/wikidot/module/page_file.py
+++ b/src/wikidot/module/page_file.py
@@ -169,7 +169,7 @@ class PageFileCollection(list["PageFile"]):
             url = f"{page.site.url}{href}"
 
             mime_elem = tds[1].select_one("span")
-            mime_type = mime_elem.get("title", "") if mime_elem else ""
+            mime_type = str(mime_elem.get("title", "")) if mime_elem else ""
 
             size_text = tds[2].get_text().strip()
             size = PageFileCollection._parse_size(size_text)


### PR DESCRIPTION
## Summary
- mypyエラー修正（5件）
- actions/checkout を v4 から v6 に更新

## Changes

### mypy修正
- `page_file.py:172`: `mime_type` を `str()` でキャスト
- `forum_post.py:13`: `Tag` をインポート
- `forum_post.py:120-121`: `class` 属性を `isinstance` でリスト型チェック
- `forum_post.py:300`: `element` フィールドの型を `BeautifulSoup` → `Tag` に修正
- `forum_post.py:415`: `revision_elem["value"]` を `str()` でキャスト

### actions/checkout更新
- check_code_quality.yml: v4 → v6
- docs.yml: v4 → v6
- publish.yml: v4 → v6

## Test plan
- [x] `make lint` 成功（mypy含む）