### PR TITLE
AMC transport 層の是正

### DIFF
--- a/src/wikidot/common/exceptions.py
+++ b/src/wikidot/common/exceptions.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 # ---
 # Base class
 # ---
@@ -139,16 +141,73 @@ class WikidotStatusCodeException(AjaxModuleConnectorException):
         Exception message
     status_code : str
         Error status code returned by Wikidot
+    response : dict[str, Any] | None, default None
+        Raw AMC response body, when available. Kept optional so existing
+        call sites that only pass message/status_code keep working
 
     Attributes
     ----------
     status_code : str
         Error status code returned by Wikidot
+    response : dict[str, Any] | None
+        Raw AMC response body, when available
     """
 
-    def __init__(self, message: str, status_code: str) -> None:
+    def __init__(self, message: str, status_code: str, response: dict[str, Any] | None = None) -> None:
         super().__init__(message)
         self.status_code = status_code
+        self.response = response
+
+
+class FormErrorsException(WikidotStatusCodeException):
+    """
+    Exception raised when the response status is "form_errors" / "form_error"
+
+    Wikidot returns this as part of the normal control flow for many save
+    operations (validation failure), not as a transport-level error. The
+    payload key holding the per-field messages differs by module
+    (`formErrors` for most modules, `errors` for `WikiPageAction/savePage`,
+    a plain string under `message` for modules such as `saveTags` or the
+    singular `form_error` status). The `errors` property absorbs this
+    difference and always exposes `dict[str, str]`.
+
+    Parameters
+    ----------
+    message : str
+        Exception message
+    status_code : str
+        Error status code returned by Wikidot ("form_errors" or "form_error")
+    response : dict[str, Any] | None, default None
+        Raw AMC response body
+    """
+
+    def __init__(self, message: str, status_code: str, response: dict[str, Any] | None = None) -> None:
+        super().__init__(message, status_code, response)
+
+    @property
+    def errors(self) -> dict[str, str]:
+        """
+        Get field name to error message mapping
+
+        Absorbs the `formErrors` / `errors` / `message` key variance across
+        modules. When only a plain `message` string is available (no field
+        name), it is exposed under the sentinel key `"_message"`.
+
+        Returns
+        -------
+        dict[str, str]
+            Field name to error message mapping. Empty if the response has
+            none of the known keys
+        """
+        response = self.response or {}
+        for key in ("formErrors", "errors"):
+            value = response.get(key)
+            if isinstance(value, dict):
+                return value
+        message = response.get("message")
+        if isinstance(message, str):
+            return {"_message": message}
+        return {}
 
 
 class ResponseDataException(AjaxModuleConnectorException):

--- a/src/wikidot/common/exceptions.py
+++ b/src/wikidot/common/exceptions.py
@@ -205,7 +205,7 @@ class FormErrorsException(WikidotStatusCodeException):
             if isinstance(value, dict):
                 return value
         message = response.get("message")
-        if isinstance(message, str):
+        if isinstance(message, str) and message:
             return {"_message": message}
         return {}
 

--- a/src/wikidot/connector/ajax.py
+++ b/src/wikidot/connector/ajax.py
@@ -204,6 +204,39 @@ def _calculate_backoff(
     return min(backoff + jitter, max_backoff)
 
 
+def require_body(response: httpx.Response, module_name: str) -> str:
+    """
+    Get the "body" field from an AMC response, raising if it is missing
+
+    A nonexistent moduleName does not cause an error on Wikidot's side;
+    it responds with HTTP 200 and status "ok" but without a "body" field,
+    so a typo in the module name would otherwise pass through silently.
+    Callers that require rendered HTML should always go through this
+    helper instead of indexing response.json()["body"] directly.
+
+    Parameters
+    ----------
+    response : httpx.Response
+        AMC response expected to carry a "body" field
+    module_name : str
+        Module name that was requested, used only for the error message
+
+    Returns
+    -------
+    str
+        Value of the "body" field
+
+    Raises
+    ------
+    ResponseDataException
+        If the response has no "body" field
+    """
+    data = response.json()
+    if "body" not in data:
+        raise ResponseDataException(f'AMC response for module "{module_name}" is missing "body"')
+    return data["body"]
+
+
 def _encode_amc_body(body: dict[str, Any]) -> dict[str, Any]:
     """
     Rewrite list-valued keys to their bracket form for an AMC request body

--- a/src/wikidot/connector/ajax.py
+++ b/src/wikidot/connector/ajax.py
@@ -447,7 +447,8 @@ class AjaxModuleConnectorClient:
                             f"(possibly unsupported action/event) -> {_mask_sensitive_data(_body)}"
                         )
                         raise AMCHttpStatusCodeException(
-                            "AMC request failed: HTTP 500 with empty body (未対応の action/event の可能性があります)",
+                            "AMC request failed: HTTP 500 with empty body "
+                            "(the action/event may not be supported by Wikidot)",
                             500,
                         ) from e
 

--- a/src/wikidot/connector/ajax.py
+++ b/src/wikidot/connector/ajax.py
@@ -18,12 +18,17 @@ from ..common import wd_logger
 from ..common.exceptions import (
     AMCHttpStatusCodeException,
     ForbiddenException,
+    FormErrorsException,
     NotFoundException,
     ResponseDataException,
     WikidotStatusCodeException,
 )
 from ..util.async_helper import run_coroutine
 from ..util.http import sync_get_with_retry
+
+#: status values that carry form validation errors as part of the normal
+#: control flow (not a transport-level error). See FormErrorsException.
+_FORM_ERROR_STATUSES = frozenset({"form_errors", "form_error"})
 
 
 class AjaxRequestHeader:
@@ -432,7 +437,9 @@ class AjaxModuleConnectorClient:
                         retry_count += 1
                         if retry_count >= self.config.attempt_limit:
                             wd_logger.error(f'AMC is respond status: "try_again" -> {_mask_sensitive_data(_body)}')
