### PR TITLE
chore: dependabot設定をpanopticon準拠に統一

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,31 +3,42 @@ updates:
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     target-branch: "main"
+    open-pull-requests-limit: 10
     assignees:
       - "ukwhatn"
-    groups:
-      dev-dependencies:
-        dependency-type: "development"
-      testing:
-        patterns:
-          - "pytest*"
-      linting:
-        patterns:
-          - "ruff"
-          - "mypy"
     cooldown:
       default-days: 3
       semver-patch-days: 1
+    groups:
+      # group を分けると同じ weekly run で複数PRが同じ uv.lock を触って
+      # コンフリクトが発生するため、全 version-updates を 1PR に集約する
+      uv-all:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      # security-updates は即応が必要なので version-updates とは別 PR で fast-track
+      uv-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     target-branch: "main"
+    open-pull-requests-limit: 5
     assignees:
       - "ukwhatn"
+    cooldown:
+      default-days: 3
     groups:
       github-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      github-actions-security:
+        applies-to: security-updates
         patterns:
           - "*"


### PR DESCRIPTION
## Summary

dependabot の設定を panopticon リポジトリの構成に揃える。従来の daily + 細分化グループ（dev-dependencies/testing/linting）では同一 run の複数PRが同じ uv.lock を触ってコンフリクトしやすいため、version-updates を1PRに集約する構成へ変更する。

## Related Issue

なし

## Changes

- schedule を daily → weekly に変更
- groups を再編
  - `uv-all`: 全 version-updates を1PRに集約（共有 lockfile のコンフリクト回避）
  - `uv-security`: security-updates を別PRで fast-track
  - `github-actions` / `github-actions-security`: 同様の2グループ構成
- `open-pull-requests-limit` を追加（uv: 10 / github-actions: 5）
- github-actions entry にも cooldown（default-days: 3）を追加

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test addition/modification
- [x] CI/CD or build related

## Testing

設定ファイルのみの変更のためアプリコードのチェックは対象外（変更なし）。

- [x] dependabot.yml の YAML parse 確認（PyYAML safe_load）
- [ ] `make format` passes（N/A）
- [ ] `make lint` passes（N/A）
- [ ] `make test` passes（N/A）

## Checklist

- [x] Code follows the project's style guidelines
- [x] Documentation has been updated as needed
- [ ] Tests have been added for the changes (if applicable)

## Additional Information

- グループ再編により、旧グループ（dev-dependencies/testing/linting 等）ベースの既存 dependabot PR は、本PRマージ後の次回 run でクローズ・再作成される（現在 dependabot/uv/main/* ブランチが複数オープン中）
- 設定の元ネタ: SCP-JP/panopticon の .github/dependabot.yml

https://claude.ai/code/session_01C44DSTLUsKZdKjm5ghaUHg