### PR TITLE
chore: dependabot設定を最新のベストプラクティスに更新

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default code owners for all files
+* @ukwhatn

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,19 @@ updates:
     target-branch: "main"
     assignees:
       - "ukwhatn"
-    reviewers:
-      - "ukwhatn"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+      testing:
+        patterns:
+          - "pytest*"
+      linting:
+        patterns:
+          - "ruff"
+          - "mypy"
+    cooldown:
+      default: 3
+      patch: 1
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -16,5 +27,7 @@ updates:
     target-branch: "main"
     assignees:
       - "ukwhatn"
-    reviewers:
-      - "ukwhatn"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

- 非推奨の`reviewers`オプションを削除（2025年8月に廃止済み）
- `.github/CODEOWNERS`ファイルを追加（レビュアー設定の移行先）
- `groups`を追加してPR数を削減
  - `dev-dependencies`: 開発依存をまとめる
  - `testing`: pytest関連
  - `linting`: ruff, mypy
  - `github-actions`: GitHub Actions関連
- `cooldown`を追加（新リリースの待機期間）
  - デフォルト: 3日
  - パッチ: 1日

## References

- [Dependabot reviewers configuration option is replaced by code owners](https://github.blog/changelog/2025-08-08-dependabot-reviewers-configuration-option-is-replaced-by-code-owners/)
- [Dependabot supports configuration of a minimum package age](https://github.blog/changelog/2025-07-01-dependabot-supports-configuration-of-a-minimum-package-age/)

## Test plan

- [ ] dependabot.ymlの構文が正しいことを確認（CIでyamlチェック通過）
- [ ] 次回のdependabot実行時に正常に動作することを確認