-                            raise WikidotStatusCodeException('AMC is respond status: "try_again"', "try_again")
+                            raise WikidotStatusCodeException(
+                                'AMC is respond status: "try_again"', "try_again", _response_body
+                            )
 
                         # Retry with exponential backoff interval
                         backoff = _calculate_backoff(
@@ -455,6 +462,20 @@ class AjaxModuleConnectorClient:
                             target_str = f"action: {_body['action']}/{_body['event'] if 'event' in _body else ''}"
                         raise ForbiddenException(f"Your account has no permission to perform this action: {target_str}")
 
+                    # form_errors / form_error is part of the normal control flow for many
+                    # save operations (form validation failure), not a transport error.
+                    # Raise the dedicated subclass so callers can read the per-field
+                    # messages via e.errors instead of only getting a generic message
+                    elif _response_body["status"] in _FORM_ERROR_STATUSES:
+                        wd_logger.info(
+                            f'AMC is respond status: "{_response_body["status"]}" -> {_mask_sensitive_data(_body)}'
+                        )
+                        raise FormErrorsException(
+                            f'AMC is respond error status: "{_response_body["status"]}"',
+                            _response_body["status"],
+                            _response_body,
+                        )
+
                     # Treat as error if status is not ok for other cases
                     elif _response_body["status"] != "ok":
                         wd_logger.error(
@@ -464,6 +485,7 @@ class AjaxModuleConnectorClient:
                         raise WikidotStatusCodeException(
                             f'AMC is respond error status: "{_response_body["status"]}"',
                             _response_body["status"],
+                            _response_body,
                         )
 
                 # Return response

--- a/src/wikidot/connector/ajax.py
+++ b/src/wikidot/connector/ajax.py
@@ -441,13 +441,19 @@ class AjaxModuleConnectorClient:
                                 'AMC is respond status: "try_again"', "try_again", _response_body
                             )
 
-                        # Retry with exponential backoff interval
-                        backoff = _calculate_backoff(
-                            retry_count,
-                            self.config.retry_interval,
-                            self.config.backoff_factor,
-                            self.config.max_backoff,
-                        )
+                        # Honor the server-specified time_to_wait (seconds) when present,
+                        # capped by max_backoff so a server-supplied value can't stall a
+                        # request indefinitely. Otherwise fall back to exponential backoff
+                        time_to_wait = _response_body.get("time_to_wait")
+                        if isinstance(time_to_wait, (int, float)) and not isinstance(time_to_wait, bool):
+                            backoff = min(float(time_to_wait), self.config.max_backoff)
+                        else:
+                            backoff = _calculate_backoff(
+                                retry_count,
+                                self.config.retry_interval,
+                                self.config.backoff_factor,
+                                self.config.max_backoff,
+                            )
                         wd_logger.info(
                             f'AMC is respond status: "try_again" (retry: {retry_count}, backoff: {backoff:.2f}s)'
                         )

--- a/src/wikidot/connector/ajax.py
+++ b/src/wikidot/connector/ajax.py
@@ -204,6 +204,38 @@ def _calculate_backoff(
     return min(backoff + jitter, max_backoff)
 
 
+def _encode_amc_body(body: dict[str, Any]) -> dict[str, Any]:
+    """
+    Rewrite list-valued keys to their bracket form for an AMC request body
+
+    Browsers serialize array parameters via jQuery.param as repeated
+    `key[]=v1&key[]=v2`. httpx's `data=` accepts a Mapping whose values may
+    be a list, but it reuses the key as-is for each item, producing
+    `key=v1&key=v2` (no brackets) instead. Some AMC modules
+    (DashboardMessageAction, ManageSiteNewsletterAction/send) expect the
+    bracketed form, so list-valued keys are renamed to "key[]" here; httpx's
+    own list expansion (see httpx._content.encode_urlencoded_data) then
+    produces "key[]=v1&key[]=v2" as desired. The result stays a plain dict
+    (still a Mapping) since httpx's data= only supports raw byte content for
+    non-Mapping values.
+
+    Parameters
+    ----------
+    body : dict[str, Any]
+        Request body to encode
+
+    Returns
+    -------
+    dict[str, Any]
+        body with list-valued keys renamed to "key[]"; scalar-only bodies
+        are returned unchanged
+    """
+    if not any(isinstance(v, list) for v in body.values()):
+        return body
+
+    return {(f"{key}[]" if isinstance(value, list) else key): value for key, value in body.items()}
+
+
 class AjaxModuleConnectorClient:
     """
     Client class for communicating with Wikidot's Ajax Module Connector
@@ -358,7 +390,7 @@ class AjaxModuleConnectorClient:
                         response = await client.post(
                             url,
                             headers=self.header.get_header(),
-                            data=_body,
+                            data=_encode_amc_body(_body),
                             timeout=self.config.request_timeout,
                         )
                         response.raise_for_status()

--- a/src/wikidot/connector/ajax.py
+++ b/src/wikidot/connector/ajax.py
@@ -363,6 +363,29 @@ class AjaxModuleConnectorClient:
                         )
                         response.raise_for_status()
                 except (httpx.HTTPStatusError, httpx.RequestError) as e:
+                    # An unrecognized action/event responds with HTTP 500 and an empty
+                    # body (PHP-level fatal error), which is indistinguishable from a
+                    # transient server error except for these three conditions together.
+                    # Retrying it would only waste attempt_limit rounds of backoff, so
+                    # fail immediately instead. Requests without "action" (module
+                    # rendering only) keep the normal retry behavior below, since a
+                    # spike-induced 500 there is otherwise indistinguishable
+                    if (
+                        isinstance(e, httpx.HTTPStatusError)
+                        and response is not None
+                        and response.status_code == 500
+                        and len(response.content) == 0
+                        and "action" in _body
+                    ):
+                        wd_logger.error(
+                            f"AMC request failed: HTTP 500 with empty body "
+                            f"(possibly unsupported action/event) -> {_mask_sensitive_data(_body)}"
+                        )
+                        raise AMCHttpStatusCodeException(
+                            "AMC request failed: HTTP 500 with empty body (未対応の action/event の可能性があります)",
+                            500,
+                        ) from e
+
                     # Retry on all request errors (HTTP errors, timeouts, network errors, etc.)
                     # Wikidot server has a relatively high error rate, so retry is essential
                     retry_count += 1

--- a/src/wikidot/module/forum_category.py
+++ b/src/wikidot/module/forum_category.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Optional
 from bs4 import BeautifulSoup
 
 from ..common.exceptions import NoElementException
+from ..connector.ajax import require_body
 from .forum_thread import ForumThread, ForumThreadCollection
 
 if TYPE_CHECKING:
@@ -109,7 +110,7 @@ class ForumCategoryCollection(list["ForumCategory"]):
 
         response = site.amc_request([{"moduleName": "forum/ForumStartModule", "hidden": "true"}])[0]
 
-        body = response.json()["body"]
+        body = require_body(response, "forum/ForumStartModule")
         html = BeautifulSoup(body, "lxml")
 
         for row in html.select("table tr.head~tr"):

--- a/src/wikidot/module/forum_post.py
+++ b/src/wikidot/module/forum_post.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Optional
 from bs4 import BeautifulSoup, Tag
 
 from ..common.exceptions import NoElementException
+from ..connector.ajax import require_body
 from ..util.parser import odate as odate_parser
 from ..util.parser import user as user_parser
 
@@ -226,7 +227,7 @@ class ForumPostCollection(list["ForumPost"]):
             ]
         )[0]
 
-        first_body = first_response.json()["body"]
+        first_body = require_body(first_response, "forum/ForumViewThreadPostsModule")
         first_html = BeautifulSoup(first_body, "lxml")
 
         posts.extend(ForumPostCollection._parse(thread, first_html))
@@ -257,7 +258,7 @@ class ForumPostCollection(list["ForumPost"]):
         )
 
         for response in responses:
-            body = response.json()["body"]
+            body = require_body(response, "forum/ForumViewThreadPostsModule")
             html = BeautifulSoup(body, "lxml")
             posts.extend(ForumPostCollection._parse(thread, html))
 
@@ -312,7 +313,7 @@ class ForumPostCollection(list["ForumPost"]):
         for thread, response in zip(threads, first_page_responses, strict=True):
             if response is None:
                 continue
-            body = response.json()["body"]
+            body = require_body(response, "forum/ForumViewThreadPostsModule")
             html = BeautifulSoup(body, "lxml")
 
             posts = ForumPostCollection._parse(thread, html)
@@ -351,7 +352,7 @@ class ForumPostCollection(list["ForumPost"]):
             for (thread, _page), response in zip(additional_requests, additional_responses, strict=True):
                 if response is None:
                     continue
-                body = response.json()["body"]
+                body = require_body(response, "forum/ForumViewThreadPostsModule")
                 html = BeautifulSoup(body, "lxml")
                 posts = ForumPostCollection._parse(thread, html)
                 result[thread.id].extend(posts)
@@ -402,7 +403,7 @@ class ForumPostCollection(list["ForumPost"]):
         )
 
         for post, response in zip(target_posts, responses, strict=True):
-            html = BeautifulSoup(response.json()["body"], "lxml")
+            html = BeautifulSoup(require_body(response, "forum/sub/ForumEditPostFormModule"), "lxml")
             source_elem = html.select_one("textarea[name='source']")
             if source_elem is None:
                 raise NoElementException(f"Source textarea is not found for post: {post.id}")
@@ -597,7 +598,7 @@ class ForumPost:
             ]
         )[0]
 
-        html = BeautifulSoup(form_response.json()["body"], "lxml")
+        html = BeautifulSoup(require_body(form_response, "forum/sub/ForumEditPostFormModule"), "lxml")
         revision_elem = html.select_one("input[name='currentRevisionId']")
         if revision_elem is None:
             raise NoElementException("Current revision ID input is not found.")

--- a/src/wikidot/module/forum_post_revision.py
+++ b/src/wikidot/module/forum_post_revision.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Optional
 
 from bs4 import BeautifulSoup
 
+from ..connector.ajax import require_body
 from ..util.parser import odate as odate_parser
 from ..util.parser import user as user_parser
 
@@ -194,7 +195,7 @@ class ForumPostRevisionCollection(list["ForumPostRevision"]):
             ]
         )[0]
 
-        body = response.json()["body"]
+        body = require_body(response, "forum/sub/ForumPostRevisionsModule")
         html = BeautifulSoup(body, "lxml")
 
         revisions = ForumPostRevisionCollection._parse(post, html)
@@ -242,7 +243,7 @@ class ForumPostRevisionCollection(list["ForumPostRevision"]):
 
         # Step 2: Parse revision lists
         for post, response in zip(posts, responses, strict=True):
-            body = response.json()["body"]
+            body = require_body(response, "forum/sub/ForumPostRevisionsModule")
             html = BeautifulSoup(body, "lxml")
             revisions = ForumPostRevisionCollection._parse(post, html)
             result[post.id] = ForumPostRevisionCollection(post=post, revisions=revisions)

--- a/src/wikidot/module/forum_thread.py
+++ b/src/wikidot/module/forum_thread.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Optional
 from bs4 import BeautifulSoup, NavigableString
 
 from ..common.exceptions import NoElementException
+from ..connector.ajax import require_body
 from ..util.parser import odate as odate_parser
 from ..util.parser import user as user_parser
 
@@ -291,7 +292,7 @@ class ForumThreadCollection(list["ForumThread"]):
             ]
         )[0]
 
-        first_body = first_response.json()["body"]
+        first_body = require_body(first_response, "forum/ForumViewCategoryModule")
         first_html = BeautifulSoup(first_body, "lxml")
 
         threads.extend(ForumThreadCollection._parse_list_in_category(category.site, first_html))
@@ -319,7 +320,7 @@ class ForumThreadCollection(list["ForumThread"]):
         for response in responses:
             if response is None:
                 continue
-            body = response.json()["body"]
+            body = require_body(response, "forum/ForumViewCategoryModule")
             html = BeautifulSoup(body, "lxml")
             threads.extend(ForumThreadCollection._parse_list_in_category(category.site, html, category))
 
@@ -361,7 +362,7 @@ class ForumThreadCollection(list["ForumThread"]):
         threads = []
 
         for response, thread_id in zip(responses, thread_ids, strict=True):
-            body = response.json()["body"]
+            body = require_body(response, "forum/ForumViewThreadModule")
             html = BeautifulSoup(body, "lxml")
 
             thread = ForumThreadCollection._parse_thread_page(site, html, category)

--- a/src/wikidot/module/page.py
+++ b/src/wikidot/module/page.py
@@ -13,7 +13,7 @@ if sys.version_info >= (3, 12):
 else:
     from typing_extensions import TypedDict, Unpack
 
-from ..common import exceptions
+from ..common import exceptions, wd_logger
 from ..connector.ajax import require_body
 from ..util.parser import odate as odate_parser
 from ..util.parser import user as user_parser
@@ -870,6 +870,57 @@ class PageCollection(list["Page"]):
         return self
 
 
+def _release_page_edit_lock(
+    site: "Site",
+    fullname: str,
+    page_id: int | None,
+    lock_id: Any,
+    lock_secret: Any,
+) -> None:
+    """
+    Release a page edit lock acquired via edit/PageEditModule
+
+    Wikidot holds the lock for up to 15 minutes once edit/PageEditModule is
+    requested. Any code path that acquires the lock but does not reach a
+    successful savePage must call this, or the page stays uneditable for
+    other users until the lock expires.
+
+    Parameters
+    ----------
+    site : Site
+        Site the page belongs to
+    fullname : str
+        Fullname of the page
+    page_id : int | None
+        Page ID, if known (omitted from the request when None, matching
+        the client-side behavior of only sending page_id when available)
+    lock_id : Any
+        Lock ID returned by edit/PageEditModule
+    lock_secret : Any
+        Lock secret returned by edit/PageEditModule
+
+    Notes
+    -----
+    Failure to release is logged, not raised, so it never masks the
+    original exception that triggered the release attempt.
+    """
+    release_body: dict[str, Any] = {
+        "action": "WikiPageAction",
+        "event": "removePageEditLock",
+        "moduleName": "Empty",
+        "lock_id": lock_id,
+        "lock_secret": lock_secret,
+        "wiki_page": fullname,
+    }
+    if page_id is not None:
+        release_body["page_id"] = page_id
+
+    try:
+        site.amc_request([release_body])
+    except Exception:
+        wd_logger.exception(f"Failed to release page edit lock for {fullname} (lock_id={lock_id})")
+
+
 @dataclass
 class Page:
     """
@@ -1410,6 +1461,7 @@ class Page:
         page_lock_response_data = page_lock_response.json()
 
         if page_lock_response_data.get("locked") or page_lock_response_data.get("other_locks"):
+            # ロック取得自体に失敗しているので解放不要
             raise exceptions.TargetErrorException(
                 f"Page {fullname} is locked or other locks exist",
             )
@@ -1417,44 +1469,55 @@ class Page:
         # ページが存在するか（page_revision_idがあるか）確認
         is_exist = "page_revision_id" in page_lock_response_data
 
-        if raise_on_exists and is_exist:
-            raise exceptions.TargetExistsException(f"Page {fullname} already exists")
-
-        if is_exist and page_id is None:
-            raise ValueError("page_id must be specified when editing existing page")
-
         # lock_idとlock_secret、page_revision_id（あれば）を取得
+        # ここから先は編集ロックを保持している状態なので、保存が成立しなかった経路は
+        # 必ずremovePageEditLockで解放する（放置すると最大15分そのページが編集不可になる）
         lock_id = page_lock_response_data["lock_id"]
         lock_secret = page_lock_response_data["lock_secret"]
         page_revision_id = page_lock_response_data.get("page_revision_id")
 
-        # ページの作成または編集
-        edit_request_body = {
-            "action": "WikiPageAction",
-            "event": "savePage",
-            "moduleName": "Empty",
-            "mode": "page",
-            "lock_id": lock_id,
-            "lock_secret": lock_secret,
-            "revision_id": page_revision_id if page_revision_id is not None else "",
-            "wiki_page": fullname,
-            "page_id": page_id if page_id is not None else "",
-            "title": title,
-            "source": source,
-            "comments": comment,
-        }
-        response = site.amc_request([edit_request_body])[0]
+        save_succeeded = False
+        try:
+            if raise_on_exists and is_exist:
+                raise exceptions.TargetExistsException(f"Page {fullname} already exists")
 
-        if response.json()["status"] != "ok":
-            raise exceptions.WikidotStatusCodeException(
-                f"Failed to create or edit page: {fullname}", response.json()["status"]
-            )
+            if is_exist and page_id is None:
+                raise ValueError("page_id must be specified when editing existing page")
 
-        res = PageCollection.search_pages(site, SearchPagesQuery(fullname=fullname))
-        if len(res) == 0:
-            raise exceptions.NotFoundException(f"Page creation failed: {fullname}")
+            # ページの作成または編集
+            edit_request_body = {
+                "action": "WikiPageAction",
+                "event": "savePage",
+                "moduleName": "Empty",
+                "mode": "page",
+                "lock_id": lock_id,
+                "lock_secret": lock_secret,
+                "revision_id": page_revision_id if page_revision_id is not None else "",
+                "wiki_page": fullname,
+                "page_id": page_id if page_id is not None else "",
+                "title": title,
+                "source": source,
+                "comments": comment,
+            }
+            response = site.amc_request([edit_request_body])[0]
 
-        return res[0]
+            if response.json()["status"] != "ok":
+                raise exceptions.WikidotStatusCodeException(
+                    f"Failed to create or edit page: {fullname}", response.json()["status"]
+                )
+
+            # savePageが成功した時点でWikidot側がロックを解放するため、以降の
+            # NotFoundException（検索側の不整合）では解放を試みない
+            save_succeeded = True
+
+            res = PageCollection.search_pages(site, SearchPagesQuery(fullname=fullname))
+            if len(res) == 0:
+                raise exceptions.NotFoundException(f"Page creation failed: {fullname}")
+
+            return res[0]
+        finally:
+            if not save_succeeded:
+                _release_page_edit_lock(site, fullname, page_id, lock_id, lock_secret)
 
     def edit(
         self,

--- a/src/wikidot/module/page.py
+++ b/src/wikidot/module/page.py
@@ -14,6 +14,7 @@ else:
     from typing_extensions import TypedDict, Unpack
 
 from ..common import exceptions
+from ..connector.ajax import require_body
 from ..util.parser import odate as odate_parser
 from ..util.parser import user as user_parser
 from ..util.requestutil import RequestUtil
@@ -496,7 +497,7 @@ class PageCollection(list["Page"]):
                 raise exceptions.ForbiddenException("Failed to get pages, target site may be private") from e
             raise e
 
-        body = response.json()["body"]
+        body = require_body(response, "list/ListPagesModule")
 
         first_page_html_body = BeautifulSoup(body, "lxml")
 
@@ -519,7 +520,9 @@ class PageCollection(list["Page"]):
                 request_bodies.append(_query_dict)
 
             responses = site.amc_request(request_bodies)
-            html_bodies.extend([BeautifulSoup(response.json()["body"], "lxml") for response in responses])
+            html_bodies.extend(
+                [BeautifulSoup(require_body(response, "list/ListPagesModule"), "lxml") for response in responses]
+            )
 
         pages: list[Page] = []
         for html_body in html_bodies:
@@ -625,7 +628,7 @@ class PageCollection(list["Page"]):
         )
 
         for page, response in zip(pages, responses, strict=True):
-            body = response.json()["body"]
+            body = require_body(response, "viewsource/ViewSourceModule")
             # nbspをスペースに置換
             body = body.replace("&nbsp;", " ")
             html = BeautifulSoup(body, "lxml")
@@ -694,7 +697,7 @@ class PageCollection(list["Page"]):
         for page, response in zip(pages, responses, strict=True):
             if response is None:
                 continue
-            body = response.json()["body"]
+            body = require_body(response, "history/PageRevisionListModule")
             revs = []
             body_html = BeautifulSoup(body, "lxml")
             for rev_element in body_html.select("table.page-history > tr[id^=revision-row-]"):
@@ -780,7 +783,7 @@ class PageCollection(list["Page"]):
         for page, response in zip(pages, responses, strict=True):
             if response is None:
                 continue
-            body = response.json()["body"]
+            body = require_body(response, "pagerate/WhoRatedPageModule")
             html = BeautifulSoup(body, "lxml")
             user_elems = html.select("span.printuser")
             value_elems = html.select("span[style^='color']")
@@ -845,7 +848,7 @@ class PageCollection(list["Page"]):
         responses = site.amc_request([{"moduleName": "files/PageFilesModule", "page_id": page.id} for page in pages])
 
         for page, response in zip(pages, responses, strict=True):
-            body = response.json()["body"]
+            body = require_body(response, "files/PageFilesModule")
             html = BeautifulSoup(body, "lxml")
             files = PageFileCollection._parse_from_html(page, html)
             page._files = PageFileCollection(page=page, files=files)
@@ -1176,7 +1179,7 @@ class Page:
                 ]
             )[0]
 
-            body = response.json()["body"]
+            body = require_body(response, "forum/ForumCommentsListModule")
             match = re.search(r"WIKIDOT\.forumThreadId = (\d+);", body)
             if match is not None:
                 from .forum_thread import ForumThread
@@ -1257,7 +1260,7 @@ class Page:
             )
 
             # レスポンス解析
-            body = response[0].json()["body"]
+            body = require_body(response[0], "edit/EditMetaModule")
 
             # <meta name="xxx" content="yyy"/> を正規表現で取得
             metas = {}

--- a/src/wikidot/module/page_file.py
+++ b/src/wikidot/module/page_file.py
@@ -11,6 +11,8 @@ from typing import TYPE_CHECKING, Optional
 
 from bs4 import BeautifulSoup
 
+from ..connector.ajax import require_body
+
 if TYPE_CHECKING:
     from .page import Page
 
@@ -208,7 +210,7 @@ class PageFileCollection(list["PageFile"]):
             ]
         )[0]
 
-        html = BeautifulSoup(response.json()["body"], "lxml")
+        html = BeautifulSoup(require_body(response, "files/PageFilesModule"), "lxml")
         files = PageFileCollection._parse_from_html(page, html)
 
         return PageFileCollection(page=page, files=files)

--- a/src/wikidot/module/page_revision.py
+++ b/src/wikidot/module/page_revision.py
@@ -14,6 +14,7 @@ import httpx
 from bs4 import BeautifulSoup
 
 from ..common.exceptions import NoElementException
+from ..connector.ajax import require_body
 from .page_source import PageSource
 
 if TYPE_CHECKING:
@@ -149,7 +150,7 @@ class PageRevisionCollection(list["PageRevision"]):
         """
 
         def process_source_response(revision: "PageRevision", response: httpx.Response, page: "Page") -> None:
-            body = response.json()["body"]
+            body = require_body(response, "history/PageSourceModule")
             # Replace nbsp with space
             body = body.replace("&nbsp;", " ")
             body_html = BeautifulSoup(body, "lxml")
@@ -204,7 +205,7 @@ class PageRevisionCollection(list["PageRevision"]):
         """
 
         def process_html_response(revision: "PageRevision", response: httpx.Response, page: "Page") -> None:
-            body = response.json()["body"]
+            body = require_body(response, "history/PageVersionModule")
             # onclick="document.getElementById('page-version-info').style.display='none'">(.*?)</a>\n\t</div>\n\n\n\n
             # 以降をソースとして取得
             source = body.split(

--- a/src/wikidot/module/private_message.py
+++ b/src/wikidot/module/private_message.py
@@ -15,6 +15,7 @@ from typing_extensions import Self
 
 from ..common import exceptions
 from ..common.decorators import login_required
+from ..connector.ajax import require_body
 from ..util.parser import odate as odate_parser
 from ..util.parser import user as user_parser
 
@@ -122,7 +123,7 @@ class PrivateMessageCollection(list["PrivateMessage"]):
             if isinstance(response, Exception):
                 raise response
 
-            html = BeautifulSoup(response.json()["body"], "lxml")
+            html = BeautifulSoup(require_body(response, "dashboard/messages/DMViewMessageModule"), "lxml")
 
             sender, recipient = html.select("div.pmessage div.header span.printuser")
 
@@ -173,7 +174,7 @@ class PrivateMessageCollection(list["PrivateMessage"]):
         # pager取得
         response = client.amc_client.request([{"moduleName": module_name}])[0]
 
-        html = BeautifulSoup(response.json()["body"], "lxml")
+        html = BeautifulSoup(require_body(response, module_name), "lxml")
         # pagerの最後から2番目の要素を取得
         # pageが存在しない場合は1ページのみ
         pager: ResultSet[Tag] = html.select("div.pager span.target")
@@ -189,7 +190,7 @@ class PrivateMessageCollection(list["PrivateMessage"]):
 
         message_ids = []
         for response in responses:
-            html = BeautifulSoup(response.json()["body"], "lxml")
+            html = BeautifulSoup(require_body(response, module_name), "lxml")
             # tr.messageのdata-href末尾の数字を取得
             message_ids.extend([int(str(tr["data-href"]).split("/")[-1]) for tr in html.select("tr.message")])
 

--- a/src/wikidot/module/site.py
+++ b/src/wikidot/module/site.py
@@ -15,6 +15,7 @@ else:
 from ..common import exceptions
 from ..common.decorators import login_required
 from ..common.logger import logger
+from ..connector.ajax import require_body
 from ..util.http import sync_get_with_retry
 from ..util.parser import odate as odate_parser
 from ..util.parser import user as user_parser
@@ -721,7 +722,7 @@ class Site:
                 ]
             )[0]
 
-            html = BeautifulSoup(response.json()["body"], "lxml")
+            html = BeautifulSoup(require_body(response, "changes/SiteChangesListModule"), "lxml")
             items = html.select("div.changes-list-item")
 
             if not items:

--- a/src/wikidot/module/site_application.py
+++ b/src/wikidot/module/site_application.py
@@ -12,6 +12,7 @@ from bs4 import BeautifulSoup
 
 from ..common import exceptions
 from ..common.decorators import login_required
+from ..connector.ajax import require_body
 from ..util.parser import user as user_parser
 
 if TYPE_CHECKING:
@@ -79,12 +80,12 @@ class SiteApplication:
         """
         response = site.amc_request([{"moduleName": "managesite/ManageSiteMembersApplicationsModule"}])[0]
 
-        body = response.json()["body"]
+        body = require_body(response, "managesite/ManageSiteMembersApplicationsModule")
 
         if "WIKIDOT.page.listeners.loginClick(event)" in body:
             raise exceptions.ForbiddenException("You are not allowed to access this page")
 
-        html = BeautifulSoup(response.json()["body"], "lxml")
+        html = BeautifulSoup(body, "lxml")
 
         applications = []
 

--- a/src/wikidot/module/site_member.py
+++ b/src/wikidot/module/site_member.py
@@ -15,6 +15,7 @@ from ..common.exceptions import (
     TargetErrorException,
     WikidotStatusCodeException,
 )
+from ..connector.ajax import require_body
 from ..util.parser import odate as odate_parser
 from ..util.parser import user as user_parser
 
@@ -128,7 +129,7 @@ class SiteMember:
             ]
         )[0]
 
-        first_body = first_response.json()["body"]
+        first_body = require_body(first_response, "membership/MembersListModule")
         first_html = BeautifulSoup(first_body, "lxml")
 
         members.extend(SiteMember._parse(site, first_html))
@@ -153,7 +154,7 @@ class SiteMember:
         )
 
         for response in responses:
-            body = response.json()["body"]
+            body = require_body(response, "membership/MembersListModule")
             html = BeautifulSoup(body, "lxml")
             members.extend(SiteMember._parse(site, html))
 

--- a/src/wikidot/util/amc_body.py
+++ b/src/wikidot/util/amc_body.py
@@ -1,0 +1,106 @@
+"""Helpers for building Ajax Module Connector request bodies.
+
+Wikidot's client-side form serialization (OZONE.utils.formToArray) has a
+rule that a plain Python dict does not reproduce on its own: an unchecked
+checkbox is not sent as `False`, its key is omitted entirely. Sending
+`"false"` or an empty string instead means "turn this off" silently
+becomes "no change". These helpers let call sites pass plain `bool` /
+`None` values and get the correct AMC wire format.
+"""
+
+import json
+from typing import Any, Literal
+
+
+def checkbox(value: bool | None) -> "str | Literal[False]":
+    """
+    Encode a checkbox-style boolean for an AMC request
+
+    Mirrors `OZONE.utils.formToArray`: a checked checkbox is sent as the
+    literal string "on"; an unchecked one is omitted from the request
+    entirely (not sent as "false"). Pass the result through omit_falsy()
+    so the False case drops the key instead of being sent.
+
+    Parameters
+    ----------
+    value : bool | None
+        Checkbox state. None is treated the same as False (omitted)
+
+    Returns
+    -------
+    str | Literal[False]
+        "on" if value is truthy, otherwise False for omit_falsy() to drop
+    """
+    return "on" if value else False
+
+
+def flag(value: bool | None) -> "str | Literal[False]":
+    """
+    Encode a JS-boolean-style flag for an AMC request
+
+    Some modules build the request body by hand in JS instead of via
+    formToArray (e.g. `if (checkbox.checked) { p.sticky = true; }`), which
+    sends the literal string "true" when set and omits the key otherwise.
+
+    Parameters
+    ----------
+    value : bool | None
+        Flag state. None is treated the same as False (omitted)
+
+    Returns
+    -------
+    str | Literal[False]
+        "true" if value is truthy, otherwise False for omit_falsy() to drop
+    """
+    return "true" if value else False
+
+
+def json_param(obj: Any) -> Any:
+    """
+    Encode a value as a JSON string for an AMC request parameter
+
+    Used for parameters such as `categories` / `options` / `addresses`
+    that Wikidot expects as a JSON-encoded string, not a native array/object.
+
+    Parameters
+    ----------
+    obj : Any
+        Value to encode. None is passed through for omit_falsy() to drop
+
+    Returns
+    -------
+    Any
+        JSON string of obj, or None if obj is None
+    """
+    if obj is None:
+        return None
+    return json.dumps(obj)
+
+
+def omit_falsy(**kwargs: Any) -> dict[str, Any]:
+    """
+    Build an AMC request body fragment, dropping None / False values
+
+    httpx serializes a request body value of Python True/False as the
+    literal strings "true"/"false" (see httpx._utils.primitive_value_to_str),
+    which is wrong for Wikidot's checkbox semantics: an unchecked checkbox
+    must be represented by the key being absent from the request entirely,
+    not present with value "false" (formToArray never emits it; see
+    10_transport.md). This is the single place that enforces that rule, so
+    call sites can pass plain bool/None values — or checkbox(v)/flag(v)/
+    json_param(v) results — without hand-rolling the omission themselves.
+
+    Uses identity comparison (`is False`, not `== False`) so a legitimate
+    `0` value is kept; only the None and False singletons are dropped.
+
+    Parameters
+    ----------
+    **kwargs : Any
+        Candidate key-value pairs
+
+    Returns
+    -------
+    dict[str, Any]
+        kwargs with None and False values removed
+    """
+    return {key: value for key, value in kwargs.items() if value is not None and value is not False}

--- a/tests/unit/test_ajax.py
+++ b/tests/unit/test_ajax.py
@@ -4,10 +4,16 @@
 AjaxRequestHeaderとAjaxModuleConnectorConfigのテストはtest_amc_client.pyに統合済み。
 """
 
+from unittest.mock import MagicMock
+
+import pytest
+
+from wikidot.common.exceptions import ResponseDataException
 from wikidot.connector.ajax import (
     _calculate_backoff,
     _encode_amc_body,
     _mask_sensitive_data,
+    require_body,
 )
 
 
@@ -122,3 +128,27 @@ class TestEncodeAmcBody:
         """戻り値はhttpxのdata=がサポートするMapping（dict）のまま"""
         result = _encode_amc_body({"others": [1, 2]})
         assert isinstance(result, dict)
+
+
+class TestRequireBody:
+    """require_body関数のテスト"""
+
+    def test_returns_body_when_present(self):
+        """bodyフィールドがあれば値を返す"""
+        response = MagicMock()
+        response.json.return_value = {"status": "ok", "body": "<div>test</div>"}
+        assert require_body(response, "TestModule") == "<div>test</div>"
+
+    def test_raises_when_body_missing(self):
+        """存在しないmoduleNameの応答（bodyフィールド欠落）ではResponseDataException"""
+        response = MagicMock()
+        response.json.return_value = {"status": "ok", "jsInclude": [], "cssInclude": []}
+        with pytest.raises(ResponseDataException):
+            require_body(response, "managesite/NoSuchModule")
+
+    def test_error_message_includes_module_name(self):
+        """例外メッセージにモジュール名が含まれる（デバッグしやすさのため）"""
+        response = MagicMock()
+        response.json.return_value = {"status": "ok"}
+        with pytest.raises(ResponseDataException, match="managesite/NoSuchModule"):
+            require_body(response, "managesite/NoSuchModule")

--- a/tests/unit/test_ajax.py
+++ b/tests/unit/test_ajax.py
@@ -6,6 +6,7 @@ AjaxRequestHeaderとAjaxModuleConnectorConfigのテストはtest_amc_client.py�
 
 from wikidot.connector.ajax import (
     _calculate_backoff,
+    _encode_amc_body,
     _mask_sensitive_data,
 )
 
@@ -92,3 +93,32 @@ class TestCalculateBackoff:
         # 3^2 * 1.0 = 9.0（ジッターなしの場合）
         result = _calculate_backoff(3, 1.0, 3.0, 60.0)
         assert 9.0 <= result <= 9.9
+
+
+class TestEncodeAmcBody:
+    """_encode_amc_body関数のテスト"""
+
+    def test_scalar_only_body_unchanged(self):
+        """list値を含まないbodyはそのまま返る"""
+        body = {"moduleName": "Test", "page_id": 123, "wikidot_token7": 123456}
+        result = _encode_amc_body(body)
+        assert result == body
+
+    def test_list_value_gets_bracket_key(self):
+        """list値を持つキーは[]サフィックス付きにリネームされる"""
+        body = {"moduleName": "DashboardMessageAction", "selected": [1, 2, 3]}
+        result = _encode_amc_body(body)
+        assert "selected" not in result
+        assert result["selected[]"] == [1, 2, 3]
+        assert result["moduleName"] == "DashboardMessageAction"
+
+    def test_multiple_list_values(self):
+        """複数のlist値キーがそれぞれ[]付きになる"""
+        body = {"selected": [1, 2], "messages": [3, 4], "other": "scalar"}
+        result = _encode_amc_body(body)
+        assert result == {"selected[]": [1, 2], "messages[]": [3, 4], "other": "scalar"}
+
+    def test_result_is_still_a_mapping(self):
+        """戻り値はhttpxのdata=がサポートするMapping（dict）のまま"""
+        result = _encode_amc_body({"others": [1, 2]})
+        assert isinstance(result, dict)

