### PR TITLE
chore: CI/CD設定からdevelopブランチ参照を削除

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    target-branch: "develop"
+    target-branch: "main"
     assignees:
       - "ukwhatn"
     reviewers:
@@ -13,7 +13,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    target-branch: "develop"
+    target-branch: "main"
     assignees:
       - "ukwhatn"
     reviewers:

--- a/.github/workflows/check_code_quality.yml
+++ b/.github/workflows/check_code_quality.yml
@@ -3,7 +3,6 @@ name: Check Code Quality
 on:
   pull_request:
     branches:
-      - develop
       - main
 
 jobs:


### PR DESCRIPTION
## Summary
- dependabot.yml: target-branchを`develop`から`main`に変更
- check_code_quality.yml: PR対象ブランチから`develop`を削除

## 背景
developブランチを廃止し、main + featureブランチのみの運用に変更するため。