### PR TITLE
feat: amc_requestの部分失敗耐性を追加

### DIFF
--- a/src/wikidot/module/forum_post.py
+++ b/src/wikidot/module/forum_post.py
@@ -295,7 +295,7 @@ class ForumPostCollection(list["ForumPost"]):
         site = threads[0].site
 
         # Step 1: Get the first page of all threads
-        first_page_responses = site.amc_request(
+        first_page_responses = site.amc_request_with_retry(
             [
                 {
                     "moduleName": "forum/ForumViewThreadPostsModule",
@@ -310,6 +310,8 @@ class ForumPostCollection(list["ForumPost"]):
         additional_requests: list[tuple[ForumThread, int]] = []
 
         for thread, response in zip(threads, first_page_responses, strict=True):
+            if response is None:
+                continue
             body = response.json()["body"]
             html = BeautifulSoup(body, "lxml")
 
@@ -335,7 +337,7 @@ class ForumPostCollection(list["ForumPost"]):
 
         # Step 3: Fetch additional pages
         if len(additional_requests) > 0:
-            additional_responses = site.amc_request(
+            additional_responses = site.amc_request_with_retry(
                 [
                     {
                         "moduleName": "forum/ForumViewThreadPostsModule",
@@ -347,6 +349,8 @@ class ForumPostCollection(list["ForumPost"]):
             )
 
             for (thread, _page), response in zip(additional_requests, additional_responses, strict=True):
+                if response is None:
+                    continue
                 body = response.json()["body"]
                 html = BeautifulSoup(body, "lxml")
                 posts = ForumPostCollection._parse(thread, html)

--- a/src/wikidot/module/forum_thread.py
+++ b/src/wikidot/module/forum_thread.py
@@ -305,7 +305,7 @@ class ForumThreadCollection(list["ForumThread"]):
         if last_page == 1:
             return ForumThreadCollection(site=category.site, threads=threads)
 
-        responses = category.site.amc_request(
+        responses = category.site.amc_request_with_retry(
             [
                 {
                     "p": page,
@@ -317,6 +317,8 @@ class ForumThreadCollection(list["ForumThread"]):
         )
 
         for response in responses:
+            if response is None:
+                continue
             body = response.json()["body"]
             html = BeautifulSoup(body, "lxml")
             threads.extend(ForumThreadCollection._parse_list_in_category(category.site, html, category))

--- a/src/wikidot/module/page.py
+++ b/src/wikidot/module/page.py
@@ -679,7 +679,7 @@ class PageCollection(list["Page"]):
         if len(pages) == 0:
             return pages
 
-        responses = site.amc_request(
+        responses = site.amc_request_with_retry(
             [
                 {
                     "moduleName": "history/PageRevisionListModule",
@@ -692,6 +692,8 @@ class PageCollection(list["Page"]):
         )
 
         for page, response in zip(pages, responses, strict=True):
+            if response is None:
+                continue
             body = response.json()["body"]
             revs = []
             body_html = BeautifulSoup(body, "lxml")
@@ -771,11 +773,13 @@ class PageCollection(list["Page"]):
         if len(pages) == 0:
             return pages
 
-        responses = site.amc_request(
+        responses = site.amc_request_with_retry(
             [{"moduleName": "pagerate/WhoRatedPageModule", "pageId": page.id} for page in pages]
         )
 
         for page, response in zip(pages, responses, strict=True):
+            if response is None:
+                continue
             body = response.json()["body"]
             html = BeautifulSoup(body, "lxml")
             user_elems = html.select("span.printuser")

--- a/src/wikidot/module/site.py
+++ b/src/wikidot/module/site.py
@@ -14,6 +14,7 @@ else:
 
 from ..common import exceptions
 from ..common.decorators import login_required
+from ..common.logger import logger
 from ..util.http import sync_get_with_retry
 from ..util.parser import odate as odate_parser
 from ..util.parser import user as user_parser
@@ -423,6 +424,51 @@ class Site:
             return self.client.amc_client.request(bodies, True, self.unix_name, self.ssl_supported)
         else:
             return self.client.amc_client.request(bodies, False, self.unix_name, self.ssl_supported)
+
+    def amc_request_with_retry(self, bodies: list[dict[str, Any]]) -> tuple[httpx.Response | None, ...]:
+        """Execute amc_request with partial failure tolerance.
+
+        Failed requests are retried once. Still-failed requests return None.
+
+        Parameters
+        ----------
+        bodies : list[dict]
+            List of request bodies
+
+        Returns
+        -------
+        tuple[httpx.Response | None, ...]
+            Responses for each body. None for permanently failed requests.
+        """
+        responses = self.amc_request(bodies, return_exceptions=True)
+        results: list[httpx.Response | None] = []
+        failed_indices: list[int] = []
+
+        for i, resp_or_exc in enumerate(responses):
+            if isinstance(resp_or_exc, Exception):
+                results.append(None)
+                failed_indices.append(i)
+            else:
+                results.append(resp_or_exc)
+
+        if failed_indices:
+            retry_bodies = [bodies[i] for i in failed_indices]
+            logger.warning(
+                "amc_request_with_retry: %d/%d requests failed, retrying",
+                len(failed_indices),
+                len(bodies),
+            )
+            retry_responses = self.amc_request(retry_bodies, return_exceptions=True)
+            for idx, retry_resp in zip(failed_indices, retry_responses, strict=True):
+                if isinstance(retry_resp, Exception):
+                    logger.warning(
+                        "amc_request_with_retry: retry failed, skipping: %s",
+                        retry_resp,
+                    )
+                else:
+                    results[idx] = retry_resp
+
+        return tuple(results)
 
     @property
     def applications(self) -> list[SiteApplication]:


### PR DESCRIPTION
## Summary
- `Site.amc_request_with_retry()` メソッドを追加: 大量並列リクエストで一部が失敗した場合、失敗分のみ1回リトライし、それでも失敗した分はNoneを返す
- 以下の4メソッドの大量リクエスト部分を `amc_request_with_retry` 経由に変更:
  - `ForumThreadCollection.acquire_all_in_category()`
  - `ForumPostCollection.acquire_all_in_threads()`（2箇所）
  - `PageCollection._acquire_page_revisions()`
  - `PageCollection._acquire_page_votes()`

## Background
panopticon-batchのSync Forum GHAが、~1,352ページの並列取得で数ページ（0.07%〜0.4%）が失敗するために100%失敗していた。既存の5回リトライ（指数バックオフ）を経ても失敗するケースで、成功した残り99.6%の結果も破棄される設計だった。

## Test plan
- [x] `make format` — OK
- [x] `make lint` — OK（ruff + mypy パス）
- [x] `make test-unit` — 446 passed
- [ ] panopticon Sync Forum GHAで最終確認