--- a/tests/unit/test_amc_body.py
+++ b/tests/unit/test_amc_body.py
@@ -1,0 +1,89 @@
+"""AMCリクエストボディ構築ヘルパー（util.amc_body）のユニットテスト"""
+
+from wikidot.util.amc_body import checkbox, flag, json_param, omit_falsy
+
+
+class TestCheckbox:
+    """checkbox関数のテスト"""
+
+    def test_true_becomes_on(self):
+        """Trueは"on"になる（formToArrayのchecked checkbox）"""
+        assert omit_falsy(foo=checkbox(True)) == {"foo": "on"}
+
+    def test_false_is_omitted(self):
+        """Falseはキーごと省略される（"false"文字列にはならない）"""
+        assert omit_falsy(foo=checkbox(False)) == {}
+
+    def test_none_is_omitted(self):
+        """Noneも省略される（未指定 = 変更なし）"""
+        assert omit_falsy(foo=checkbox(None)) == {}
+
+
+class TestFlag:
+    """flag関数のテスト"""
+
+    def test_true_becomes_true_string(self):
+        """Trueは文字列"true"になる（sticky?/block?系のJS個別組み立てパターン）"""
+        assert omit_falsy(sticky=flag(True)) == {"sticky": "true"}
+
+    def test_false_is_omitted(self):
+        """Falseはキーごと省略される"""
+        assert omit_falsy(sticky=flag(False)) == {}
+
+    def test_none_is_omitted(self):
+        """Noneも省略される"""
+        assert omit_falsy(sticky=flag(None)) == {}
+
+
+class TestJsonParam:
+    """json_param関数のテスト"""
+
+    def test_encodes_dict_as_json_string(self):
+        """dictはJSON文字列にエンコードされる"""
+        result = json_param({"a": 1})
+        assert omit_falsy(categories=result) == {"categories": '{"a": 1}'}
+
+    def test_encodes_list_as_json_string(self):
+        """listもJSON文字列にエンコードされる"""
+        result = json_param([1, 2, 3])
+        assert omit_falsy(options=result) == {"options": "[1, 2, 3]"}
+
+    def test_none_is_omitted(self):
+        """Noneは省略される"""
+        assert omit_falsy(categories=json_param(None)) == {}
+
+
+class TestOmitFalsy:
+    """omit_falsy関数のテスト"""
+
+    def test_drops_none_values(self):
+        """None値のキーは落ちる"""
+        result = omit_falsy(a=1, b=None, c="x")
+        assert result == {"a": 1, "c": "x"}
+
+    def test_drops_false_values(self):
+        """False値のキーも落ちる（httpxがTrue/Falseを"true"/"false"文字列化するため、
+        Falseをそのまま送るとWikidotのcheckbox省略規則（キー自体を送らない）に反する）"""
+        result = omit_falsy(a=1, b=False, c="x")
+        assert result == {"a": 1, "c": "x"}
+
+    def test_keeps_other_falsy_values(self):
+        """0や空文字はNone/False（同一性比較）ではないので保持される"""
+        result = omit_falsy(a=0, b="")
+        assert result == {"a": 0, "b": ""}
+
+    def test_empty_kwargs(self):
+        """引数無しなら空dict"""
+        assert omit_falsy() == {}
+
+    def test_mixed_with_checkbox_and_flag(self):
+        """checkbox/flag/生の値/Noneを混在させても正しくフィルタされる"""
+        result = omit_falsy(
+            name="test",
+            hide_nav=checkbox(False),
+            allow_hotlink=checkbox(True),
+            sticky=flag(True),
+            block=flag(False),
+            optional=None,
+        )
+        assert result == {"name": "test", "allow_hotlink": "on", "sticky": "true"}

--- a/tests/unit/test_amc_client.py
+++ b/tests/unit/test_amc_client.py
@@ -436,6 +436,41 @@ class TestAjaxModuleConnectorClientRequest:
         called_backoff = mock_sleep.call_args[0][0]
         assert 1.0 <= called_backoff <= 1.1
 
+    def test_unknown_action_event_fails_immediately(self, httpx_mock: HTTPXMock) -> None:
+        """actionを伴うHTTP 500 + 空ボディはリトライせず即座に失敗する（未対応event検出）"""
+        httpx_mock.add_response(
+            url="https://www.wikidot.com/ajax-module-connector.php",
+            status_code=500,
+        )
+
+        config = AjaxModuleConnectorConfig(attempt_limit=5, retry_interval=0)
+        client = AjaxModuleConnectorClient(site_name="www", config=config)
+
+        with pytest.raises(AMCHttpStatusCodeException):
+            client.request([{"moduleName": "Empty", "action": "ManageSiteAction", "event": "noSuchEvent"}])
+
+        # リトライせず1回のみリクエストされていること
+        assert len(httpx_mock.get_requests()) == 1
+
+    def test_action_500_with_body_still_retries(self, httpx_mock: HTTPXMock) -> None:
+        """actionを伴っていてもボディが空でなければ通常どおりリトライする"""
+        httpx_mock.add_response(
+            url="https://www.wikidot.com/ajax-module-connector.php",
+            status_code=500,
+            text="Internal Server Error",
+        )
+        httpx_mock.add_response(
+            url="https://www.wikidot.com/ajax-module-connector.php",
+            json={"status": "ok", "body": ""},
+        )
+
+        config = AjaxModuleConnectorConfig(retry_interval=0)
+        client = AjaxModuleConnectorClient(site_name="www", config=config)
+
+        client.request([{"moduleName": "Empty", "action": "ManageSiteAction", "event": "saveGeneral"}])
+
+        assert len(httpx_mock.get_requests()) == 2
+
 
 class TestAjaxModuleConnectorClientFormErrors:
     """form_errors / form_error ステータスのハンドリングのテスト"""

--- a/tests/unit/test_amc_client.py
+++ b/tests/unit/test_amc_client.py
@@ -471,6 +471,35 @@ class TestAjaxModuleConnectorClientRequest:
 
         assert len(httpx_mock.get_requests()) == 2
 
+    def test_list_value_sent_with_bracket_notation(self, httpx_mock: HTTPXMock) -> None:
+        """list値を含むbodyはkey[]=v1&key[]=v2形式で送信される（jQuery.param互換）"""
+        httpx_mock.add_response(
+            url="https://www.wikidot.com/ajax-module-connector.php",
+            json={"status": "ok", "body": ""},
+        )
+
+        client = AjaxModuleConnectorClient(site_name="www")
+        client.request([{"moduleName": "DashboardMessageAction", "selected": [1, 2]}])
+
+        sent_body = httpx_mock.get_requests()[0].content.decode()
+        assert "selected%5B%5D=1" in sent_body
+        assert "selected%5B%5D=2" in sent_body
+        assert "selected=1" not in sent_body
+
+    def test_scalar_body_unaffected_by_bracket_encoding(self, httpx_mock: HTTPXMock) -> None:
+        """list値を含まないbodyのエンコード結果は変わらない"""
+        httpx_mock.add_response(
+            url="https://www.wikidot.com/ajax-module-connector.php",
+            json={"status": "ok", "body": ""},
+        )
+
+        client = AjaxModuleConnectorClient(site_name="www")
+        client.request([{"moduleName": "Test", "page_id": 123}])
+
+        sent_body = httpx_mock.get_requests()[0].content.decode()
+        assert "page_id=123" in sent_body
+        assert "moduleName=Test" in sent_body
+
 
 class TestAjaxModuleConnectorClientFormErrors:
     """form_errors / form_error ステータスのハンドリングのテスト"""

--- a/tests/unit/test_amc_client.py
+++ b/tests/unit/test_amc_client.py
@@ -1,5 +1,7 @@
 """AMCクライアントのユニットテスト"""
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
 from pytest_httpx import HTTPXMock
 
@@ -374,6 +376,65 @@ class TestAjaxModuleConnectorClientRequest:
         responses = client.request([{"moduleName": "Test"}])
 
         assert len(responses) == 1
