### PR TITLE
chore: PyPI Trusted Publishingに移行

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
## Summary

- PYPI_API_TOKENシークレットを使用した認証からOIDC認証（Trusted Publishing）に移行
- セキュリティ向上: 長期トークンの管理が不要に

## 変更内容

- `permissions: id-token: write` を追加（OIDC認証に必要）
- `permissions: contents: read` を追加（checkout用）
- `user`/`password` パラメータを削除

## 必要な設定

このPRをマージする前に、PyPIでTrusted Publisherを設定する必要があります:

1. https://pypi.org/manage/project/wikidot/settings/publishing/ にアクセス
2. "Add a new publisher" をクリック
3. 以下を設定:
   - Owner: ukwhatn
   - Repository name: wikidot.py
   - Workflow name: publish.yml
   - Environment name: (空欄)

## 参考

- [PyPI Trusted Publishers docs](https://docs.pypi.org/trusted-publishers/)
- [pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish)