### PR TITLE
feat: amc_request_with_retryにバッチ分割・複数回リトライ・Config対応を追加

### DIFF
--- a/src/wikidot/connector/ajax.py
+++ b/src/wikidot/connector/ajax.py
@@ -329,7 +329,7 @@ class AjaxModuleConnectorClient:
         site_name = site_name if site_name is not None else self.site_name
         site_ssl_supported = site_ssl_supported if site_ssl_supported is not None else self.ssl_supported
 
-        async def _request(_body: dict[str, Any]) -> httpx.Response:
+        async def _request(_body: dict[str, Any], client: httpx.AsyncClient) -> httpx.Response:
             retry_count = 0
             response: httpx.Response | None = None
 
@@ -337,7 +337,7 @@ class AjaxModuleConnectorClient:
                 # Execute request
                 try:
                     # Control concurrent execution with Semaphore
-                    async with semaphore_instance, httpx.AsyncClient() as client:
+                    async with semaphore_instance:
                         url = (
                             f"http{'s' if site_ssl_supported else ''}://{site_name}.wikidot.com/"
                             f"ajax-module-connector.php"
@@ -464,10 +464,11 @@ class AjaxModuleConnectorClient:
                 return response
 
         async def _execute_requests() -> list[httpx.Response | BaseException]:
-            return await asyncio.gather(
-                *[_request(body) for body in bodies],
-                return_exceptions=return_exceptions,
-            )
+            async with httpx.AsyncClient() as client:
+                return await asyncio.gather(
+                    *[_request(body, client) for body in bodies],
+                    return_exceptions=return_exceptions,
+                )
 
         # Execute processing (works safely even in existing loop environments)
         results: list[httpx.Response | BaseException] = run_coroutine(_execute_requests())

--- a/src/wikidot/connector/ajax.py
+++ b/src/wikidot/connector/ajax.py
@@ -129,6 +129,10 @@ class AjaxModuleConnectorConfig:
         Exponential backoff factor (interval is multiplied by this factor for each retry)
     semaphore_limit : int, default 10
         Maximum number of concurrent async requests
+    retry_batch_size : int, default 50
+        Default batch size for amc_request_with_retry
+    retry_max_retries : int, default 3
+        Default maximum retry attempts for amc_request_with_retry
     """
 
     request_timeout: int = 20
@@ -137,6 +141,8 @@ class AjaxModuleConnectorConfig:
     max_backoff: float = 60.0
     backoff_factor: float = 2.0
     semaphore_limit: int = 10
+    retry_batch_size: int = 50
+    retry_max_retries: int = 3
 
 
 def _mask_sensitive_data(body: dict[str, Any]) -> dict[str, Any]:

--- a/src/wikidot/module/site.py
+++ b/src/wikidot/module/site.py
@@ -425,50 +425,81 @@ class Site:
         else:
             return self.client.amc_client.request(bodies, False, self.unix_name, self.ssl_supported)
 
-    def amc_request_with_retry(self, bodies: list[dict[str, Any]]) -> tuple[httpx.Response | None, ...]:
-        """Execute amc_request with partial failure tolerance.
+    def amc_request_with_retry(
+        self,
+        bodies: list[dict[str, Any]],
+        *,
+        batch_size: int = 50,
+        max_retries: int = 3,
+    ) -> tuple[httpx.Response | None, ...]:
+        """Execute amc_request with batch splitting and partial failure tolerance.
 
-        Failed requests are retried once. Still-failed requests return None.
+        Requests are split into batches and failed requests are retried
+        up to max_retries times. Still-failed requests return None.
 
         Parameters
         ----------
         bodies : list[dict]
             List of request bodies
+        batch_size : int, default 50
+            Number of requests per batch
+        max_retries : int, default 3
+            Maximum number of retry attempts for failed requests
 
         Returns
         -------
         tuple[httpx.Response | None, ...]
             Responses for each body. None for permanently failed requests.
         """
-        responses = self.amc_request(bodies, return_exceptions=True)
-        results: list[httpx.Response | None] = []
-        failed_indices: list[int] = []
+        all_results: list[httpx.Response | None] = []
 
-        for i, resp_or_exc in enumerate(responses):
-            if isinstance(resp_or_exc, Exception):
-                results.append(None)
-                failed_indices.append(i)
-            else:
-                results.append(resp_or_exc)
+        for batch_start in range(0, len(bodies), batch_size):
+            batch = bodies[batch_start : batch_start + batch_size]
 
-        if failed_indices:
-            retry_bodies = [bodies[i] for i in failed_indices]
-            logger.warning(
-                "amc_request_with_retry: %d/%d requests failed, retrying",
-                len(failed_indices),
-                len(bodies),
-            )
-            retry_responses = self.amc_request(retry_bodies, return_exceptions=True)
-            for idx, retry_resp in zip(failed_indices, retry_responses, strict=True):
-                if isinstance(retry_resp, Exception):
-                    logger.warning(
-                        "amc_request_with_retry: retry failed, skipping: %s",
-                        retry_resp,
-                    )
+            responses = self.amc_request(batch, return_exceptions=True)
+            batch_results: list[httpx.Response | None] = []
+            failed_indices: list[int] = []
+
+            for i, resp_or_exc in enumerate(responses):
+                if isinstance(resp_or_exc, Exception):
+                    batch_results.append(None)
+                    failed_indices.append(i)
                 else:
-                    results[idx] = retry_resp
+                    batch_results.append(resp_or_exc)
 
-        return tuple(results)
+            for attempt in range(max_retries):
+                if not failed_indices:
+                    break
+                retry_bodies = [batch[i] for i in failed_indices]
+                logger.warning(
+                    "amc_request_with_retry: %d/%d requests failed, retrying (attempt %d/%d)",
+                    len(failed_indices),
+                    len(batch),
+                    attempt + 1,
+                    max_retries,
+                )
+                retry_responses = self.amc_request(retry_bodies, return_exceptions=True)
+
+                still_failed_indices: list[int] = []
+                for j, retry_resp in enumerate(retry_responses):
+                    if isinstance(retry_resp, Exception):
+                        still_failed_indices.append(failed_indices[j])
+                    else:
+                        batch_results[failed_indices[j]] = retry_resp
+                failed_indices = still_failed_indices
+
+            all_results.extend(batch_results)
+
+        failed_count = sum(1 for r in all_results if r is None)
+        if failed_count > 0:
+            logger.warning(
+                "amc_request_with_retry: %d/%d succeeded (%d failed)",
+                len(all_results) - failed_count,
+                len(all_results),
+                failed_count,
+            )
+
+        return tuple(all_results)
 
     @property
     def applications(self) -> list[SiteApplication]:

--- a/src/wikidot/module/site.py
+++ b/src/wikidot/module/site.py
@@ -429,8 +429,8 @@ class Site:
         self,
         bodies: list[dict[str, Any]],
         *,
-        batch_size: int = 50,
-        max_retries: int = 3,
+        batch_size: int | None = None,
+        max_retries: int | None = None,
     ) -> tuple[httpx.Response | None, ...]:
         """Execute amc_request with batch splitting and partial failure tolerance.
 
@@ -441,16 +441,21 @@ class Site:
         ----------
         bodies : list[dict]
             List of request bodies
-        batch_size : int, default 50
-            Number of requests per batch
-        max_retries : int, default 3
-            Maximum number of retry attempts for failed requests
+        batch_size : int | None, optional
+            Number of requests per batch.
+            Defaults to config.retry_batch_size if not specified.
+        max_retries : int | None, optional
+            Maximum number of retry attempts for failed requests.
+            Defaults to config.retry_max_retries if not specified.
 
         Returns
         -------
         tuple[httpx.Response | None, ...]
             Responses for each body. None for permanently failed requests.
         """
+        config = self.client.amc_client.config
+        batch_size = batch_size if batch_size is not None else config.retry_batch_size
+        max_retries = max_retries if max_retries is not None else config.retry_max_retries
         all_results: list[httpx.Response | None] = []
 
         for batch_start in range(0, len(bodies), batch_size):

--- a/src/wikidot/module/site.py
+++ b/src/wikidot/module/site.py
@@ -456,6 +456,12 @@ class Site:
         config = self.client.amc_client.config
         batch_size = batch_size if batch_size is not None else config.retry_batch_size
         max_retries = max_retries if max_retries is not None else config.retry_max_retries
+
+        if batch_size <= 0:
+            raise ValueError(f"batch_size must be positive, got {batch_size}")
+        if max_retries < 0:
+            raise ValueError(f"max_retries must be non-negative, got {max_retries}")
+
         all_results: list[httpx.Response | None] = []
 
         for batch_start in range(0, len(bodies), batch_size):


### PR DESCRIPTION
## Summary
- `httpx.AsyncClient` をリクエスト間で共有しTCP接続プールを再利用（従来はリクエストごとに新規作成）
- `amc_request_with_retry` に `batch_size` (デフォルト50) 単位のバッチ分割を追加
- 失敗リクエストの `max_retries` (デフォルト3) 回リトライを追加（従来は1回固定）
- `AjaxModuleConnectorConfig` に `retry_batch_size` / `retry_max_retries` を追加し、設定から変更可能に
- 入力バリデーション追加（正の整数チェック）

## Test plan
- [ ] format/lint/mypy パス確認
- [ ] 実環境（GHA/Azure US-East）でのフォーラムスレッド大量取得テスト