+
+    def test_try_again_respects_time_to_wait(self, httpx_mock: HTTPXMock) -> None:
+        """try_againにtime_to_wait（秒）があればその秒数だけ待つ"""
+        httpx_mock.add_response(
+            url="https://www.wikidot.com/ajax-module-connector.php",
+            json={"status": "try_again", "time_to_wait": 3},
+        )
+        httpx_mock.add_response(
+            url="https://www.wikidot.com/ajax-module-connector.php",
+            json={"status": "ok", "body": ""},
+        )
+
+        config = AjaxModuleConnectorConfig(retry_interval=0)
+        client = AjaxModuleConnectorClient(site_name="www", config=config)
+
+        with patch("wikidot.connector.ajax.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            client.request([{"moduleName": "Test"}])
+
+        mock_sleep.assert_called_once_with(3.0)
+
+    def test_try_again_time_to_wait_capped_by_max_backoff(self, httpx_mock: HTTPXMock) -> None:
+        """time_to_waitがmax_backoffを超える場合は上限で切る（サーバ値を無制限に信用しない）"""
+        httpx_mock.add_response(
+            url="https://www.wikidot.com/ajax-module-connector.php",
+            json={"status": "try_again", "time_to_wait": 999},
+        )
+        httpx_mock.add_response(
+            url="https://www.wikidot.com/ajax-module-connector.php",
+            json={"status": "ok", "body": ""},
+        )
+
+        config = AjaxModuleConnectorConfig(retry_interval=0, max_backoff=5.0)
+        client = AjaxModuleConnectorClient(site_name="www", config=config)
+
+        with patch("wikidot.connector.ajax.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            client.request([{"moduleName": "Test"}])
+
+        mock_sleep.assert_called_once_with(5.0)
+
+    def test_try_again_without_time_to_wait_uses_backoff(self, httpx_mock: HTTPXMock) -> None:
+        """time_to_waitが無い場合は従来の指数バックオフのまま（挙動が変わらないこと）"""
+        httpx_mock.add_response(
+            url="https://www.wikidot.com/ajax-module-connector.php",
+            json={"status": "try_again"},
+        )
+        httpx_mock.add_response(
+            url="https://www.wikidot.com/ajax-module-connector.php",
+            json={"status": "ok", "body": ""},
+        )
+
+        config = AjaxModuleConnectorConfig(retry_interval=1.0)
+        client = AjaxModuleConnectorClient(site_name="www", config=config)
+
+        with patch("wikidot.connector.ajax.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            client.request([{"moduleName": "Test"}])
+
+        # backoff_factor^(1-1) * 1.0 = 1.0 + jitter(0~10%)
+        called_backoff = mock_sleep.call_args[0][0]
+        assert 1.0 <= called_backoff <= 1.1
 
 
 class TestAjaxModuleConnectorClientFormErrors:

--- a/tests/unit/test_amc_client.py
+++ b/tests/unit/test_amc_client.py
@@ -6,6 +6,7 @@ from pytest_httpx import HTTPXMock
 from wikidot.common.exceptions import (
     AMCHttpStatusCodeException,
     ForbiddenException,
+    FormErrorsException,
     NotFoundException,
     ResponseDataException,
     WikidotStatusCodeException,
@@ -373,3 +374,65 @@ class TestAjaxModuleConnectorClientRequest:
         responses = client.request([{"moduleName": "Test"}])
 
         assert len(responses) == 1
+
+
+class TestAjaxModuleConnectorClientFormErrors:
+    """form_errors / form_error ステータスのハンドリングのテスト"""
+
+    def test_form_errors_key_variant(self, httpx_mock: HTTPXMock) -> None:
+        """formErrorsキー（多数派: Forum系, Clone, saveGeneral等）"""
+        httpx_mock.add_response(
+            url="https://www.wikidot.com/ajax-module-connector.php",
+            json={
+                "status": "form_errors",
+                "formErrors": {"name": "Please provide the site title"},
+                "message": "Form errors",
+            },
+        )
+
+        client = AjaxModuleConnectorClient(site_name="www")
+
+        with pytest.raises(FormErrorsException) as exc_info:
+            client.request([{"moduleName": "Empty", "action": "ManageSiteAction", "event": "saveGeneral"}])
+
+        assert exc_info.value.errors == {"name": "Please provide the site title"}
+
+    def test_errors_key_variant(self, httpx_mock: HTTPXMock) -> None:
+        """errorsキー（WikiPageAction/savePage専用）"""
+        httpx_mock.add_response(
+            url="https://www.wikidot.com/ajax-module-connector.php",
+            json={"status": "form_errors", "errors": {"title": "Title is required"}},
+        )
+
+        client = AjaxModuleConnectorClient(site_name="www")
+
+        with pytest.raises(FormErrorsException) as exc_info:
+            client.request([{"moduleName": "Empty", "action": "WikiPageAction", "event": "savePage"}])
+
+        assert exc_info.value.errors == {"title": "Title is required"}
+
+    def test_message_only_variant(self, httpx_mock: HTTPXMock) -> None:
+        """messageのみ（文字列。saveTags・form_error単数形系）"""
+        httpx_mock.add_response(
+            url="https://www.wikidot.com/ajax-module-connector.php",
+            json={"status": "form_error", "message": "Invalid tag name"},
+        )
+
+        client = AjaxModuleConnectorClient(site_name="www")
+
+        with pytest.raises(FormErrorsException) as exc_info:
+            client.request([{"moduleName": "Empty", "action": "WikiPageAction", "event": "saveTags"}])
+
+        assert exc_info.value.errors == {"_message": "Invalid tag name"}
+
+    def test_is_also_a_wikidot_status_code_exception(self, httpx_mock: HTTPXMock) -> None:
+        """既存のexcept WikidotStatusCodeExceptionでも捕捉できる（継承関係）"""
+        httpx_mock.add_response(
+            url="https://www.wikidot.com/ajax-module-connector.php",
+            json={"status": "form_errors", "formErrors": {"name": "required"}},
+        )
+
+        client = AjaxModuleConnectorClient(site_name="www")
+
+        with pytest.raises(WikidotStatusCodeException):
+            client.request([{"moduleName": "Test"}])

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -6,6 +6,7 @@ from wikidot.common.exceptions import (
     AjaxModuleConnectorException,
     AMCHttpStatusCodeException,
     ForbiddenException,
+    FormErrorsException,
     LoginRequiredException,
     NoElementException,
     NotFoundException,
@@ -104,6 +105,65 @@ class TestWikidotStatusCodeException:
         """継承関係のテスト"""
         exc = WikidotStatusCodeException("test", "error")
         assert isinstance(exc, AjaxModuleConnectorException)
+
+    def test_response_defaults_to_none(self):
+        """responseを渡さない場合はNone（既存呼び出しとの後方互換）"""
+        exc = WikidotStatusCodeException("test", "error")
+        assert exc.response is None
+
+    def test_response_is_stored(self):
+        """responseを渡すと属性に保持される"""
+        payload = {"status": "error", "message": "boom"}
+        exc = WikidotStatusCodeException("test", "error", payload)
+        assert exc.response == payload
+
+
+class TestFormErrorsException:
+    """FormErrorsExceptionのテスト"""
+
+    def test_inheritance(self):
+        """WikidotStatusCodeExceptionのサブクラスである（既存exceptハンドラで捕捉可能）"""
+        exc = FormErrorsException("test", "form_errors", {})
+        assert isinstance(exc, WikidotStatusCodeException)
+        assert isinstance(exc, AjaxModuleConnectorException)
+
+    def test_errors_from_form_errors_key(self):
+        """formErrorsキー（多数派: Forum系, Clone, saveGeneral等）"""
+        response = {
+            "status": "form_errors",
+            "formErrors": {"name": "Please provide the site title"},
+            "message": "Form errors",
+        }
+        exc = FormErrorsException("test", "form_errors", response)
+        assert exc.errors == {"name": "Please provide the site title"}
+
+    def test_errors_from_errors_key(self):
+        """errorsキー（WikiPageAction/savePage専用）"""
+        response = {"status": "form_errors", "errors": {"title": "Title is required"}}
+        exc = FormErrorsException("test", "form_errors", response)
+        assert exc.errors == {"title": "Title is required"}
+
+    def test_errors_from_message_only(self):
+        """messageのみ（文字列。saveTags・form_error単数形系）はセンチネルキーで返す"""
+        response = {"status": "form_error", "message": "Invalid tag name"}
+        exc = FormErrorsException("test", "form_error", response)
+        assert exc.errors == {"_message": "Invalid tag name"}
+
+    def test_errors_empty_when_no_response(self):
+        """responseが無い場合は空dict"""
+        exc = FormErrorsException("test", "form_errors")
+        assert exc.errors == {}
+
+    def test_errors_empty_when_no_known_key(self):
+        """formErrors/errors/messageのいずれも無い場合は空dict"""
+        exc = FormErrorsException("test", "form_errors", {"status": "form_errors"})
+        assert exc.errors == {}
+
+    def test_errors_prefers_form_errors_over_message(self):
+        """formErrorsとmessageが両方あればformErrorsを優先する"""
+        response = {"formErrors": {"a": "b"}, "message": "Form errors"}
+        exc = FormErrorsException("test", "form_errors", response)
+        assert exc.errors == {"a": "b"}
 
 
 class TestResponseDataException:

--- a/tests/unit/test_page.py
+++ b/tests/unit/test_page.py
@@ -594,6 +594,141 @@ class TestPageCreateOrEdit:
         with pytest.raises(exceptions.LoginRequiredException):
             Page.create_or_edit(mock_site_no_http, "new-page")
 
+    def test_create_new_page_does_not_release_lock(
+        self,
+        mock_site_no_http: Site,
+        page_pageedit_success: dict[str, Any],
+        page_savepage_success: dict[str, Any],
+        page_listpages_single: dict[str, Any],
+    ) -> None:
+        """保存成功時はremovePageEditLockを送らない（Wikidot側がsavePageで解放するため）"""
+        mock_site_no_http.client.is_logged_in = True
+        mock_site_no_http.client.login_check = MagicMock()
+
+        mock_lock_response = MagicMock()
+        mock_lock_response.json.return_value = page_pageedit_success
+
+        mock_save_response = MagicMock()
+        mock_save_response.json.return_value = page_savepage_success
+
+        mock_search_response = MagicMock()
+        mock_search_response.json.return_value = page_listpages_single
+
+        # side_effectを3要素ちょうどにすることで、余計なamc_request呼び出し
+        # （=誤ったremovePageEditLock送信）があればStopIterationで検出できる
+        mock_site_no_http.amc_request = MagicMock(
+            side_effect=[
+                [mock_lock_response],
+                [mock_save_response],
+                [mock_search_response],
+            ]
+        )
+
+        Page.create_or_edit(mock_site_no_http, "new-page", title="New Page Title", source="Page content")
+
+        assert mock_site_no_http.amc_request.call_count == 3
+
+    def test_edit_without_page_id_releases_lock(self, mock_site_no_http: Site) -> None:
+        """page_id未指定でValueErrorになった場合、取得済みの編集ロックを解放する"""
+        mock_site_no_http.client.is_logged_in = True
+        mock_site_no_http.client.login_check = MagicMock()
+
+        lock_response = MagicMock()
+        lock_response.json.return_value = {
+            "status": "ok",
+            "lock_id": "lock-abc",
+            "lock_secret": "secret-xyz",
+            "page_revision_id": 100,  # 既存ページ
+        }
+        release_response = MagicMock()
+        release_response.json.return_value = {"status": "ok"}
+
+        mock_site_no_http.amc_request = MagicMock(side_effect=[[lock_response], [release_response]])
+
+        with pytest.raises(ValueError, match="page_id must be specified"):
+            Page.create_or_edit(mock_site_no_http, "existing-page")
+
+        assert mock_site_no_http.amc_request.call_count == 2
+        release_body = mock_site_no_http.amc_request.call_args_list[1][0][0][0]
+        assert release_body["action"] == "WikiPageAction"
+        assert release_body["event"] == "removePageEditLock"
+        assert release_body["lock_id"] == "lock-abc"
+        assert release_body["lock_secret"] == "secret-xyz"
+        assert release_body["wiki_page"] == "existing-page"
+        # page_id未指定（新規扱い）の場合、リリースリクエストにも含めない
+        # （WIKIREQUEST.info.pageIdがある時だけpage_idを足すJS実装に合わせる）
+        assert "page_id" not in release_body
+
+    def test_edit_raise_on_exists_releases_lock(self, mock_site_no_http: Site) -> None:
+        """raise_on_exists=Trueで既存ページの場合、取得済みの編集ロックを解放する"""
+        mock_site_no_http.client.is_logged_in = True
+        mock_site_no_http.client.login_check = MagicMock()
+
+        lock_response = MagicMock()
+        lock_response.json.return_value = {
+            "status": "ok",
+            "lock_id": "lock-abc",
+            "lock_secret": "secret-xyz",
+            "page_revision_id": 100,
+        }
+        release_response = MagicMock()
+        release_response.json.return_value = {"status": "ok"}
+
+        mock_site_no_http.amc_request = MagicMock(side_effect=[[lock_response], [release_response]])
+
+        with pytest.raises(exceptions.TargetExistsException):
+            Page.create_or_edit(mock_site_no_http, "existing-page", page_id=1, raise_on_exists=True)
+
+        assert mock_site_no_http.amc_request.call_count == 2
+        release_body = mock_site_no_http.amc_request.call_args_list[1][0][0][0]
+        assert release_body["event"] == "removePageEditLock"
+
+    def test_savepage_failure_releases_lock(self, mock_site_no_http: Site) -> None:
+        """savePage自体が失敗（status != ok）した場合、取得済みの編集ロックを解放する"""
+        mock_site_no_http.client.is_logged_in = True
+        mock_site_no_http.client.login_check = MagicMock()
+
+        lock_response = MagicMock()
+        lock_response.json.return_value = {
+            "status": "ok",
+            "lock_id": "lock-abc",
+            "lock_secret": "secret-xyz",
+        }
+        save_response = MagicMock()
+        save_response.json.return_value = {"status": "no_permission"}
+        release_response = MagicMock()
+        release_response.json.return_value = {"status": "ok"}
+
+        mock_site_no_http.amc_request = MagicMock(side_effect=[[lock_response], [save_response], [release_response]])
+
+        with pytest.raises(exceptions.WikidotStatusCodeException):
+            Page.create_or_edit(mock_site_no_http, "new-page")
+
+        assert mock_site_no_http.amc_request.call_count == 3
+        release_body = mock_site_no_http.amc_request.call_args_list[2][0][0][0]
+        assert release_body["event"] == "removePageEditLock"
+        assert release_body["lock_id"] == "lock-abc"
+
+    def test_release_lock_failure_does_not_mask_original_exception(self, mock_site_no_http: Site) -> None:
+        """ロック解放自体が失敗しても、元の例外（この場合ValueError）を隠さない"""
+        mock_site_no_http.client.is_logged_in = True
+        mock_site_no_http.client.login_check = MagicMock()
+
+        lock_response = MagicMock()
+        lock_response.json.return_value = {
+            "status": "ok",
+            "lock_id": "lock-abc",
+            "lock_secret": "secret-xyz",
+            "page_revision_id": 100,
+        }
+
+        mock_site_no_http.amc_request = MagicMock(
+            side_effect=[[lock_response], exceptions.ForbiddenException("no permission to release lock")]
+        )
+
+        with pytest.raises(ValueError, match="page_id must be specified"):
+            Page.create_or_edit(mock_site_no_http, "existing-page")
+
 
 class TestPageEdit:
     """Page.editのテスト"""


### PR DESCRIPTION
## Summary

Wikidot の AJAX API を追加実装する前提として、AMC クライアントの欠陥を修正する。


## Related Issue

なし

## Changes

- `form_errors` のペイロードを例外から取得できるようにする（`formErrors` / `errors` / `message` のキー揺れを吸収）
- `try_again` 応答の `time_to_wait` を尊重する
- `action` を含むリクエストの HTTP 500 + 空ボディを即時失敗させる
- 配列パラメータをブラケット記法（`key[]=v1&key[]=v2`）でエンコードする
- `False` / `None` をキーごと省略するリクエストボディ構築ヘルパを追加
- モジュール応答の `body` 欠落を検出するヘルパを追加
- ページ作成失敗時に編集ロックを解放する

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring
- [x] Test addition/modification
- [ ] CI/CD or build related

## Testing

- [x] `make format` passes
- [x] `make lint` passes
- [x] `make test` passes

## Checklist

- [x] Code follows the project's style guidelines
- [ ] Documentation has been updated as needed
- [x] Tests have been added for the changes (if applicable)

## Additional Information

- 既存ページに `create()` した場合などロック取得後の失敗経路で解放しておらず、対象ページが最大15分編集不可になっていた
- checkbox 由来のパラメータは `False` を送ると Wikidot 側で「オン」と解釈されうるため、キーごと省略する必要がある
- 未対応の `action`/`event` は HTTP 500 + 空ボディで返るため、従来は既定5回の指数バックオフを空振りしていた

README と `llms.txt` は追加した API を反映していない。リリース前にまとめて追随させる。
