### PR TITLE
サイト設定(site.settings)の追加

### DIFF
--- a/src/wikidot/module/site.py
+++ b/src/wikidot/module/site.py
@@ -25,6 +25,7 @@ from .forum_thread import ForumThread, ForumThreadCollection
 from .page import Page, PageCollection, SearchPagesQuery, SearchPagesQueryParams
 from .site_application import SiteApplication
 from .site_member import SiteMember
+from .site_settings import SiteSettingsAccessor
 
 if TYPE_CHECKING:
     from .client import Client
@@ -283,6 +284,7 @@ class Site:
     pages: "SitePagesAccessor" = field(init=False, repr=False)
     page: "SitePageAccessor" = field(init=False, repr=False)
     forum: "SiteForumAccessor" = field(init=False, repr=False)
+    settings: "SiteSettingsAccessor" = field(init=False, repr=False)
 
     # キャッシュ属性
     _members: list["SiteMember"] | None = field(init=False, default=None, repr=False)
@@ -298,6 +300,7 @@ class Site:
         self.pages = SitePagesAccessor(self)
         self.page = SitePageAccessor(self)
         self.forum = SiteForumAccessor(self)
+        self.settings = SiteSettingsAccessor(self)
 
     def __str__(self) -> str:
         """

--- a/src/wikidot/module/site_category.py
+++ b/src/wikidot/module/site_category.py
@@ -1,0 +1,360 @@
+"""
+Module for handling Wikidot's per-site "category" objects
+
+`categories` is the shared read-modify-write data structure behind seven
+Manage Site areas (Permissions / License / Navigation / Templates / PageRate
+/ PerPageDiscussion / Appearance): each renders the *entire* category array
+alongside its HTML body, and each save sends the *entire* array back as a
+single JSON string — there is no partial-update endpoint. See 30_plan.md D3
+and 40_admin-managesite.md for the schema and wire format this is built
+from.
+"""
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+from ..common import exceptions
+from ..util.amc_body import json_param
+from .site_permissions import Actor, PagePermissions, RatingSettings, replace_actors
+
+if TYPE_CHECKING:
+    from .site import Site
+
+
+class SiteLicense(Enum):
+    """
+    Known `license_id` values for a category
+
+    Values and English names come from 35_form-fields.md's "license_id の値
+    （実測）" table. That table grouped ids 5/6/7 and 15/16/17 under a single
+    generic label each ("CC Attribution Non-commercial 系") rather than
+    naming the individual ShareAlike/NoDerivs variants, so those six
+    members below are also generic placeholders distinguished only by id;
+    treat their exact license text as unconfirmed until verified against a
+    real site (see the P1 completion report for this flag).
+    """
+
+    OTHER = 1
+    """Other. Requires `license_other` to be set."""
+    CC_ATTRIBUTION_SHAREALIKE_2_5 = 2
+    CC_ATTRIBUTION_2_5 = 3
+    CC_ATTRIBUTION_NO_DERIVATIVES_2_5 = 4
+    CC_ATTRIBUTION_NONCOMMERCIAL_2_5_VARIANT_A = 5
+    CC_ATTRIBUTION_NONCOMMERCIAL_2_5_VARIANT_B = 6
+    CC_ATTRIBUTION_NONCOMMERCIAL_2_5_VARIANT_C = 7
+    GFDL_1_2 = 8
+    STANDARD_COPYRIGHT = 11
+    CC_ATTRIBUTION_SHAREALIKE_3_0 = 12
+    CC_ATTRIBUTION_3_0 = 13
+    CC_ATTRIBUTION_NO_DERIVATIVES_3_0 = 14
+    CC_ATTRIBUTION_NONCOMMERCIAL_3_0_VARIANT_A = 15
+    CC_ATTRIBUTION_NONCOMMERCIAL_3_0_VARIANT_B = 16
+    CC_ATTRIBUTION_NONCOMMERCIAL_3_0_VARIANT_C = 17
+
+
+@dataclass
+class SiteCategory:
+    """
+    A single category object from a site's Manage Site `categories` array
+
+    Attributes mirror the JSON schema documented in 40_admin-managesite.md
+    (24 fields, `_default` category holds the site-wide defaults that other
+    categories inherit when their own `*_default` flag is set).
+
+    Attributes
+    ----------
+    category_id : int
+    site_id : int
+    name : str
+    theme_default : bool
+    theme_id : int | str
+        Normally an int theme id. Wikidot's own client sends the empty
+        string here (not 0) when `theme_external_url` is used instead
+        (see 40_admin-managesite.md「Appearance」)
+    layout_default : bool
+    layout_id : int
+    theme_external_url : str
+    permissions_default : bool
+    permissions : PagePermissions | None
+        None when permissions_default is True (inherits site default)
+    license_default : bool
+    license_id : int | None
+    license_other : str
+    nav_default : bool
+    top_bar_page_name : str | None
+    side_bar_page_name : str | None
+    template_id : int | None
+    per_page_discussion : bool | None
+        None means "use site default"
+    per_page_discussion_default : bool
+    rating : RatingSettings | None
+    autonumerate : bool
+    page_title_template : str | None
+    enable_pingback_out : bool
+    enable_pingback_in : bool
+    """
+
+    category_id: int
+    site_id: int
+    name: str
+    theme_default: bool
+    theme_id: int | str
+    layout_default: bool
+    layout_id: int
+    theme_external_url: str
+    permissions_default: bool
+    permissions: PagePermissions | None
+    license_default: bool
+    license_id: int | None
+    license_other: str
+    nav_default: bool
+    top_bar_page_name: str | None
+    side_bar_page_name: str | None
+    template_id: int | None
+    per_page_discussion: bool | None
+    per_page_discussion_default: bool
+    rating: RatingSettings | None
+    autonumerate: bool
+    page_title_template: str | None
+    enable_pingback_out: bool
+    enable_pingback_in: bool
+    #: Original response dict, kept so to_dict() can round-trip fields this
+    #: library does not (yet) know about instead of dropping them
+    _raw: dict[str, Any] = field(repr=False)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "SiteCategory":
+        """
+        Parse a single category object from a `categories` array element
+
+        Parameters
+        ----------
+        data : dict[str, Any]
+            Raw category object as returned by Wikidot
+
+        Returns
+        -------
+        SiteCategory
+        """
+        permissions_str = data.get("permissions")
+        rating_str = data.get("rating")
+        return cls(
+            category_id=data["category_id"],
+            site_id=data["site_id"],
+            name=data["name"],
+            theme_default=bool(data.get("theme_default", False)),
+            theme_id=data.get("theme_id", 0),
+            layout_default=bool(data.get("layout_default", True)),
+            layout_id=data.get("layout_id", 0),
+            theme_external_url=data.get("theme_external_url") or "",
+            permissions_default=bool(data.get("permissions_default", False)),
+            permissions=PagePermissions.decode(permissions_str) if permissions_str else None,
+            license_default=bool(data.get("license_default", True)),
+            license_id=data.get("license_id"),
+            license_other=data.get("license_other") or "",
+            nav_default=bool(data.get("nav_default", True)),
+            top_bar_page_name=data.get("top_bar_page_name"),
+            side_bar_page_name=data.get("side_bar_page_name"),
+            template_id=data.get("template_id"),
+            per_page_discussion=data.get("per_page_discussion"),
+            per_page_discussion_default=bool(data.get("per_page_discussion_default", True)),
+            rating=RatingSettings.decode(rating_str) if rating_str else None,
+            autonumerate=bool(data.get("autonumerate", False)),
+            page_title_template=data.get("page_title_template"),
+            enable_pingback_out=bool(data.get("enable_pingback_out", False)),
+            enable_pingback_in=bool(data.get("enable_pingback_in", False)),
+            _raw=data,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Rebuild a category object for sending back to Wikidot
+
+        Starts from `_raw` (so unknown fields survive the round trip) and
+        overwrites only the fields this class models.
+
+        Returns
+        -------
+        dict[str, Any]
+        """
+        result = dict(self._raw)
+        result.update(
+            category_id=self.category_id,
+            site_id=self.site_id,
+            name=self.name,
+            theme_default=self.theme_default,
+            theme_id=self.theme_id,
+            layout_default=self.layout_default,
+            layout_id=self.layout_id,
+            theme_external_url=self.theme_external_url,
+            permissions_default=self.permissions_default,
+            permissions=self.permissions.encode() if self.permissions is not None else None,
+            license_default=self.license_default,
+            license_id=self.license_id,
+            license_other=self.license_other,
+            nav_default=self.nav_default,
+            top_bar_page_name=self.top_bar_page_name,
+            side_bar_page_name=self.side_bar_page_name,
+            template_id=self.template_id,
+            per_page_discussion=self.per_page_discussion,
+            per_page_discussion_default=self.per_page_discussion_default,
+            rating=self.rating.encode() if self.rating is not None else None,
+            autonumerate=self.autonumerate,
+            page_title_template=self.page_title_template,
+            enable_pingback_out=self.enable_pingback_out,
+            enable_pingback_in=self.enable_pingback_in,
+        )
+        return result
+
+    def set_permissions(
+        self,
+        *,
+        view: Iterable[Actor] | None = None,
+        create: Iterable[Actor] | None = None,
+        edit: Iterable[Actor] | None = None,
+        move: Iterable[Actor] | None = None,
+        delete: Iterable[Actor] | None = None,
+        upload_files: Iterable[Actor] | None = None,
+        rename_files: Iterable[Actor] | None = None,
+        replace_files: Iterable[Actor] | None = None,
+        show_options: Iterable[Actor] | None = None,
+    ) -> None:
+        """
+        Update the specified page-permission fields, leaving the rest unchanged
+
+        Also clears `permissions_default` (this category now has its own
+        explicit permissions instead of inheriting the site default).
+
+        Parameters
+        ----------
+        view, create, edit, move, delete, upload_files, rename_files,
+        replace_files, show_options : Iterable[Actor] | None
+            New actor set for that permission. Fields left as None are
+            unchanged
+        """
+        current = self.permissions or PagePermissions()
+        updates = {
+            name: value
+            for name, value in (
+                ("view", view),
+                ("create", create),
+                ("edit", edit),
+                ("move", move),
+                ("delete", delete),
+                ("upload_files", upload_files),
+                ("rename_files", rename_files),
+                ("replace_files", replace_files),
+                ("show_options", show_options),
+            )
+            if value is not None
+        }
+        self.permissions = replace_actors(current, **updates)
+        self.permissions_default = False
+
+
+@dataclass
+class SiteCategoryCollection:
+    """
+    The full `categories` array for a site, keyed by category name
+
+    Never cached (see 30_plan.md D3): a new collection is fetched every
+    time `SiteSettingsAccessor.update_categories` is called, so concurrent
+    changes by other admins are not clobbered by a stale save.
+    """
+
+    site: "Site"
+    categories: list[SiteCategory]
+
+    def __getitem__(self, name: str) -> SiteCategory:
+        """
+        Look up a category by name
+
+        Parameters
+        ----------
+        name : str
+            Category name (e.g. "_default")
+
+        Returns
+        -------
+        SiteCategory
+
+        Raises
+        ------
+        KeyError
+            If no category with that name exists
+        """
+        for category in self.categories:
+            if category.name == name:
+                return category
+        raise KeyError(f"Category not found: {name}")
+
+    def __iter__(self) -> Iterable[SiteCategory]:
+        """Iterate over categories"""
+        return iter(self.categories)
+
+    def __len__(self) -> int:
+        """Number of categories"""
+        return len(self.categories)
+
+    def names(self) -> list[str]:
+        """
+        Get all category names
+
+        Returns
+        -------
+        list[str]
+        """
+        return [category.name for category in self.categories]
+
+    @classmethod
+    def fetch(cls, site: "Site", module_name: str) -> "SiteCategoryCollection":
+        """
+        Fetch the current `categories` array by rendering a Manage Site module
+
+        Parameters
+        ----------
+        site : Site
+            Site to fetch categories for
+        module_name : str
+            Any Manage Site module documented to embed the full `categories`
+            array in its response (e.g. "managesite/ManageSitePermissionsModule")
+
+        Returns
+        -------
+        SiteCategoryCollection
+
+        Raises
+        ------
+        ResponseDataException
+            If the response has no `categories` field
+        """
+        response = site.amc_request([{"moduleName": module_name}])[0]
+        data = response.json()
+        raw_categories = data.get("categories")
+        if raw_categories is None:
+            raise exceptions.ResponseDataException(f"Response has no 'categories' field: {module_name}")
+        return cls(site=site, categories=[SiteCategory.from_dict(item) for item in raw_categories])
+
+    def save(self, action: str, event: str) -> None:
+        """
+        Send the full `categories` array back to Wikidot
+
+        Parameters
+        ----------
+        action : str
+            AMC action (e.g. "ManageSiteAction")
+        event : str
+            AMC event (e.g. "savePermissions")
+        """
+        self.site.amc_request(
+            [
+                {
+                    "action": action,
+                    "event": event,
+                    "categories": json_param([category.to_dict() for category in self.categories]),
+                    "moduleName": "Empty",
+                }
+            ]
+        )

--- a/src/wikidot/module/site_category.py
+++ b/src/wikidot/module/site_category.py
@@ -27,31 +27,43 @@ class SiteLicense(Enum):
     """
     Known `license_id` values for a category
 
-    Values and English names come from 35_form-fields.md's "license_id の値
-    （実測）" table. That table grouped ids 5/6/7 and 15/16/17 under a single
-    generic label each ("CC Attribution Non-commercial 系") rather than
-    naming the individual ShareAlike/NoDerivs variants, so those six
-    members below are also generic placeholders distinguished only by id;
-    treat their exact license text as unconfirmed until verified against a
-    real site (see the P1 completion report for this flag).
+    Values and the exact option text come from a live read-only fetch of
+    `managesite/ManageSiteLicenseModule` (`select#sm-license-lic`), recorded
+    in 35_form-fields.md's "license_id の値（実測）" table. All 15 values are
+    confirmed, including the previously-grouped NonCommercial variants
+    (5/6/7 and 15/16/17).
     """
 
     OTHER = 1
-    """Other. Requires `license_other` to be set."""
+    """"Other" (custom license). Requires `license_other` to be set."""
     CC_ATTRIBUTION_SHAREALIKE_2_5 = 2
+    """"Creative Commons Attribution Share Alike 2.5" """
     CC_ATTRIBUTION_2_5 = 3
+    """"Creative Commons Attribution 2.5" """
     CC_ATTRIBUTION_NO_DERIVATIVES_2_5 = 4
-    CC_ATTRIBUTION_NONCOMMERCIAL_2_5_VARIANT_A = 5
-    CC_ATTRIBUTION_NONCOMMERCIAL_2_5_VARIANT_B = 6
-    CC_ATTRIBUTION_NONCOMMERCIAL_2_5_VARIANT_C = 7
+    """"Creative Commons Attribution No Derivatives 2.5" """
+    CC_ATTRIBUTION_NONCOMMERCIAL_2_5 = 5
+    """"Creative Commons Attribution Non-commercial 2.5" """
+    CC_ATTRIBUTION_NONCOMMERCIAL_SHAREALIKE_2_5 = 6
+    """"Creative Commons Attribution Non-commercial Share Alike 2.5" """
+    CC_ATTRIBUTION_NONCOMMERCIAL_NO_DERIVATIVES_2_5 = 7
+    """"Creative Commons Attribution Non-commercial No Derivatives 2.5" """
     GFDL_1_2 = 8
+    """"GNU Free Documentation License 1.2" """
     STANDARD_COPYRIGHT = 11
+    """"Standard copyright (not recommended)" """
     CC_ATTRIBUTION_SHAREALIKE_3_0 = 12
+    """"Creative Commons Attribution-ShareAlike 3.0 License (recommended)" """
     CC_ATTRIBUTION_3_0 = 13
+    """"Creative Commons Attribution 3.0 License" """
     CC_ATTRIBUTION_NO_DERIVATIVES_3_0 = 14
-    CC_ATTRIBUTION_NONCOMMERCIAL_3_0_VARIANT_A = 15
-    CC_ATTRIBUTION_NONCOMMERCIAL_3_0_VARIANT_B = 16
-    CC_ATTRIBUTION_NONCOMMERCIAL_3_0_VARIANT_C = 17
+    """"Creative Commons Attribution-NoDerivs 3.0 License" """
+    CC_ATTRIBUTION_NONCOMMERCIAL_3_0 = 15
+    """"Creative Commons Attribution-NonCommercial 3.0 License" """
+    CC_ATTRIBUTION_NONCOMMERCIAL_SHAREALIKE_3_0 = 16
+    """"Creative Commons Attribution-NonCommercial-ShareAlike 3.0 License" """
+    CC_ATTRIBUTION_NONCOMMERCIAL_NO_DERIVATIVES_3_0 = 17
+    """"Creative Commons Attribution-NonCommercial-NoDerivs 3.0 License" """
 
 
 @dataclass

--- a/src/wikidot/module/site_permissions.py
+++ b/src/wikidot/module/site_permissions.py
@@ -1,0 +1,373 @@
+"""
+Encoders/decoders for Wikidot's compact permission and rating strings
+
+Manage Site's category objects hold permissions as a single semicolon-
+separated string (e.g. ``v:armo;c:m;...``), forum permissions in a similar
+but distinct format, and rating configuration as a fixed 4-character code
+(e.g. ``drvM``). These are typed here instead of being passed around as raw
+strings so callers get validation and IDE support; see 30_plan.md D4 for the
+design rationale (in particular: unknown symbols are preserved through a
+decode/encode round trip rather than dropped, since at least one forum
+permission symbol ("s") is defined in Wikidot's client JS but has an
+unconfirmed purpose).
+"""
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import Literal
+
+Actor = Literal["anonymous", "registered", "member", "author"]
+
+#: Fixed column order used when encoding an actor set back to symbols.
+#: Matches the "users" column order documented in 40_admin-managesite.md
+#: (a/r/m/o), which the "v:armo" example relies on.
+_ACTOR_ORDER: tuple[Actor, ...] = ("anonymous", "registered", "member", "author")
+
+_ACTOR_TO_SYMBOL: dict[Actor, str] = {
+    "anonymous": "a",
+    "registered": "r",
+    "member": "m",
+    "author": "o",
+}
+_SYMBOL_TO_ACTOR: dict[str, Actor] = {v: k for k, v in _ACTOR_TO_SYMBOL.items()}
+
+
+def _encode_actors(actors: frozenset[Actor]) -> str:
+    """Encode an actor set into its fixed-order symbol string (e.g. "armo")"""
+    return "".join(_ACTOR_TO_SYMBOL[actor] for actor in _ACTOR_ORDER if actor in actors)
+
+
+def _decode_actors(symbols: str) -> frozenset[Actor] | None:
+    """
+    Decode a symbol string into an actor set
+
+    Returns None (instead of a partial set) if any character is not a known
+    actor symbol, so the caller can preserve the whole segment verbatim
+    rather than silently drop the unrecognized part.
+    """
+    actors: set[Actor] = set()
+    for symbol in symbols:
+        actor = _SYMBOL_TO_ACTOR.get(symbol)
+        if actor is None:
+            return None
+        actors.add(actor)
+    return frozenset(actors)
+
+
+# Row (permission) order is fixed by 40_admin-managesite.md.
+_PAGE_PERM_ORDER: tuple[str, ...] = ("v", "c", "e", "m", "d", "a", "r", "z", "o")
+_PAGE_PERM_FIELD: dict[str, str] = {
+    "v": "view",
+    "c": "create",
+    "e": "edit",
+    "m": "move",
+    "d": "delete",
+    "a": "upload_files",
+    "r": "rename_files",
+    "z": "replace_files",
+    "o": "show_options",
+}
+
+
+@dataclass(frozen=True)
+class PagePermissions:
+    """
+    Decoded form of a category's `permissions` string
+
+    Attributes
+    ----------
+    view, create, edit, move, delete, upload_files, rename_files,
+    replace_files, show_options : frozenset[Actor]
+        Actors granted each permission. Empty by default (no one)
+    """
+
+    view: frozenset[Actor] = frozenset()
+    create: frozenset[Actor] = frozenset()
+    edit: frozenset[Actor] = frozenset()
+    move: frozenset[Actor] = frozenset()
+    delete: frozenset[Actor] = frozenset()
+    upload_files: frozenset[Actor] = frozenset()
+    rename_files: frozenset[Actor] = frozenset()
+    replace_files: frozenset[Actor] = frozenset()
+    show_options: frozenset[Actor] = frozenset()
+    #: Raw "letter:users" segments this library did not recognize, preserved
+    #: verbatim so a decode -> encode round trip never loses data
+    _unknown: tuple[str, ...] = field(default_factory=tuple)
+
+    def encode(self) -> str:
+        """
+        Encode back into Wikidot's `permissions` string format
+
+        Returns
+        -------
+        str
+            e.g. "v:armo;c:m;e:m;m:m;d:m;a:m;r:m;z:m;o:rm"
+        """
+        segments = [
+            f"{symbol}:{_encode_actors(getattr(self, _PAGE_PERM_FIELD[symbol]))}" for symbol in _PAGE_PERM_ORDER
+        ]
+        segments.extend(self._unknown)
+        return ";".join(segments)
+
+    @classmethod
+    def decode(cls, s: str) -> "PagePermissions":
+        """
+        Decode a category's `permissions` string
+
+        Parameters
+        ----------
+        s : str
+            Raw string, e.g. "v:armo;c:m;e:m;m:m;d:m;a:m;r:m;z:m;o:rm"
+
+        Returns
+        -------
+        PagePermissions
+        """
+        fields: dict[str, frozenset[Actor]] = {}
+        unknown: list[str] = []
+        for segment in s.split(";"):
+            if not segment:
+                continue
+            symbol, _, users = segment.partition(":")
+            field_name = _PAGE_PERM_FIELD.get(symbol)
+            actors = _decode_actors(users) if field_name is not None else None
+            if field_name is not None and actors is not None:
+                fields[field_name] = actors
+            else:
+                unknown.append(segment)
+        return cls(**fields, _unknown=tuple(unknown))
+
+    def validate(self) -> list[str]:
+        """
+        Check the anonymous ⊂ registered ⊂ member containment convention
+
+        Wikidot's Manage Site UI enforces this relationship client-side
+        (granting anonymous access implies registered and member access,
+        and so on), but it is unconfirmed whether the server enforces it
+        too. This library does not auto-correct the containment (doing so
+        could silently grant permissions the caller did not ask for); call
+        this explicitly if you want to check before saving.
+
+        Returns
+        -------
+        list[str]
+            Human-readable description of each violated field. Empty if
+            everything is consistent
+        """
+        violations: list[str] = []
+        for symbol in _PAGE_PERM_ORDER:
+            field_name = _PAGE_PERM_FIELD[symbol]
+            actors = getattr(self, field_name)
+            if "anonymous" in actors and not {"registered", "member"} <= actors:
+                violations.append(f"{field_name}: anonymous access requires registered and member access too")
+            elif "registered" in actors and "member" not in actors:
+                violations.append(f"{field_name}: registered access requires member access too")
+        return violations
+
+
+# Forum permission row order per 40_admin-managesite.md ("t"=Create new
+# threads / "p"=Add new posts / "e"=Edit posts). The "s" symbol is defined
+# in Wikidot's client JS (vars.permissions) but not rendered in the
+# permission table on any site checked during the survey, so its meaning
+# is unconfirmed; it round-trips through `_unknown` like any other
+# unrecognized segment instead of being modeled as a known field.
+_FORUM_PERM_ORDER: tuple[str, ...] = ("t", "p", "e")
+_FORUM_PERM_FIELD: dict[str, str] = {
+    "t": "create_threads",
+    "p": "add_posts",
+    "e": "edit_posts",
+}
+
+
+@dataclass(frozen=True)
+class ForumPermissions:
+    """
+    Decoded form of `ManageSiteForumAction/saveForumPermissions`'s
+    per-category `permissions` string (a separate encoding from
+    PagePermissions despite the similar shape)
+
+    Attributes
+    ----------
+    create_threads, add_posts, edit_posts : frozenset[Actor]
+        Actors granted each permission
+    """
+
+    create_threads: frozenset[Actor] = frozenset()
+    add_posts: frozenset[Actor] = frozenset()
+    edit_posts: frozenset[Actor] = frozenset()
+    #: Raw "letter:users" segments this library did not recognize (e.g. the
+    #: unconfirmed "s" symbol), preserved verbatim
+    _unknown: tuple[str, ...] = field(default_factory=tuple)
+
+    def encode(self) -> str:
+        """
+        Encode back into the forum `permissions` string format
+
+        Returns
+        -------
+        str
+        """
+        segments = [
+            f"{symbol}:{_encode_actors(getattr(self, _FORUM_PERM_FIELD[symbol]))}" for symbol in _FORUM_PERM_ORDER
+        ]
+        segments.extend(self._unknown)
+        return ";".join(segments)
+
+    @classmethod
+    def decode(cls, s: str) -> "ForumPermissions":
+        """
+        Decode a forum category's `permissions` string
+
+        Parameters
+        ----------
+        s : str
+
+        Returns
+        -------
+        ForumPermissions
+        """
+        fields: dict[str, frozenset[Actor]] = {}
+        unknown: list[str] = []
+        for segment in s.split(";"):
+            if not segment:
+                continue
+            symbol, _, users = segment.partition(":")
+            field_name = _FORUM_PERM_FIELD.get(symbol)
+            actors = _decode_actors(users) if field_name is not None else None
+            if field_name is not None and actors is not None:
+                fields[field_name] = actors
+            else:
+                unknown.append(segment)
+        return cls(**fields, _unknown=tuple(unknown))
+
+
+_VOTER_TO_SYMBOL: dict[str, str] = {"registered": "r", "member": "m"}
+_SYMBOL_TO_VOTER: dict[str, Literal["registered", "member"]] = {"r": "registered", "m": "member"}
+_KIND_TO_SYMBOL: dict[str, str] = {"plus_only": "P", "plus_minus": "M", "stars": "S"}
+_SYMBOL_TO_KIND: dict[str, Literal["plus_only", "plus_minus", "stars"]] = {
+    "P": "plus_only",
+    "M": "plus_minus",
+    "S": "stars",
+}
+
+
+@dataclass(frozen=True)
+class RatingSettings:
+    """
+    Decoded form of a category's 4-character `rating` code (e.g. "drvM")
+
+    Attributes
+    ----------
+    enabled : bool
+        Whether rating is enabled for the category
+    voters : Literal["registered", "member"]
+        Who can vote
+    anonymous : bool
+        Whether votes are anonymous (True) or show the voter (False)
+    kind : Literal["plus_only", "plus_minus", "stars"]
+        Rating widget type
+    """
+
+    enabled: bool
+    voters: Literal["registered", "member"]
+    anonymous: bool
+    kind: Literal["plus_only", "plus_minus", "stars"]
+
+    def encode(self) -> str:
+        """
+        Encode back into Wikidot's 4-character `rating` code
+
+        Returns
+        -------
+        str
+            e.g. "drvM"
+        """
+        return "".join(
+            [
+                "e" if self.enabled else "d",
+                _VOTER_TO_SYMBOL[self.voters],
+                "a" if self.anonymous else "v",
+                _KIND_TO_SYMBOL[self.kind],
+            ]
+        )
+
+    @classmethod
+    def decode(cls, s: str) -> "RatingSettings":
+        """
+        Decode a category's `rating` code
+
+        Parameters
+        ----------
+        s : str
+            4-character code, e.g. "drvM"
+
+        Returns
+        -------
+        RatingSettings
+
+        Raises
+        ------
+        ValueError
+            If `s` is not a recognized 4-character code. Unlike
+            PagePermissions/ForumPermissions, no unrecognized-but-real
+            variant of this code was found during the survey (each of the
+            4 positions has exactly 2 documented values), so this raises
+            instead of silently guessing at an unknown format
+        """
+        if (
+            len(s) != 4
+            or s[0] not in "ed"
+            or s[1] not in _SYMBOL_TO_VOTER
+            or s[2] not in "av"
+            or s[3] not in _SYMBOL_TO_KIND
+        ):
+            raise ValueError(f"Invalid rating code: {s!r}")
+        return cls(
+            enabled=s[0] == "e",
+            voters=_SYMBOL_TO_VOTER[s[1]],
+            anonymous=s[2] == "a",
+            kind=_SYMBOL_TO_KIND[s[3]],
+        )
+
+
+def replace_actors(permissions: PagePermissions, **updates: Iterable[Actor]) -> PagePermissions:
+    """
+    Return a copy of `permissions` with only the specified fields replaced
+
+    Convenience for the common "change one permission, leave the rest"
+    pattern. Built as an explicit field-by-field copy rather than
+    `dataclasses.replace(permissions, **updates)`: mypy's dataclass plugin
+    cannot type-check a `**dict` splat against per-field types, so this
+    keeps every field statically checked instead of relying on `# type:
+    ignore`
+
+    Parameters
+    ----------
+    permissions : PagePermissions
+        Base permissions to copy
+    **updates : Iterable[Actor]
+        Field name to new actor iterable (e.g. view=("anonymous",))
+
+    Returns
+    -------
+    PagePermissions
+    """
+    unknown_names = set(updates) - set(_PAGE_PERM_FIELD.values())
+    if unknown_names:
+        raise ValueError(f"Unknown PagePermissions field(s): {sorted(unknown_names)}")
+
+    def _field(name: str) -> frozenset[Actor]:
+        return frozenset(updates[name]) if name in updates else getattr(permissions, name)
+
+    return PagePermissions(
+        view=_field("view"),
+        create=_field("create"),
+        edit=_field("edit"),
+        move=_field("move"),
+        delete=_field("delete"),
+        upload_files=_field("upload_files"),
+        rename_files=_field("rename_files"),
+        replace_files=_field("replace_files"),
+        show_options=_field("show_options"),
+        _unknown=permissions._unknown,
+    )

--- a/src/wikidot/module/site_settings.py
+++ b/src/wikidot/module/site_settings.py
@@ -35,18 +35,28 @@ if TYPE_CHECKING:
     from .user import AbstractUser
 
 
+#: Module names that render each categories-backed settings area. Each of
+#: these embeds the site's full `categories` array (same 24-field schema;
+#: see 40_admin-managesite.md), so update_categories fetches from the
+#: module matching the area being changed rather than a single fixed one
+#: — a module that only echoes back a subset of fields would otherwise
+#: cause the categories round trip (SiteCategory._raw, see D3) to lose
+#: the fields it didn't include on the next save of a *different* area.
+_MODULE_PERMISSIONS = "managesite/ManageSitePermissionsModule"
+_MODULE_LICENSE = "managesite/ManageSiteLicenseModule"
+_MODULE_NAVIGATION = "managesite/ManageSiteNavigationModule"
+_MODULE_TEMPLATES = "managesite/ManageSiteTemplatesModule"
+_MODULE_PAGE_RATE = "managesite/pagerate/ManageSitePageRateSettingsModule"
+_MODULE_PER_PAGE_DISCUSSION = "managesite/ManageSitePerPageDiscussionModule"
+_MODULE_APPEARANCE = "managesite/themes/ManageSiteAppearanceModule"
+
+
 class SiteSettingsAccessor:
     """
     Accessor for Manage Site (`_admin`) settings
 
     Access through `Site.settings`.
     """
-
-    #: Any categories-rendering module works as the fetch source for
-    #: update_categories (they all embed the same full-schema array); this
-    #: one is used because it's the module the categories schema in
-    #: 40_admin-managesite.md was captured from.
-    _CATEGORIES_FETCH_MODULE = "managesite/ManageSitePermissionsModule"
 
     def __init__(self, site: "Site"):
         """
@@ -65,6 +75,7 @@ class SiteSettingsAccessor:
 
     def update_categories(
         self,
+        module_name: str,
         action: str,
         event: str,
         mutator: Callable[[SiteCategoryCollection], None],
@@ -82,6 +93,14 @@ class SiteSettingsAccessor:
 
         Parameters
         ----------
+        module_name : str
+            Manage Site module to fetch the `categories` array from before
+            mutating (e.g. "managesite/ManageSitePermissionsModule").
+            Matches the module that would render the area being changed —
+            it is unconfirmed whether every categories-rendering module
+            echoes back the same full 24-field schema, so this fetches
+            from the module for the area actually being saved rather than
+            a single fixed one
         action : str
             AMC action for the save request (e.g. "ManageSiteAction")
         event : str
@@ -93,13 +112,14 @@ class SiteSettingsAccessor:
         Examples
         --------
         >>> site.settings.update_categories(
+        ...     "managesite/ManageSitePermissionsModule",
         ...     "ManageSiteAction", "savePermissions",
         ...     lambda cats: cats["_default"].set_permissions(
         ...         view={"anonymous", "registered", "member"}
         ...     ),
         ... )
         """
-        collection = SiteCategoryCollection.fetch(self.site, self._CATEGORIES_FETCH_MODULE)
+        collection = SiteCategoryCollection.fetch(self.site, module_name)
         mutator(collection)
         collection.save(action, event)
 
@@ -125,7 +145,7 @@ class SiteSettingsAccessor:
             category.permissions = permissions
             category.permissions_default = False
 
-        self.update_categories("ManageSiteAction", "savePermissions", mutator)
+        self.update_categories(_MODULE_PERMISSIONS, "ManageSiteAction", "savePermissions", mutator)
 
     def use_default_page_permissions(self, category_name: str) -> None:
         """
@@ -142,7 +162,7 @@ class SiteSettingsAccessor:
             category.permissions = None
             category.permissions_default = True
 
-        self.update_categories("ManageSiteAction", "savePermissions", mutator)
+        self.update_categories(_MODULE_PERMISSIONS, "ManageSiteAction", "savePermissions", mutator)
 
     def set_license(self, category_name: str, license: SiteLicense, other: str = "") -> None:
         """
@@ -172,7 +192,7 @@ class SiteSettingsAccessor:
             category.license_other = other
             category.license_default = False
 
-        self.update_categories("ManageSiteAction", "saveLicense", mutator)
+        self.update_categories(_MODULE_LICENSE, "ManageSiteAction", "saveLicense", mutator)
 
     def use_default_license(self, category_name: str) -> None:
         """
@@ -187,7 +207,7 @@ class SiteSettingsAccessor:
         def mutator(cats: SiteCategoryCollection) -> None:
             cats[category_name].license_default = True
 
-        self.update_categories("ManageSiteAction", "saveLicense", mutator)
+        self.update_categories(_MODULE_LICENSE, "ManageSiteAction", "saveLicense", mutator)
 
     def set_navigation(self, category_name: str, top_bar_page_name: str, side_bar_page_name: str) -> None:
         """
@@ -209,7 +229,7 @@ class SiteSettingsAccessor:
             category.side_bar_page_name = side_bar_page_name
             category.nav_default = False
 
-        self.update_categories("ManageSiteAction", "saveNavigation", mutator)
+        self.update_categories(_MODULE_NAVIGATION, "ManageSiteAction", "saveNavigation", mutator)
 
     def use_default_navigation(self, category_name: str) -> None:
         """
@@ -224,7 +244,7 @@ class SiteSettingsAccessor:
         def mutator(cats: SiteCategoryCollection) -> None:
             cats[category_name].nav_default = True
 
-        self.update_categories("ManageSiteAction", "saveNavigation", mutator)
+        self.update_categories(_MODULE_NAVIGATION, "ManageSiteAction", "saveNavigation", mutator)
 
     def set_template(self, category_name: str, template_id: int | None) -> None:
         """
@@ -241,7 +261,7 @@ class SiteSettingsAccessor:
         def mutator(cats: SiteCategoryCollection) -> None:
             cats[category_name].template_id = template_id
 
-        self.update_categories("ManageSiteAction", "saveTemplates", mutator)
+        self.update_categories(_MODULE_TEMPLATES, "ManageSiteAction", "saveTemplates", mutator)
 
     def set_page_rate_settings(self, category_name: str, rating: RatingSettings) -> None:
         """
@@ -258,7 +278,7 @@ class SiteSettingsAccessor:
         def mutator(cats: SiteCategoryCollection) -> None:
             cats[category_name].rating = rating
 
-        self.update_categories("ManageSiteAction", "savePageRateSettings", mutator)
+        self.update_categories(_MODULE_PAGE_RATE, "ManageSiteAction", "savePageRateSettings", mutator)
 
     def set_per_page_discussion(self, category_name: str, enabled: bool | None) -> None:
         """
@@ -277,7 +297,7 @@ class SiteSettingsAccessor:
             category.per_page_discussion = enabled
             category.per_page_discussion_default = enabled is None
 
-        self.update_categories("ManageSiteForumAction", "savePerPageDiscussion", mutator)
+        self.update_categories(_MODULE_PER_PAGE_DISCUSSION, "ManageSiteForumAction", "savePerPageDiscussion", mutator)
 
     def set_appearance_theme(self, category_name: str, theme_id: int) -> None:
         """
@@ -297,7 +317,7 @@ class SiteSettingsAccessor:
             category.theme_external_url = ""
             category.theme_default = False
 
-        self.update_categories("ManageSiteThemeAction", "saveAppearance", mutator)
+        self.update_categories(_MODULE_APPEARANCE, "ManageSiteThemeAction", "saveAppearance", mutator)
 
     def set_appearance_external_theme(self, category_name: str, theme_external_url: str) -> None:
         """
@@ -320,7 +340,7 @@ class SiteSettingsAccessor:
             category.theme_external_url = theme_external_url
             category.theme_default = False
 
-        self.update_categories("ManageSiteThemeAction", "saveAppearance", mutator)
+        self.update_categories(_MODULE_APPEARANCE, "ManageSiteThemeAction", "saveAppearance", mutator)
 
     def use_default_appearance(self, category_name: str) -> None:
         """
@@ -335,7 +355,7 @@ class SiteSettingsAccessor:
         def mutator(cats: SiteCategoryCollection) -> None:
             cats[category_name].theme_default = True
 
-        self.update_categories("ManageSiteThemeAction", "saveAppearance", mutator)
+        self.update_categories(_MODULE_APPEARANCE, "ManageSiteThemeAction", "saveAppearance", mutator)
 
     # ------------------------------------------------------------------
     # Task 1-3: General / Domain / Access policy

--- a/src/wikidot/module/site_settings.py
+++ b/src/wikidot/module/site_settings.py
@@ -9,23 +9,29 @@ Access through `Site.settings`. Methods are grouped following
 - Permissions / License / Navigation / Templates / PageRate /
   PerPageDiscussion / Appearance: thin wrappers over `update_categories`
   (Task 1-4)
-- General / Domain / Access policy: standalone form saves (Task 1-3)
+- General / Domain / Access policy: read-modify-write form saves
+  (Task 1-3)
 - Everything else (CustomFooter / Toolbars / GoogleAnalytics /
   Autonumerate / Pingbacks / API / OpenID / Backup / Icons / Newsletter):
   single-shot settings (Task 1-5)
 
-Only the *save* side is implemented for General/Domain/Access policy.
-Reading the current values back would require scraping the rendered
-`sm-general-form` / `sm-private-form` / `sm-domain` HTML, and the survey
-this plan is based on did not capture a real HTML sample for those forms
-(only the field name/type list in 35_form-fields.md) — see the P1
-completion report for this as a flagged, deliberate scope decision rather
-than a silent omission.
+General/Domain/Access policy have both a `get_*` and a `save_*` method.
+`save_*`'s parameters all default to None, meaning "keep the current
+value" (fetched via `get_*` first); pass "" explicitly to clear a text
+field. This matters because Wikidot's save events resubmit the whole
+form, not a diff — omitting a field silently blanks it (`saveGeneral`
+called with only `name` would otherwise wipe subtitle/description/
+default_page/welcome_page and reset language to "en").
 """
 
 from collections.abc import Callable, Iterable
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
+from bs4 import BeautifulSoup
+from bs4.element import Tag
+
+from ..connector.ajax import require_body
 from ..util.amc_body import checkbox, flag, json_param, omit_falsy
 from .site_category import SiteCategoryCollection, SiteLicense
 from .site_permissions import PagePermissions, RatingSettings
@@ -33,7 +39,6 @@ from .site_permissions import PagePermissions, RatingSettings
 if TYPE_CHECKING:
     from .site import Site
     from .user import AbstractUser
-
 
 #: Module names that render each categories-backed settings area. Each of
 #: these embeds the site's full `categories` array (same 24-field schema;
@@ -49,6 +54,117 @@ _MODULE_TEMPLATES = "managesite/ManageSiteTemplatesModule"
 _MODULE_PAGE_RATE = "managesite/pagerate/ManageSitePageRateSettingsModule"
 _MODULE_PER_PAGE_DISCUSSION = "managesite/ManageSitePerPageDiscussionModule"
 _MODULE_APPEARANCE = "managesite/themes/ManageSiteAppearanceModule"
+
+
+def _form_field(soup: Tag, name: str) -> str | None:
+    """
+    Read a form field's current value by its `name` attribute
+
+    Handles the three form control shapes formToArray understands
+    (text-like input, textarea, select); returns None if the element is
+    missing or (for select) nothing is marked selected, rather than
+    guessing a value.
+    """
+    el = soup.select_one(f'[name="{name}"]')
+    if el is None:
+        return None
+    if el.name == "textarea":
+        return el.get_text()
+    if el.name == "select":
+        selected = el.select_one("option[selected]")
+        if selected is None:
+            return None
+        value = selected.get("value")
+        return str(value) if value is not None else selected.get_text()
+    value = el.get("value")
+    return str(value) if value is not None else None
+
+
+def _form_checkbox(soup: Tag, name: str) -> bool | None:
+    """Read a checkbox's current checked state by its `name` attribute"""
+    el = soup.select_one(f'input[name="{name}"]')
+    if el is None:
+        return None
+    return el.has_attr("checked")
+
+
+def _form_radio(soup: Tag, name: str) -> str | None:
+    """Read the checked option's value from a radio button group"""
+    el = soup.select_one(f'input[name="{name}"][checked]')
+    if el is None:
+        return None
+    value = el.get("value")
+    return str(value) if value is not None else None
+
+
+def _element_value(soup: Tag, element_id: str) -> str | None:
+    """
+    Read an element's current value by its `id`
+
+    For the handful of fields Wikidot's own JS reads by id instead of via
+    formToArray (see 35_form-fields.md "JS が id で直接読む項目"), such as
+    Domain's fields.
+    """
+    el = soup.select_one(f"#{element_id}")
+    if el is None:
+        return None
+    value = el.get("value")
+    return str(value) if value is not None else None
+
+
+def _element_checkbox(soup: Tag, element_id: str) -> bool | None:
+    """Read a checkbox's current checked state by its `id`"""
+    el = soup.select_one(f"#{element_id}")
+    if el is None:
+        return None
+    return el.has_attr("checked")
+
+
+@dataclass
+class GeneralSettings:
+    """
+    Current values of the site's General settings form (`sm-general-form`)
+
+    Any field is None when the corresponding form element could not be
+    found in the rendered HTML; this library does not guess a value in
+    that case.
+    """
+
+    name: str | None
+    subtitle: str | None
+    language: str | None
+    description: str | None
+    default_page: str | None
+    welcome_page: str | None
+
+
+@dataclass
+class DomainSettings:
+    """Current values of the site's Domain settings"""
+
+    domain: str | None
+    domain_default: bool | None
+    redirects: list[str] | None
+
+
+@dataclass
+class AccessPolicySettings:
+    """
+    Current values of the site's Access policy settings (`sm-private-form`)
+
+    `viewers` (extra allowed users for a private site) is intentionally
+    absent: it is not part of this form, see `save_access_policy`'s
+    docstring for why it cannot be read back.
+    """
+
+    privacy: Literal["open", "closed", "private"] | None
+    by_apply: bool | None
+    by_domain: str | None
+    by_password: bool | None
+    password: str | None
+    allow_hotlink: bool | None
+    landing_page: str | None
+    hide_nav: bool | None
 
 
 class SiteSettingsAccessor:
@@ -361,30 +477,61 @@ class SiteSettingsAccessor:
     # Task 1-3: General / Domain / Access policy
     # ------------------------------------------------------------------
 
+    def get_general(self) -> GeneralSettings:
+        """
+        Fetch the site's current General settings
+
+        Renders `managesite/ManageSiteGeneralModule` and reads the current
+        values out of `sm-general-form` by its documented field names
+        (35_form-fields.md).
+
+        Returns
+        -------
+        GeneralSettings
+        """
+        module_name = "managesite/ManageSiteGeneralModule"
+        response = self.site.amc_request([{"moduleName": module_name}])[0]
+        soup = BeautifulSoup(require_body(response, module_name), "lxml")
+        return GeneralSettings(
+            name=_form_field(soup, "name"),
+            subtitle=_form_field(soup, "subtitle"),
+            language=_form_field(soup, "language"),
+            description=_form_field(soup, "description"),
+            default_page=_form_field(soup, "default_page"),
+            welcome_page=_form_field(soup, "welcome_page"),
+        )
+
     def save_general(
         self,
-        name: str,
-        subtitle: str = "",
-        language: str = "en",
-        description: str = "",
-        default_page: str = "",
-        welcome_page: str = "",
+        name: str | None = None,
+        subtitle: str | None = None,
+        language: str | None = None,
+        description: str | None = None,
+        default_page: str | None = None,
+        welcome_page: str | None = None,
     ) -> str | None:
         """
         Save the site's title/subtitle/language/description/entry pages
 
+        `saveGeneral` resubmits the whole form rather than a diff, so this
+        fetches the current settings (`get_general`) first and only
+        overrides the fields the caller passed explicitly. None keeps the
+        current value; pass "" to clear a field.
+
         Parameters
         ----------
-        name : str
-            Site title. Required (an empty value raises FormErrorsException)
-        subtitle : str, default ""
-        language : str, default "en"
+        name : str | None, default None
+            Site title. None keeps the current title. An empty string (or
+            a current title this library could not read) raises
+            FormErrorsException, since the title is required
+        subtitle : str | None, default None
+        language : str | None, default None
             Site language code (e.g. "en", "ja")
-        description : str, default ""
+        description : str | None, default None
             Up to 300 characters
-        default_page : str, default ""
+        default_page : str | None, default None
             Fullname of the page to use as the site's start page
-        welcome_page : str, default ""
+        welcome_page : str | None, default None
             Fullname of the page shown to first-time visitors
 
         Returns
@@ -398,17 +545,18 @@ class SiteSettingsAccessor:
         FormErrorsException
             When validation fails (e.g. an empty title)
         """
+        current = self.get_general()
         response = self.site.amc_request(
             [
                 {
                     "action": "ManageSiteAction",
                     "event": "saveGeneral",
-                    "name": name,
-                    "subtitle": subtitle,
-                    "language": language,
-                    "description": description,
-                    "default_page": default_page,
-                    "welcome_page": welcome_page,
+                    "name": name if name is not None else (current.name or ""),
+                    "subtitle": subtitle if subtitle is not None else (current.subtitle or ""),
+                    "language": language if language is not None else (current.language or "en"),
+                    "description": description if description is not None else (current.description or ""),
+                    "default_page": default_page if default_page is not None else (current.default_page or ""),
+                    "welcome_page": welcome_page if welcome_page is not None else (current.welcome_page or ""),
                     "moduleName": "Empty",
                 }
             ]
@@ -416,21 +564,58 @@ class SiteSettingsAccessor:
         result = response.json().get("unixName")
         return result if isinstance(result, str) else None
 
-    def save_domain(self, domain: str, redirects: list[str] | None = None, domain_default: bool = False) -> str | None:
+    def get_domain(self) -> DomainSettings:
+        """
+        Fetch the site's current Domain settings
+
+        Renders `managesite/ManageSiteDomainModule`. Unlike General/Access
+        policy these fields are read by element id, not `name` (Wikidot's
+        own JS reads them the same way; see 35_form-fields.md "JS が id で
+        直接読む項目").
+
+        Returns
+        -------
+        DomainSettings
+        """
+        module_name = "managesite/ManageSiteDomainModule"
+        response = self.site.amc_request([{"moduleName": module_name}])[0]
+        soup = BeautifulSoup(require_body(response, module_name), "lxml")
+        redirects_box = soup.select_one("#sm-redirects-box")
+        redirects: list[str] | None = None
+        if redirects_box is not None:
+            redirects = [str(value) for el in redirects_box.select("input") if (value := el.get("value")) is not None]
+        return DomainSettings(
+            domain=_element_value(soup, "sm-domain-field"),
+            domain_default=_element_checkbox(soup, "sm-domain-default"),
+            redirects=redirects,
+        )
+
+    def save_domain(
+        self,
+        domain: str | None = None,
+        redirects: list[str] | None = None,
+        domain_default: bool | None = None,
+    ) -> str | None:
         """
         Save the site's custom domain and redirect domains
 
+        Fetches the current settings (`get_domain`) first; None keeps the
+        current value for each parameter.
+
         Parameters
         ----------
-        domain : str
-            Custom domain (fully qualified, e.g. "example.com")
+        domain : str | None, default None
+            Custom domain (fully qualified, e.g. "example.com"). None
+            keeps the current domain
         redirects : list[str] | None, default None
-            Additional domains that redirect to this site. At most 10
+            Additional domains that redirect to this site. None keeps the
+            current redirect list; pass [] to clear it. At most 10
             (Wikidot's own client also allows empty entries through, which
             show up as consecutive ";" in the joined string; this method
             does not filter them out to match observed behavior)
-        domain_default : bool, default False
-            Whether to reset to the default wikidot.com subdomain
+        domain_default : bool | None, default None
+            Whether to reset to the default wikidot.com subdomain. None
+            keeps the current state
 
         Returns
         -------
@@ -444,14 +629,18 @@ class SiteSettingsAccessor:
         """
         if redirects is not None and len(redirects) > 10:
             raise ValueError("redirects supports at most 10 entries")
-        body = omit_falsy(domainDefault=flag(domain_default))
+        current = self.get_domain()
+        resolved_domain = domain if domain is not None else (current.domain or "")
+        resolved_redirects = redirects if redirects is not None else (current.redirects or [])
+        resolved_domain_default = domain_default if domain_default is not None else bool(current.domain_default)
+        body = omit_falsy(domainDefault=flag(resolved_domain_default))
         response = self.site.amc_request(
             [
                 {
                     "action": "ManageSiteAction",
                     "event": "saveDomain",
-                    "domain": domain,
-                    "redirects": ";".join(redirects) if redirects else "",
+                    "domain": resolved_domain,
+                    "redirects": ";".join(resolved_redirects),
                     "moduleName": "Empty",
                     **body,
                 }
@@ -460,61 +649,131 @@ class SiteSettingsAccessor:
         result = response.json().get("newDomain")
         return result if isinstance(result, str) else None
 
+    def get_access_policy(self) -> AccessPolicySettings:
+        """
+        Fetch the site's current Access policy settings
+
+        Renders `managesite/ManageSiteAccessPolicyModule` and reads
+        `sm-private-form`. Does not include `viewers` — see
+        `save_access_policy` for why that field cannot be read back.
+
+        Returns
+        -------
+        AccessPolicySettings
+        """
+        module_name = "managesite/ManageSiteAccessPolicyModule"
+        response = self.site.amc_request([{"moduleName": module_name}])[0]
+        soup = BeautifulSoup(require_body(response, module_name), "lxml")
+        privacy_raw = _form_radio(soup, "privacy")
+        privacy: Literal["open", "closed", "private"] | None = (
+            privacy_raw if privacy_raw in ("open", "closed", "private") else None  # type: ignore[assignment]
+        )
+        return AccessPolicySettings(
+            privacy=privacy,
+            by_apply=_form_checkbox(soup, "by_apply"),
+            by_domain=_form_field(soup, "by_domain"),
+            by_password=_form_checkbox(soup, "by_password"),
+            password=_form_field(soup, "password"),
+            allow_hotlink=_form_checkbox(soup, "allowHotlink"),
+            landing_page=_form_field(soup, "landingPage"),
+            hide_nav=_form_checkbox(soup, "hideNav"),
+        )
+
     def save_access_policy(
         self,
-        privacy: Literal["open", "closed", "private"],
-        by_apply: bool = False,
-        by_domain: str = "",
-        by_password: bool = False,
-        password: str = "",
-        allow_hotlink: bool = False,
-        landing_page: str = "",
-        hide_nav: bool = False,
+        privacy: Literal["open", "closed", "private"] | None = None,
+        by_apply: bool | None = None,
+        by_domain: str | None = None,
+        by_password: bool | None = None,
+        password: str | None = None,
+        allow_hotlink: bool | None = None,
+        landing_page: str | None = None,
+        hide_nav: bool | None = None,
         viewers: "Iterable[AbstractUser] | Iterable[int] | None" = None,
     ) -> None:
         """
         Save the site's access policy (privacy level, apply/password/domain
         gating, extra viewers, hotlinking, landing page, nav visibility)
 
+        Fetches the current settings (`get_access_policy`) first; None
+        keeps the current value for each parameter (except `viewers`, see
+        below).
+
         Parameters
         ----------
-        privacy : Literal["open", "closed", "private"]
-        by_apply : bool, default False
-            Allow joining by application
-        by_domain : str, default ""
-            Email domain that may join without application
-        by_password : bool, default False
-            Allow joining with a password
-        password : str, default ""
-            Join password (used when by_password is True)
-        allow_hotlink : bool, default False
-        landing_page : str, default ""
+        privacy : Literal["open", "closed", "private"] | None, default None
+            None keeps the current value. Raises ValueError if it cannot
+            be determined (this library will not guess between open /
+            closed / private, since a wrong guess could expose a private
+            site)
+        by_apply : bool | None, default None
+            Allow joining by application. None keeps the current value
+        by_domain : str | None, default None
+            Email domain that may join without application. None keeps
+            the current value
+        by_password : bool | None, default None
+            Allow joining with a password. None keeps the current value
+        password : str | None, default None
+            Join password (used when by_password is True). None keeps the
+            current value. **Note**: it is unconfirmed whether Wikidot
+            actually echoes the real current password back in this form
+            (services commonly blank password fields for security) — if
+            you are changing another field on a password-gated site,
+            pass the password explicitly rather than relying on this
+        allow_hotlink : bool | None, default None
+        landing_page : str | None, default None
             Fullname of the page shown to non-members when privacy is
-            "private"
-        hide_nav : bool, default False
+            "private". None keeps the current value
+        hide_nav : bool | None, default None
         viewers : Iterable[AbstractUser | int] | None, default None
-            Extra users allowed to view a private site
+            Extra users allowed to view a private site. **Not** part of
+            `sm-private-form` — Wikidot assembles it client-side via an
+            autocomplete widget with no static representation of the
+            current selection, so it cannot be read back the way the
+            other fields can. None omits the `viewers` parameter from the
+            request entirely (rather than sending an empty string, which
+            would actively clear it), but this is *not* the same
+            guarantee as the other fields' "keeps the current value": if
+            the site has extra viewers configured, pass them explicitly
+            to preserve them
+
+        Raises
+        ------
+        ValueError
+            If `privacy` is None and the current value could not be
+            determined
         """
-        viewers_str = ""
+        current = self.get_access_policy()
+        resolved_privacy = privacy if privacy is not None else current.privacy
+        if resolved_privacy is None:
+            raise ValueError("privacy could not be determined from the site's current settings; pass it explicitly")
+        resolved_by_domain = by_domain if by_domain is not None else (current.by_domain or "")
+        resolved_password = password if password is not None else (current.password or "")
+        resolved_landing_page = landing_page if landing_page is not None else (current.landing_page or "")
+        resolved_by_apply = by_apply if by_apply is not None else bool(current.by_apply)
+        resolved_by_password = by_password if by_password is not None else bool(current.by_password)
+        resolved_allow_hotlink = allow_hotlink if allow_hotlink is not None else bool(current.allow_hotlink)
+        resolved_hide_nav = hide_nav if hide_nav is not None else bool(current.hide_nav)
+
+        body = omit_falsy(
+            by_apply=checkbox(resolved_by_apply),
+            by_password=checkbox(resolved_by_password),
+            allowHotlink=checkbox(resolved_allow_hotlink),
+            hideNav=checkbox(resolved_hide_nav),
+        )
         if viewers is not None:
             ids = [v if isinstance(v, int) else v.id for v in viewers]
-            viewers_str = ",".join(str(i) for i in ids)
-        body = omit_falsy(
-            by_apply=checkbox(by_apply),
-            by_password=checkbox(by_password),
-            allowHotlink=checkbox(allow_hotlink),
-            hideNav=checkbox(hide_nav),
-        )
+            body["viewers"] = ",".join(str(i) for i in ids)
+
         self.site.amc_request(
             [
                 {
                     "action": "ManageSiteAction",
                     "event": "savePrivateSettings",
-                    "privacy": privacy,
-                    "by_domain": by_domain,
-                    "password": password,
-                    "landingPage": landing_page,
-                    "viewers": viewers_str,
+                    "privacy": resolved_privacy,
+                    "by_domain": resolved_by_domain,
+                    "password": resolved_password,
+                    "landingPage": resolved_landing_page,
                     "moduleName": "Empty",
                     **body,
                 }

--- a/src/wikidot/module/site_settings.py
+++ b/src/wikidot/module/site_settings.py
@@ -1,0 +1,990 @@
+"""
+Module for Wikidot's site-wide settings (Manage Site's `_admin` panel)
+
+Access through `Site.settings`. Methods are grouped following
+31_tasks.md's P1 breakdown:
+
+- `update_categories`: the read-modify-write primitive for the seven
+  `categories`-backed areas (Task 1-1)
+- Permissions / License / Navigation / Templates / PageRate /
+  PerPageDiscussion / Appearance: thin wrappers over `update_categories`
+  (Task 1-4)
+- General / Domain / Access policy: standalone form saves (Task 1-3)
+- Everything else (CustomFooter / Toolbars / GoogleAnalytics /
+  Autonumerate / Pingbacks / API / OpenID / Backup / Icons / Newsletter):
+  single-shot settings (Task 1-5)
+
+Only the *save* side is implemented for General/Domain/Access policy.
+Reading the current values back would require scraping the rendered
+`sm-general-form` / `sm-private-form` / `sm-domain` HTML, and the survey
+this plan is based on did not capture a real HTML sample for those forms
+(only the field name/type list in 35_form-fields.md) — see the P1
+completion report for this as a flagged, deliberate scope decision rather
+than a silent omission.
+"""
+
+from collections.abc import Callable, Iterable
+from typing import TYPE_CHECKING, Literal
+
+from ..util.amc_body import checkbox, flag, json_param, omit_falsy
+from .site_category import SiteCategoryCollection, SiteLicense
+from .site_permissions import PagePermissions, RatingSettings
+
+if TYPE_CHECKING:
+    from .site import Site
+    from .user import AbstractUser
+
+
+class SiteSettingsAccessor:
+    """
+    Accessor for Manage Site (`_admin`) settings
+
+    Access through `Site.settings`.
+    """
+
+    #: Any categories-rendering module works as the fetch source for
+    #: update_categories (they all embed the same full-schema array); this
+    #: one is used because it's the module the categories schema in
+    #: 40_admin-managesite.md was captured from.
+    _CATEGORIES_FETCH_MODULE = "managesite/ManageSitePermissionsModule"
+
+    def __init__(self, site: "Site"):
+        """
+        Initialize method
+
+        Parameters
+        ----------
+        site : Site
+            Parent site instance
+        """
+        self.site = site
+
+    # ------------------------------------------------------------------
+    # Task 1-1: categories read-modify-write primitive
+    # ------------------------------------------------------------------
+
+    def update_categories(
+        self,
+        action: str,
+        event: str,
+        mutator: Callable[[SiteCategoryCollection], None],
+    ) -> None:
+        """
+        Fetch the current `categories` array, mutate it, and save it back
+
+        This is the single place that performs the categories
+        read-modify-write cycle; every method below that touches
+        `categories` (Permissions / License / Navigation / Templates /
+        PageRate / PerPageDiscussion / Appearance) is a thin wrapper over
+        this. The array is always re-fetched here (never cached), because
+        a partial-update API does not exist and holding a stale snapshot
+        risks reverting another admin's concurrent change.
+
+        Parameters
+        ----------
+        action : str
+            AMC action for the save request (e.g. "ManageSiteAction")
+        event : str
+            AMC event for the save request (e.g. "savePermissions")
+        mutator : Callable[[SiteCategoryCollection], None]
+            Called with the freshly fetched collection; mutate categories
+            in place
+
+        Examples
+        --------
+        >>> site.settings.update_categories(
+        ...     "ManageSiteAction", "savePermissions",
+        ...     lambda cats: cats["_default"].set_permissions(
+        ...         view={"anonymous", "registered", "member"}
+        ...     ),
+        ... )
+        """
+        collection = SiteCategoryCollection.fetch(self.site, self._CATEGORIES_FETCH_MODULE)
+        mutator(collection)
+        collection.save(action, event)
+
+    # ------------------------------------------------------------------
+    # Task 1-4: categories-backed settings
+    # ------------------------------------------------------------------
+
+    def set_page_permissions(self, category_name: str, permissions: PagePermissions) -> None:
+        """
+        Set explicit page permissions for a category
+
+        Parameters
+        ----------
+        category_name : str
+            Category name (e.g. "_default")
+        permissions : PagePermissions
+            New permissions. Clears the category's `permissions_default`
+            flag (it stops inheriting the site default)
+        """
+
+        def mutator(cats: SiteCategoryCollection) -> None:
+            category = cats[category_name]
+            category.permissions = permissions
+            category.permissions_default = False
+
+        self.update_categories("ManageSiteAction", "savePermissions", mutator)
+
+    def use_default_page_permissions(self, category_name: str) -> None:
+        """
+        Make a category inherit the site's default page permissions
+
+        Parameters
+        ----------
+        category_name : str
+            Category name
+        """
+
+        def mutator(cats: SiteCategoryCollection) -> None:
+            category = cats[category_name]
+            category.permissions = None
+            category.permissions_default = True
+
+        self.update_categories("ManageSiteAction", "savePermissions", mutator)
+
+    def set_license(self, category_name: str, license: SiteLicense, other: str = "") -> None:
+        """
+        Set an explicit license for a category
+
+        Parameters
+        ----------
+        category_name : str
+            Category name
+        license : SiteLicense
+            License to apply
+        other : str, default ""
+            Free-text license description. Required when `license` is
+            `SiteLicense.OTHER`
+
+        Raises
+        ------
+        ValueError
+            If `license` is `SiteLicense.OTHER` and `other` is empty
+        """
+        if license is SiteLicense.OTHER and not other:
+            raise ValueError("license_other is required when license is SiteLicense.OTHER")
+
+        def mutator(cats: SiteCategoryCollection) -> None:
+            category = cats[category_name]
+            category.license_id = license.value
+            category.license_other = other
+            category.license_default = False
+
+        self.update_categories("ManageSiteAction", "saveLicense", mutator)
+
+    def use_default_license(self, category_name: str) -> None:
+        """
+        Make a category inherit the site's default license
+
+        Parameters
+        ----------
+        category_name : str
+            Category name
+        """
+
+        def mutator(cats: SiteCategoryCollection) -> None:
+            cats[category_name].license_default = True
+
+        self.update_categories("ManageSiteAction", "saveLicense", mutator)
+
+    def set_navigation(self, category_name: str, top_bar_page_name: str, side_bar_page_name: str) -> None:
+        """
+        Set explicit top/side navigation pages for a category
+
+        Parameters
+        ----------
+        category_name : str
+            Category name
+        top_bar_page_name : str
+            Fullname of the page used as the top bar
+        side_bar_page_name : str
+            Fullname of the page used as the side bar
+        """
+
+        def mutator(cats: SiteCategoryCollection) -> None:
+            category = cats[category_name]
+            category.top_bar_page_name = top_bar_page_name
+            category.side_bar_page_name = side_bar_page_name
+            category.nav_default = False
+
+        self.update_categories("ManageSiteAction", "saveNavigation", mutator)
+
+    def use_default_navigation(self, category_name: str) -> None:
+        """
+        Make a category inherit the site's default navigation
+
+        Parameters
+        ----------
+        category_name : str
+            Category name
+        """
+
+        def mutator(cats: SiteCategoryCollection) -> None:
+            cats[category_name].nav_default = True
+
+        self.update_categories("ManageSiteAction", "saveNavigation", mutator)
+
+    def set_template(self, category_name: str, template_id: int | None) -> None:
+        """
+        Set (or clear, with None) the page template for a category
+
+        Parameters
+        ----------
+        category_name : str
+            Category name
+        template_id : int | None
+            Template ID, or None to unset
+        """
+
+        def mutator(cats: SiteCategoryCollection) -> None:
+            cats[category_name].template_id = template_id
+
+        self.update_categories("ManageSiteAction", "saveTemplates", mutator)
+
+    def set_page_rate_settings(self, category_name: str, rating: RatingSettings) -> None:
+        """
+        Set the rating (vote) configuration for a category
+
+        Parameters
+        ----------
+        category_name : str
+            Category name
+        rating : RatingSettings
+            New rating configuration
+        """
+
+        def mutator(cats: SiteCategoryCollection) -> None:
+            cats[category_name].rating = rating
+
+        self.update_categories("ManageSiteAction", "savePageRateSettings", mutator)
+
+    def set_per_page_discussion(self, category_name: str, enabled: bool | None) -> None:
+        """
+        Enable/disable the per-page discussion thread for a category
+
+        Parameters
+        ----------
+        category_name : str
+            Category name
+        enabled : bool | None
+            True/False to force on/off, or None to use the site default
+        """
+
+        def mutator(cats: SiteCategoryCollection) -> None:
+            category = cats[category_name]
+            category.per_page_discussion = enabled
+            category.per_page_discussion_default = enabled is None
+
+        self.update_categories("ManageSiteForumAction", "savePerPageDiscussion", mutator)
+
+    def set_appearance_theme(self, category_name: str, theme_id: int) -> None:
+        """
+        Apply a built-in theme to a category
+
+        Parameters
+        ----------
+        category_name : str
+            Category name
+        theme_id : int
+            Theme ID
+        """
+
+        def mutator(cats: SiteCategoryCollection) -> None:
+            category = cats[category_name]
+            category.theme_id = theme_id
+            category.theme_external_url = ""
+            category.theme_default = False
+
+        self.update_categories("ManageSiteThemeAction", "saveAppearance", mutator)
+
+    def set_appearance_external_theme(self, category_name: str, theme_external_url: str) -> None:
+        """
+        Apply an external theme URL to a category
+
+        Wikidot represents "external theme" by sending `theme_id` as the
+        empty string instead of an int (see SiteCategory.theme_id).
+
+        Parameters
+        ----------
+        category_name : str
+            Category name
+        theme_external_url : str
+            External theme stylesheet URL
+        """
+
+        def mutator(cats: SiteCategoryCollection) -> None:
+            category = cats[category_name]
+            category.theme_id = ""
+            category.theme_external_url = theme_external_url
+            category.theme_default = False
+
+        self.update_categories("ManageSiteThemeAction", "saveAppearance", mutator)
+
+    def use_default_appearance(self, category_name: str) -> None:
+        """
+        Make a category inherit the site's default appearance
+
+        Parameters
+        ----------
+        category_name : str
+            Category name
+        """
+
+        def mutator(cats: SiteCategoryCollection) -> None:
+            cats[category_name].theme_default = True
+
+        self.update_categories("ManageSiteThemeAction", "saveAppearance", mutator)
+
+    # ------------------------------------------------------------------
+    # Task 1-3: General / Domain / Access policy
+    # ------------------------------------------------------------------
+
+    def save_general(
+        self,
+        name: str,
+        subtitle: str = "",
+        language: str = "en",
+        description: str = "",
+        default_page: str = "",
+        welcome_page: str = "",
+    ) -> str | None:
+        """
+        Save the site's title/subtitle/language/description/entry pages
+
+        Parameters
+        ----------
+        name : str
+            Site title. Required (an empty value raises FormErrorsException)
+        subtitle : str, default ""
+        language : str, default "en"
+            Site language code (e.g. "en", "ja")
+        description : str, default ""
+            Up to 300 characters
+        default_page : str, default ""
+            Fullname of the page to use as the site's start page
+        welcome_page : str, default ""
+            Fullname of the page shown to first-time visitors
+
+        Returns
+        -------
+        str | None
+            New unix name, only returned when the site's unix name changed
+            as a result
+
+        Raises
+        ------
+        FormErrorsException
+            When validation fails (e.g. an empty title)
+        """
+        response = self.site.amc_request(
+            [
+                {
+                    "action": "ManageSiteAction",
+                    "event": "saveGeneral",
+                    "name": name,
+                    "subtitle": subtitle,
+                    "language": language,
+                    "description": description,
+                    "default_page": default_page,
+                    "welcome_page": welcome_page,
+                    "moduleName": "Empty",
+                }
+            ]
+        )[0]
+        result = response.json().get("unixName")
+        return result if isinstance(result, str) else None
+
+    def save_domain(self, domain: str, redirects: list[str] | None = None, domain_default: bool = False) -> str | None:
+        """
+        Save the site's custom domain and redirect domains
+
+        Parameters
+        ----------
+        domain : str
+            Custom domain (fully qualified, e.g. "example.com")
+        redirects : list[str] | None, default None
+            Additional domains that redirect to this site. At most 10
+            (Wikidot's own client also allows empty entries through, which
+            show up as consecutive ";" in the joined string; this method
+            does not filter them out to match observed behavior)
+        domain_default : bool, default False
+            Whether to reset to the default wikidot.com subdomain
+
+        Returns
+        -------
+        str | None
+            New domain, only returned when it changed
+
+        Raises
+        ------
+        ValueError
+            If more than 10 redirects are given
+        """
+        if redirects is not None and len(redirects) > 10:
+            raise ValueError("redirects supports at most 10 entries")
+        body = omit_falsy(domainDefault=flag(domain_default))
+        response = self.site.amc_request(
+            [
+                {
+                    "action": "ManageSiteAction",
+                    "event": "saveDomain",
+                    "domain": domain,
+                    "redirects": ";".join(redirects) if redirects else "",
+                    "moduleName": "Empty",
+                    **body,
+                }
+            ]
+        )[0]
+        result = response.json().get("newDomain")
+        return result if isinstance(result, str) else None
+
+    def save_access_policy(
+        self,
+        privacy: Literal["open", "closed", "private"],
+        by_apply: bool = False,
+        by_domain: str = "",
+        by_password: bool = False,
+        password: str = "",
+        allow_hotlink: bool = False,
+        landing_page: str = "",
+        hide_nav: bool = False,
+        viewers: "Iterable[AbstractUser] | Iterable[int] | None" = None,
+    ) -> None:
+        """
+        Save the site's access policy (privacy level, apply/password/domain
+        gating, extra viewers, hotlinking, landing page, nav visibility)
+
+        Parameters
+        ----------
+        privacy : Literal["open", "closed", "private"]
+        by_apply : bool, default False
+            Allow joining by application
+        by_domain : str, default ""
+            Email domain that may join without application
+        by_password : bool, default False
+            Allow joining with a password
+        password : str, default ""
+            Join password (used when by_password is True)
+        allow_hotlink : bool, default False
+        landing_page : str, default ""
+            Fullname of the page shown to non-members when privacy is
+            "private"
+        hide_nav : bool, default False
+        viewers : Iterable[AbstractUser | int] | None, default None
+            Extra users allowed to view a private site
+        """
+        viewers_str = ""
+        if viewers is not None:
+            ids = [v if isinstance(v, int) else v.id for v in viewers]
+            viewers_str = ",".join(str(i) for i in ids)
+        body = omit_falsy(
+            by_apply=checkbox(by_apply),
+            by_password=checkbox(by_password),
+            allowHotlink=checkbox(allow_hotlink),
+            hideNav=checkbox(hide_nav),
+        )
+        self.site.amc_request(
+            [
+                {
+                    "action": "ManageSiteAction",
+                    "event": "savePrivateSettings",
+                    "privacy": privacy,
+                    "by_domain": by_domain,
+                    "password": password,
+                    "landingPage": landing_page,
+                    "viewers": viewers_str,
+                    "moduleName": "Empty",
+                    **body,
+                }
+            ]
+        )
+
+    # ------------------------------------------------------------------
+    # Task 1-5: single-shot settings
+    # ------------------------------------------------------------------
+
+    def save_custom_footer(self, source: str, use: bool = False) -> None:
+        """
+        Save the site's custom footer
+
+        Parameters
+        ----------
+        source : str
+            Footer Wikidot markup source
+        use : bool, default False
+            Whether to actually use the custom footer
+        """
+        body = omit_falsy(use=flag(use))
+        self.site.amc_request(
+            [
+                {
+                    "action": "ManageSiteAction",
+                    "event": "saveCustomFooter",
+                    "source": source,
+                    "moduleName": "Empty",
+                    **body,
+                }
+            ]
+        )
+
+    def save_toolbars_preference(
+        self, toolbar_top: bool = False, toolbar_bottom: bool = False, promote: bool = False
+    ) -> None:
+        """
+        Save the site's edit-toolbar visibility preference
+
+        Parameters
+        ----------
+        toolbar_top : bool, default False
+        toolbar_bottom : bool, default False
+        promote : bool, default False
+        """
+        body = omit_falsy(
+            toolbarTop=checkbox(toolbar_top),
+            toolbarBottom=checkbox(toolbar_bottom),
+            promote=checkbox(promote),
+        )
+        self.site.amc_request(
+            [{"action": "ManageSiteAction", "event": "saveToolbarsPref", "moduleName": "Empty", **body}]
+        )
+
+    def save_google_analytics(self, key: str, use: bool = False) -> None:
+        """
+        Save the site's Google Analytics key
+
+        Parameters
+        ----------
+        key : str
+            Google Analytics tracking key
+        use : bool, default False
+            Whether to actually enable tracking
+        """
+        body = omit_falsy(use=checkbox(use))
+        self.site.amc_request(
+            [
+                {
+                    "action": "ManageSite3rdPartyAction",
+                    "event": "saveGoogleAnalytics",
+                    "key": key,
+                    "moduleName": "Empty",
+                    **body,
+                }
+            ]
+        )
+
+    def add_autonumeration(self, category_name: str, override: bool = False) -> None:
+        """
+        Enable page auto-numbering for a category
+
+        Parameters
+        ----------
+        category_name : str
+            Category name
+        override : bool, default False
+            Wikidot responds with status "non_numeric" and asks for
+            confirmation when the category has pages with non-numeric
+            names; pass override=True to confirm and proceed. This method
+            does not auto-retry on "non_numeric" — catch
+            WikidotStatusCodeException and re-call with override=True if
+            needed
+
+        Raises
+        ------
+        WikidotStatusCodeException
+            status_code "non_numeric" if the category has non-numeric page
+            names and override is False
+        """
+        body = omit_falsy(override=flag(override))
+        self.site.amc_request(
+            [
+                {
+                    "action": "ManageSiteAutonumerateAction",
+                    "event": "addAutonumeration",
+                    "categoryName": category_name,
+                    "moduleName": "Empty",
+                    **body,
+                }
+            ]
+        )
+
+    def remove_autonumeration(self, category_name: str) -> None:
+        """
+        Disable page auto-numbering for a category
+
+        Parameters
+        ----------
+        category_name : str
+            Category name
+        """
+        self.site.amc_request(
+            [
+                {
+                    "action": "ManageSiteAutonumerateAction",
+                    "event": "removeAutonumeration",
+                    "categoryName": category_name,
+                    "moduleName": "Empty",
+                }
+            ]
+        )
+
+    def set_autonumerate_title_format(self, category_name: str, title_format: str) -> None:
+        """
+        Set the auto-numbering title format for a category
+
+        Parameters
+        ----------
+        category_name : str
+            Category name
+        title_format : str
+            Title format string
+        """
+        self.site.amc_request(
+            [
+                {
+                    "action": "ManageSiteAutonumerateAction",
+                    "event": "setTitleFormat",
+                    "categoryName": category_name,
+                    "titleFormat": title_format,
+                    "moduleName": "Empty",
+                }
+            ]
+        )
+
+    def add_pingbacks(self, category_name: str, override: bool = False) -> None:
+        """
+        Enable outgoing pingbacks for a category
+
+        Parameters
+        ----------
+        category_name : str
+            Category name
+        override : bool, default False
+            Confirmation flag mirroring add_autonumeration's override
+        """
+        body = omit_falsy(override=flag(override))
+        self.site.amc_request(
+            [
+                {
+                    "action": "ManageSitePingbacksAction",
+                    "event": "addPingbacks",
+                    "categoryName": category_name,
+                    "moduleName": "Empty",
+                    **body,
+                }
+            ]
+        )
+
+    def remove_pingbacks(self, category_name: str) -> None:
+        """
+        Disable outgoing pingbacks for a category
+
+        Parameters
+        ----------
+        category_name : str
+            Category name
+        """
+        self.site.amc_request(
+            [
+                {
+                    "action": "ManageSitePingbacksAction",
+                    "event": "removePingbacks",
+                    "categoryName": category_name,
+                    "moduleName": "Empty",
+                }
+            ]
+        )
+
+    def set_global_pingback(self, enabled: bool = False) -> None:
+        """
+        Enable/disable pingbacks site-wide
+
+        Parameters
+        ----------
+        enabled : bool, default False
+        """
+        body = omit_falsy(enabled=flag(enabled))
+        self.site.amc_request(
+            [{"action": "ManageSitePingbacksAction", "event": "setGlobalPingback", "moduleName": "Empty", **body}]
+        )
+
+    def save_api_settings(
+        self,
+        enabled: bool = False,
+        read_1: bool = False,
+        read_2: bool = False,
+        write_1: bool = False,
+        write_2: bool = False,
+    ) -> None:
+        """
+        Save the site's public API access settings
+
+        Parameters
+        ----------
+        enabled : bool, default False
+            Whether the API is enabled at all
+        read_1, read_2 : bool, default False
+            Read permission levels
+        write_1, write_2 : bool, default False
+            Write permission levels
+        """
+        body = omit_falsy(
+            **{
+                "sm-api-enable": checkbox(enabled),
+                "read-1": checkbox(read_1),
+                "read-2": checkbox(read_2),
+                "write-1": checkbox(write_1),
+                "write-2": checkbox(write_2),
+            }
+        )
+        self.site.amc_request([{"action": "ManageSiteApiAction", "event": "save", "moduleName": "Empty", **body}])
+
+    def save_openid(self, enabled: bool, identity_url: str = "", server_url: str = "") -> None:
+        """
+        Save the site-wide OpenID configuration
+
+        Only the site-wide form (`sm-openid-form-0`) is modeled; the
+        per-page OpenID forms are dynamically added/removed in the UI and
+        out of scope for this method.
+
+        Parameters
+        ----------
+        enabled : bool
+            Whether OpenID login is enabled. Sent as the literal string
+            "true"/"false" (unlike most other boolean settings here, this
+            one is not omitted when False; see 40_admin-managesite.md)
+        identity_url : str, default ""
+        server_url : str, default ""
+        """
+        vals = [{"identityUrl": identity_url, "serverUrl": server_url}]
+        self.site.amc_request(
+            [
+                {
+                    "action": "ManageSiteOpenIDAction",
+                    "event": "saveOpenID",
+                    "enableOpenID": "true" if enabled else "false",
+                    "vals": json_param(vals),
+                    "moduleName": "Empty",
+                }
+            ]
+        )
+
+    def request_backup(
+        self,
+        backup_sources: bool = False,
+        backup_files: bool = False,
+        backup_type: Literal["tar", "zip"] = "zip",
+    ) -> None:
+        """
+        Request a site backup
+
+        Parameters
+        ----------
+        backup_sources : bool, default False
+            Include page sources
+        backup_files : bool, default False
+            Include uploaded files
+        backup_type : Literal["tar", "zip"], default "zip"
+        """
+        body = omit_falsy(backupSources=checkbox(backup_sources), backupFiles=checkbox(backup_files))
+        self.site.amc_request(
+            [
+                {
+                    "action": "ManageSiteBackupAction",
+                    "event": "requestBackup",
+                    "backupType": backup_type,
+                    "moduleName": "Empty",
+                    **body,
+                }
+            ]
+        )
+
+    def delete_backup(
+        self,
+        *,
+        confirm: bool,
+        backup_sources: bool = False,
+        backup_files: bool = False,
+        backup_type: Literal["tar", "zip"] = "zip",
+    ) -> None:
+        """
+        Delete a site backup. Destructive and irreversible
+
+        Parameters
+        ----------
+        confirm : bool
+            Must be explicitly True to proceed (safety gate for a
+            destructive operation)
+        backup_sources : bool, default False
+        backup_files : bool, default False
+        backup_type : Literal["tar", "zip"], default "zip"
+
+        Raises
+        ------
+        ValueError
+            If confirm is not True
+        """
+        if not confirm:
+            raise ValueError("delete_backup is destructive; pass confirm=True to proceed")
+        body = omit_falsy(backupSources=checkbox(backup_sources), backupFiles=checkbox(backup_files))
+        self.site.amc_request(
+            [
+                {
+                    "action": "ManageSiteBackupAction",
+                    "event": "deleteBackup",
+                    "backupType": backup_type,
+                    "moduleName": "Empty",
+                    **body,
+                }
+            ]
+        )
+
+    def delete_favicon(self) -> None:
+        """Delete the site's favicon"""
+        self.site.amc_request([{"action": "ManageSiteIconsAction", "event": "deleteFavicon", "moduleName": "Empty"}])
+
+    def set_favicon_from_uri(self, uri: str) -> None:
+        """
+        Set the site's favicon from a URL
+
+        Parameters
+        ----------
+        uri : str
+            Image URL
+        """
+        self.site.amc_request(
+            [{"action": "ManageSiteIconsAction", "event": "uploadFaviconUri", "uri": uri, "moduleName": "Empty"}]
+        )
+
+    def delete_ios_icon(self) -> None:
+        """Delete the site's iOS home screen icon"""
+        self.site.amc_request([{"action": "ManageSiteIconsAction", "event": "deleteIosIcon", "moduleName": "Empty"}])
+
+    def set_ios_icon_from_uri(self, uri: str) -> None:
+        """
+        Set the site's iOS home screen icon from a URL
+
+        Parameters
+        ----------
+        uri : str
+            Image URL
+        """
+        self.site.amc_request(
+            [{"action": "ManageSiteIconsAction", "event": "uploadIosIconUri", "uri": uri, "moduleName": "Empty"}]
+        )
+
+    def delete_windows_icon(self) -> None:
+        """Delete the site's Windows tile icon"""
+        self.site.amc_request(
+            [{"action": "ManageSiteIconsAction", "event": "deleteWindowsIcon", "moduleName": "Empty"}]
+        )
+
+    def set_windows_icon_from_uri(self, uri: str) -> None:
+        """
+        Set the site's Windows tile icon from a URL
+
+        Parameters
+        ----------
+        uri : str
+            Image URL
+        """
+        self.site.amc_request(
+            [{"action": "ManageSiteIconsAction", "event": "uploadWindowsIconUri", "uri": uri, "moduleName": "Empty"}]
+        )
+
+    def set_windows_icon_background_color(self, color: str) -> None:
+        """
+        Set the site's Windows tile background color
+
+        Parameters
+        ----------
+        color : str
+            CSS color value
+
+        Notes
+        -----
+        The AMC event name is `windowsIconBackroundColor` (missing the "g"
+        in "Background") — this is a typo in Wikidot's own JS, kept
+        verbatim here since the server only recognizes the exact name.
+        """
+        self.site.amc_request(
+            [
+                {
+                    "action": "ManageSiteIconsAction",
+                    "event": "windowsIconBackroundColor",
+                    "color": color,
+                    "moduleName": "Empty",
+                }
+            ]
+        )
+
+    def preview_newsletter(self, title: str, content: str) -> tuple[str, str]:
+        """
+        Render a newsletter preview
+
+        Parameters
+        ----------
+        title : str
+        content : str
+
+        Returns
+        -------
+        tuple[str, str]
+            Rendered (title, content)
+        """
+        response = self.site.amc_request(
+            [
+                {
+                    "action": "ManageSiteNewsletterAction",
+                    "event": "preview",
+                    "title": title,
+                    "content": content,
+                    "moduleName": "Empty",
+                }
+            ]
+        )[0]
+        data = response.json()
+        return data.get("title", ""), data.get("content", "")
+
+    def send_newsletter(
+        self,
+        title: str,
+        content: str,
+        admins: bool = False,
+        moderators: bool = False,
+        members: bool = False,
+        others: "list[AbstractUser] | list[int] | None" = None,
+    ) -> None:
+        """
+        Send a newsletter to site members
+
+        Parameters
+        ----------
+        title : str
+        content : str
+        admins : bool, default False
+            Send to admins
+        moderators : bool, default False
+            Send to moderators
+        members : bool, default False
+            Send to all members
+        others : list[AbstractUser | int] | None, default None
+            Additional specific recipients
+        """
+        other_ids = [u if isinstance(u, int) else u.id for u in others] if others else []
+        self.site.amc_request(
+            [
+                {
+                    "action": "ManageSiteNewsletterAction",
+                    "event": "send",
+                    "title": title,
+                    "content": content,
+                    "admins": "true" if admins else "false",
+                    "moderators": "true" if moderators else "false",
+                    "members": "true" if members else "false",
+                    "others": other_ids,
+                    "moduleName": "Empty",
+                }
+            ]
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -640,6 +640,12 @@ def site_applications() -> dict[str, Any]:
 
 
 @pytest.fixture
+def site_categories_single() -> dict[str, Any]:
+    """カテゴリ1件（_default）のManage Siteレスポンス"""
+    return _load_json("site", "categories_single.json")
+
+
+@pytest.fixture
 def site_applications_empty() -> dict[str, Any]:
     """サイト参加申請（空）レスポンス"""
     return _load_json("site", "applications_empty.json")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -646,6 +646,24 @@ def site_categories_single() -> dict[str, Any]:
 
 
 @pytest.fixture
+def site_general_form() -> dict[str, Any]:
+    """General設定フォームのManage Siteレスポンス"""
+    return _load_json("site", "general_form.json")
+
+
+@pytest.fixture
+def site_domain_module() -> dict[str, Any]:
+    """Domain設定モジュールのManage Siteレスポンス"""
+    return _load_json("site", "domain_module.json")
+
+
+@pytest.fixture
+def site_access_policy_form() -> dict[str, Any]:
+    """Access policy設定フォームのManage Siteレスポンス"""
+    return _load_json("site", "access_policy_form.json")
+
+
+@pytest.fixture
 def site_applications_empty() -> dict[str, Any]:
     """サイト参加申請（空）レスポンス"""
     return _load_json("site", "applications_empty.json")

--- a/tests/fixtures/amc_responses/site/access_policy_form.json
+++ b/tests/fixtures/amc_responses/site/access_policy_form.json
@@ -1,0 +1,4 @@
+{
+  "status": "ok",
+  "body": "<form id=\"sm-private-form\"><input type=\"radio\" name=\"privacy\" value=\"open\"><input type=\"radio\" name=\"privacy\" value=\"closed\" checked=\"checked\"><input type=\"radio\" name=\"privacy\" value=\"private\"><input type=\"checkbox\" name=\"by_apply\" checked=\"checked\"><input type=\"text\" name=\"by_domain\" value=\"example.com\"><input type=\"checkbox\" name=\"by_password\"><input type=\"text\" name=\"password\" value=\"\"><input type=\"checkbox\" name=\"allowHotlink\" checked=\"checked\"><input type=\"text\" name=\"landingPage\" value=\"start\"><input type=\"checkbox\" name=\"hideNav\"></form>"
+}

--- a/tests/fixtures/amc_responses/site/categories_single.json
+++ b/tests/fixtures/amc_responses/site/categories_single.json
@@ -1,0 +1,32 @@
+{
+  "status": "ok",
+  "body": "<div>permissions form</div>",
+  "categories": [
+    {
+      "category_id": 30228632,
+      "site_id": 3632981,
+      "name": "_default",
+      "theme_default": false,
+      "theme_id": 0,
+      "layout_default": true,
+      "layout_id": 1,
+      "theme_external_url": "",
+      "permissions_default": false,
+      "permissions": "v:armo;c:m;e:m;m:m;d:m;a:m;r:m;z:m;o:rm",
+      "license_default": true,
+      "license_id": 12,
+      "license_other": "",
+      "nav_default": true,
+      "top_bar_page_name": "nav:global",
+      "side_bar_page_name": "nav:side",
+      "template_id": null,
+      "per_page_discussion": true,
+      "per_page_discussion_default": true,
+      "rating": "drvM",
+      "autonumerate": false,
+      "page_title_template": null,
+      "enable_pingback_out": false,
+      "enable_pingback_in": false
+    }
+  ]
+}

--- a/tests/fixtures/amc_responses/site/domain_module.json
+++ b/tests/fixtures/amc_responses/site/domain_module.json
@@ -1,0 +1,4 @@
+{
+  "status": "ok",
+  "body": "<div class=\"content\"><input type=\"text\" id=\"sm-domain-field\" value=\"example.com\"><input type=\"checkbox\" id=\"sm-domain-default\" checked=\"checked\"><div id=\"sm-redirects-box\"><input type=\"text\" value=\"a.com\"><input type=\"text\" value=\"b.com\"></div></div>"
+}

--- a/tests/fixtures/amc_responses/site/general_form.json
+++ b/tests/fixtures/amc_responses/site/general_form.json
@@ -1,0 +1,4 @@
+{
+  "status": "ok",
+  "body": "<div class=\"content\"><form id=\"sm-general-form\"><input type=\"text\" name=\"name\" value=\"My Site\"><input type=\"text\" name=\"subtitle\" value=\"A subtitle\"><select name=\"language\"><option value=\"en\">English</option><option value=\"ja\" selected=\"selected\">Japanese</option></select><textarea name=\"description\">A description</textarea><input type=\"text\" name=\"default_page\" value=\"start\"><input type=\"text\" name=\"welcome_page\" value=\"welcome\"></form></div>"
+}

--- a/tests/unit/test_site_category.py
+++ b/tests/unit/test_site_category.py
@@ -125,3 +125,13 @@ class TestSiteLicense:
 
     def test_all_15_values_present(self):
         assert len(SiteLicense) == 15
+
+    def test_noncommercial_variants_are_uniquely_named_by_id(self):
+        # Regression check for the VARIANT_A/B/C placeholders replaced after
+        # lead confirmed the real option text via a live read-only fetch
+        assert SiteLicense.CC_ATTRIBUTION_NONCOMMERCIAL_2_5.value == 5
+        assert SiteLicense.CC_ATTRIBUTION_NONCOMMERCIAL_SHAREALIKE_2_5.value == 6
+        assert SiteLicense.CC_ATTRIBUTION_NONCOMMERCIAL_NO_DERIVATIVES_2_5.value == 7
+        assert SiteLicense.CC_ATTRIBUTION_NONCOMMERCIAL_3_0.value == 15
+        assert SiteLicense.CC_ATTRIBUTION_NONCOMMERCIAL_SHAREALIKE_3_0.value == 16
+        assert SiteLicense.CC_ATTRIBUTION_NONCOMMERCIAL_NO_DERIVATIVES_3_0.value == 17

--- a/tests/unit/test_site_category.py
+++ b/tests/unit/test_site_category.py
@@ -1,0 +1,127 @@
+"""site_categoryモジュールのユニットテスト"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from wikidot.common.exceptions import ResponseDataException
+from wikidot.module.site_category import SiteCategory, SiteCategoryCollection, SiteLicense
+from wikidot.module.site_permissions import PagePermissions, RatingSettings
+
+
+class TestSiteCategoryRoundTrip:
+    """SiteCategory.from_dict -> to_dict のラウンドトリップ"""
+
+    def test_roundtrip_matches_original(self, site_categories_single):
+        raw = site_categories_single["categories"][0]
+        category = SiteCategory.from_dict(raw)
+
+        assert category.to_dict() == raw
+
+    def test_decoded_fields(self, site_categories_single):
+        raw = site_categories_single["categories"][0]
+        category = SiteCategory.from_dict(raw)
+
+        assert category.category_id == 30228632
+        assert category.name == "_default"
+        assert isinstance(category.permissions, PagePermissions)
+        assert category.permissions.view == {"anonymous", "registered", "member", "author"}
+        assert isinstance(category.rating, RatingSettings)
+        assert category.rating.kind == "plus_minus"
+
+    def test_unknown_field_survives_roundtrip(self, site_categories_single):
+        # A field this library does not model must not be dropped when
+        # rebuilding the dict for the save request (see 30_plan.md D3)
+        raw = dict(site_categories_single["categories"][0])
+        raw["some_future_field"] = "unmodeled_value"
+
+        category = SiteCategory.from_dict(raw)
+
+        assert category.to_dict()["some_future_field"] == "unmodeled_value"
+
+    def test_permissions_default_true_means_none(self, site_categories_single):
+        raw = dict(site_categories_single["categories"][0])
+        raw["permissions_default"] = True
+        raw["permissions"] = None
+
+        category = SiteCategory.from_dict(raw)
+
+        assert category.permissions is None
+        assert category.to_dict()["permissions"] is None
+
+    def test_set_permissions_updates_single_field_and_clears_default(self, site_categories_single):
+        raw = site_categories_single["categories"][0]
+        category = SiteCategory.from_dict(raw)
+
+        category.set_permissions(view={"anonymous", "registered", "member", "author"})
+
+        assert category.permissions_default is False
+        # untouched fields keep their decoded value
+        assert category.permissions.create == {"member"}
+
+
+class TestSiteCategoryCollection:
+    def test_getitem_found(self, site_categories_single):
+        site = MagicMock()
+        categories = [SiteCategory.from_dict(c) for c in site_categories_single["categories"]]
+        collection = SiteCategoryCollection(site=site, categories=categories)
+
+        assert collection["_default"].category_id == 30228632
+
+    def test_getitem_not_found_raises(self, site_categories_single):
+        site = MagicMock()
+        categories = [SiteCategory.from_dict(c) for c in site_categories_single["categories"]]
+        collection = SiteCategoryCollection(site=site, categories=categories)
+
+        with pytest.raises(KeyError):
+            collection["nonexistent"]
+
+    def test_len_and_names(self, site_categories_single):
+        site = MagicMock()
+        categories = [SiteCategory.from_dict(c) for c in site_categories_single["categories"]]
+        collection = SiteCategoryCollection(site=site, categories=categories)
+
+        assert len(collection) == 1
+        assert collection.names() == ["_default"]
+
+    def test_fetch_parses_categories(self, site_categories_single):
+        site = MagicMock()
+        response = MagicMock()
+        response.json.return_value = site_categories_single
+        site.amc_request.return_value = [response]
+
+        collection = SiteCategoryCollection.fetch(site, "managesite/ManageSitePermissionsModule")
+
+        assert len(collection) == 1
+        site.amc_request.assert_called_once_with([{"moduleName": "managesite/ManageSitePermissionsModule"}])
+
+    def test_fetch_missing_categories_raises(self):
+        site = MagicMock()
+        response = MagicMock()
+        response.json.return_value = {"status": "ok", "body": ""}
+        site.amc_request.return_value = [response]
+
+        with pytest.raises(ResponseDataException):
+            SiteCategoryCollection.fetch(site, "managesite/ManageSitePermissionsModule")
+
+    def test_save_sends_full_array_as_json(self, site_categories_single):
+        site = MagicMock()
+        categories = [SiteCategory.from_dict(c) for c in site_categories_single["categories"]]
+        collection = SiteCategoryCollection(site=site, categories=categories)
+
+        collection.save("ManageSiteAction", "savePermissions")
+
+        body = site.amc_request.call_args[0][0][0]
+        assert body["action"] == "ManageSiteAction"
+        assert body["event"] == "savePermissions"
+        assert body["moduleName"] == "Empty"
+        assert isinstance(body["categories"], str)
+        assert "_default" in body["categories"]
+
+
+class TestSiteLicense:
+    def test_other_is_one(self):
+        assert SiteLicense.OTHER.value == 1
+
+    def test_all_15_values_present(self):
+        assert len(SiteLicense) == 15

--- a/tests/unit/test_site_permissions.py
+++ b/tests/unit/test_site_permissions.py
@@ -1,0 +1,114 @@
+"""site_permissionsモジュールのユニットテスト"""
+
+import pytest
+
+from wikidot.module.site_permissions import (
+    ForumPermissions,
+    PagePermissions,
+    RatingSettings,
+    replace_actors,
+)
+
+
+class TestPagePermissions:
+    """PagePermissionsのラウンドトリップ・validateテスト"""
+
+    RAW = "v:armo;c:m;e:m;m:m;d:m;a:m;r:m;z:m;o:rm"
+
+    def test_decode(self):
+        perms = PagePermissions.decode(self.RAW)
+        assert perms.view == {"anonymous", "registered", "member", "author"}
+        assert perms.create == {"member"}
+        assert perms.show_options == {"registered", "member"}
+        assert perms._unknown == ()
+
+    def test_roundtrip(self):
+        perms = PagePermissions.decode(self.RAW)
+        assert perms.encode() == self.RAW
+
+    def test_decode_unknown_symbol_preserved(self):
+        # "x" is not a documented perm letter; the whole segment must
+        # survive the round trip instead of being silently dropped
+        raw = "v:armo;x:ar"
+        perms = PagePermissions.decode(raw)
+        assert perms._unknown == ("x:ar",)
+        # unknown segments are re-appended (after the fixed known order)
+        assert perms.encode().endswith("x:ar")
+
+    def test_decode_unknown_user_symbol_in_known_perm_preserved(self):
+        # "q" is not a documented actor symbol; the whole "letter:users"
+        # segment is kept as unknown rather than losing the "q"
+        raw = "v:arq"
+        perms = PagePermissions.decode(raw)
+        assert perms._unknown == ("v:arq",)
+        assert perms.view == frozenset()
+
+    def test_validate_no_violation(self):
+        perms = PagePermissions.decode(self.RAW)
+        assert perms.validate() == []
+
+    def test_validate_anonymous_without_registered(self):
+        perms = PagePermissions(view=frozenset({"anonymous"}))
+        violations = perms.validate()
+        assert len(violations) == 1
+        assert "view" in violations[0]
+
+    def test_validate_registered_without_member(self):
+        perms = PagePermissions(view=frozenset({"registered"}))
+        violations = perms.validate()
+        assert len(violations) == 1
+
+    def test_empty_string_roundtrip(self):
+        perms = PagePermissions.decode("")
+        assert perms.encode() == "v:;c:;e:;m:;d:;a:;r:;z:;o:"
+
+
+class TestReplaceActors:
+    def test_replace_single_field(self):
+        base = PagePermissions.decode(TestPagePermissions.RAW)
+        updated = replace_actors(base, view={"anonymous"})
+        assert updated.view == {"anonymous"}
+        # untouched fields survive
+        assert updated.create == base.create
+
+    def test_replace_accepts_any_iterable(self):
+        base = PagePermissions()
+        updated = replace_actors(base, view=["member", "registered"])
+        assert updated.view == frozenset({"member", "registered"})
+
+
+class TestForumPermissions:
+    RAW = "t:m;p:armo;e:m"
+
+    def test_roundtrip(self):
+        perms = ForumPermissions.decode(self.RAW)
+        assert perms.encode() == self.RAW
+
+    def test_unknown_s_symbol_preserved(self):
+        # "s" is defined in Wikidot's client JS but not rendered in the
+        # permission table on any tested site; must not be dropped
+        raw = "t:m;p:armo;e:m;s:ar"
+        perms = ForumPermissions.decode(raw)
+        assert perms._unknown == ("s:ar",)
+        assert perms.encode() == raw
+
+
+class TestRatingSettings:
+    def test_decode_drvm(self):
+        rating = RatingSettings.decode("drvM")
+        assert rating.enabled is False
+        assert rating.voters == "registered"
+        assert rating.anonymous is False
+        assert rating.kind == "plus_minus"
+
+    def test_roundtrip(self):
+        for raw in ("drvM", "eraP", "dmaS"):
+            assert RatingSettings.decode(raw).encode() == raw
+
+    def test_decode_invalid_length_raises(self):
+        with pytest.raises(ValueError):
+            RatingSettings.decode("drv")
+
+    def test_decode_invalid_char_raises(self):
+        with pytest.raises(ValueError):
+            RatingSettings.decode("xrvM")

--- a/tests/unit/test_site_settings.py
+++ b/tests/unit/test_site_settings.py
@@ -195,87 +195,242 @@ class TestNavigationTemplatesPageRatePerPageDiscussionAppearance:
         assert '"theme_id": ""' in save_body["categories"] or '"theme_id":""' in save_body["categories"]
 
 
-class TestGeneralDomainAccessPolicy:
-    def test_save_general_success_no_unixname(self):
+class TestGetGeneral:
+    def test_reads_all_fields(self, site_general_form):
         site = MagicMock()
         response = MagicMock()
-        response.json.return_value = {"status": "ok", "CURRENT_TIMESTAMP": 1785204323, "callbackIndex": None}
+        response.json.return_value = site_general_form
         site.amc_request.return_value = [response]
 
-        result = SiteSettingsAccessor(site).save_general(name="Test Site")
+        settings = SiteSettingsAccessor(site).get_general()
 
-        assert result is None
-        body = site.amc_request.call_args[0][0][0]
-        assert body["action"] == "ManageSiteAction"
-        assert body["event"] == "saveGeneral"
-        assert body["name"] == "Test Site"
+        assert settings.name == "My Site"
+        assert settings.subtitle == "A subtitle"
+        assert settings.language == "ja"
+        assert settings.description == "A description"
+        assert settings.default_page == "start"
+        assert settings.welcome_page == "welcome"
 
-    def test_save_general_returns_new_unixname(self):
+    def test_missing_field_is_none_not_guessed(self):
         site = MagicMock()
         response = MagicMock()
-        response.json.return_value = {"status": "ok", "unixName": "new-name"}
+        response.json.return_value = {"status": "ok", "body": "<div></div>"}
         site.amc_request.return_value = [response]
+
+        settings = SiteSettingsAccessor(site).get_general()
+
+        assert settings.name is None
+        assert settings.language is None
+
+
+class TestSaveGeneralReadModifyWrite:
+    def _mocked_site(self, get_payload: dict, save_payload: dict | None = None) -> MagicMock:
+        site = MagicMock()
+        get_response = MagicMock()
+        get_response.json.return_value = get_payload
+        save_response = MagicMock()
+        save_response.json.return_value = save_payload or {"status": "ok"}
+        site.amc_request.side_effect = [[get_response], [save_response]]
+        return site
+
+    def test_only_name_given_preserves_other_fields(self, site_general_form):
+        site = self._mocked_site(site_general_form)
+
+        SiteSettingsAccessor(site).save_general(name="New Title")
+
+        save_body = site.amc_request.call_args_list[1][0][0][0]
+        assert save_body["name"] == "New Title"
+        assert save_body["subtitle"] == "A subtitle"
+        assert save_body["language"] == "ja"
+        assert save_body["description"] == "A description"
+        assert save_body["default_page"] == "start"
+        assert save_body["welcome_page"] == "welcome"
+
+    def test_explicit_empty_string_clears_a_field(self, site_general_form):
+        site = self._mocked_site(site_general_form)
+
+        SiteSettingsAccessor(site).save_general(subtitle="")
+
+        save_body = site.amc_request.call_args_list[1][0][0][0]
+        assert save_body["subtitle"] == ""
+        assert save_body["name"] == "My Site"
+
+    def test_no_arguments_resends_all_current_values(self, site_general_form):
+        site = self._mocked_site(site_general_form)
+
+        SiteSettingsAccessor(site).save_general()
+
+        save_body = site.amc_request.call_args_list[1][0][0][0]
+        assert save_body["name"] == "My Site"
+        assert save_body["subtitle"] == "A subtitle"
+        assert save_body["language"] == "ja"
+        assert save_body["description"] == "A description"
+        assert save_body["default_page"] == "start"
+        assert save_body["welcome_page"] == "welcome"
+
+    def test_returns_new_unixname(self, site_general_form):
+        site = self._mocked_site(site_general_form, {"status": "ok", "unixName": "new-name"})
 
         result = SiteSettingsAccessor(site).save_general(name="Test Site")
 
         assert result == "new-name"
 
-    def test_save_general_empty_name_raises_form_errors(self):
+    def test_returns_none_without_unixname_change(self, site_general_form):
+        site = self._mocked_site(site_general_form)
+
+        result = SiteSettingsAccessor(site).save_general(name="Test Site")
+
+        assert result is None
+
+    def test_empty_name_raises_form_errors(self, site_general_form):
         site = MagicMock()
-        site.amc_request.side_effect = FormErrorsException(
-            "form_errors",
-            "form_errors",
-            {
-                "status": "form_errors",
-                "formErrors": {"name": "Please provide the site title", "defaultPage": "..."},
-                "message": "Form errors",
-            },
-        )
+        get_response = MagicMock()
+        get_response.json.return_value = site_general_form
+        site.amc_request.side_effect = [
+            [get_response],
+            FormErrorsException(
+                "form_errors",
+                "form_errors",
+                {
+                    "status": "form_errors",
+                    "formErrors": {"name": "Please provide the site title"},
+                    "message": "Form errors",
+                },
+            ),
+        ]
 
         with pytest.raises(FormErrorsException) as exc_info:
             SiteSettingsAccessor(site).save_general(name="")
 
         assert exc_info.value.errors["name"] == "Please provide the site title"
 
-    def test_save_domain_too_many_redirects_raises(self):
+
+class TestGetDomain:
+    def test_reads_fields_by_id(self, site_domain_module):
+        site = MagicMock()
+        response = MagicMock()
+        response.json.return_value = site_domain_module
+        site.amc_request.return_value = [response]
+
+        settings = SiteSettingsAccessor(site).get_domain()
+
+        assert settings.domain == "example.com"
+        assert settings.domain_default is True
+        assert settings.redirects == ["a.com", "b.com"]
+
+
+class TestSaveDomainReadModifyWrite:
+    def test_too_many_redirects_raises_without_any_request(self):
         site = MagicMock()
         with pytest.raises(ValueError, match="10"):
-            SiteSettingsAccessor(site).save_domain("example.com", redirects=[f"r{i}.com" for i in range(11)])
+            SiteSettingsAccessor(site).save_domain(redirects=[f"r{i}.com" for i in range(11)])
+        site.amc_request.assert_not_called()
 
-    def test_save_domain_joins_redirects_with_semicolon(self):
+    def test_joins_redirects_with_semicolon(self, site_domain_module):
+        site = MagicMock()
+        get_response = MagicMock()
+        get_response.json.return_value = site_domain_module
+        save_response = MagicMock()
+        save_response.json.return_value = {"status": "ok"}
+        site.amc_request.side_effect = [[get_response], [save_response]]
+
+        SiteSettingsAccessor(site).save_domain(redirects=["a.com", "b.com"])
+
+        save_body = site.amc_request.call_args_list[1][0][0][0]
+        assert save_body["redirects"] == "a.com;b.com"
+
+    def test_only_domain_given_preserves_redirects_and_default_flag(self, site_domain_module):
+        site = MagicMock()
+        get_response = MagicMock()
+        get_response.json.return_value = site_domain_module
+        save_response = MagicMock()
+        save_response.json.return_value = {"status": "ok"}
+        site.amc_request.side_effect = [[get_response], [save_response]]
+
+        SiteSettingsAccessor(site).save_domain(domain="new.example.com")
+
+        save_body = site.amc_request.call_args_list[1][0][0][0]
+        assert save_body["domain"] == "new.example.com"
+        assert save_body["redirects"] == "a.com;b.com"
+        assert save_body["domainDefault"] == "true"
+
+
+class TestGetAccessPolicy:
+    def test_reads_all_fields(self, site_access_policy_form):
         site = MagicMock()
         response = MagicMock()
-        response.json.return_value = {"status": "ok"}
+        response.json.return_value = site_access_policy_form
         site.amc_request.return_value = [response]
 
-        SiteSettingsAccessor(site).save_domain("example.com", redirects=["a.com", "b.com"])
+        settings = SiteSettingsAccessor(site).get_access_policy()
 
-        body = site.amc_request.call_args[0][0][0]
-        assert body["redirects"] == "a.com;b.com"
+        assert settings.privacy == "closed"
+        assert settings.by_apply is True
+        assert settings.by_domain == "example.com"
+        assert settings.by_password is False
+        assert settings.password == ""
+        assert settings.allow_hotlink is True
+        assert settings.landing_page == "start"
+        assert settings.hide_nav is False
 
-    def test_save_access_policy_viewers_from_ids(self):
+
+class TestSaveAccessPolicyReadModifyWrite:
+    def _mocked_site(self, get_payload: dict) -> MagicMock:
+        site = MagicMock()
+        get_response = MagicMock()
+        get_response.json.return_value = get_payload
+        save_response = MagicMock()
+        save_response.json.return_value = {"status": "ok"}
+        site.amc_request.side_effect = [[get_response], [save_response]]
+        return site
+
+    def test_no_privacy_given_keeps_current_value(self, site_access_policy_form):
+        site = self._mocked_site(site_access_policy_form)
+
+        SiteSettingsAccessor(site).save_access_policy()
+
+        save_body = site.amc_request.call_args_list[1][0][0][0]
+        assert save_body["privacy"] == "closed"
+        assert save_body["by_domain"] == "example.com"
+        assert save_body["landingPage"] == "start"
+        # by_apply / allowHotlink were checked in the fixture, so they must
+        # still be sent even though this call didn't touch them
+        assert save_body["by_apply"] == "on"
+        assert save_body["allowHotlink"] == "on"
+        assert "hideNav" not in save_body
+
+    def test_privacy_cannot_be_determined_raises(self):
         site = MagicMock()
         response = MagicMock()
-        response.json.return_value = {"status": "ok"}
+        response.json.return_value = {"status": "ok", "body": "<form id='sm-private-form'></form>"}
         site.amc_request.return_value = [response]
 
-        SiteSettingsAccessor(site).save_access_policy("private", viewers=[111, 222])
+        with pytest.raises(ValueError, match="privacy"):
+            SiteSettingsAccessor(site).save_access_policy()
 
-        body = site.amc_request.call_args[0][0][0]
-        assert body["viewers"] == "111,222"
-        assert body["privacy"] == "private"
+    def test_viewers_from_ids(self, site_access_policy_form):
+        site = self._mocked_site(site_access_policy_form)
 
-    def test_save_access_policy_omits_unchecked_checkboxes(self):
-        site = MagicMock()
-        response = MagicMock()
-        response.json.return_value = {"status": "ok"}
-        site.amc_request.return_value = [response]
+        SiteSettingsAccessor(site).save_access_policy(viewers=[111, 222])
 
-        SiteSettingsAccessor(site).save_access_policy("open")
+        save_body = site.amc_request.call_args_list[1][0][0][0]
+        assert save_body["viewers"] == "111,222"
 
-        body = site.amc_request.call_args[0][0][0]
-        assert "by_apply" not in body
-        assert "allowHotlink" not in body
+    def test_viewers_omitted_when_not_given(self, site_access_policy_form):
+        site = self._mocked_site(site_access_policy_form)
+
+        SiteSettingsAccessor(site).save_access_policy()
+
+        save_body = site.amc_request.call_args_list[1][0][0][0]
+        assert "viewers" not in save_body
+
+    def test_explicit_privacy_overrides_current_value(self, site_access_policy_form):
+        site = self._mocked_site(site_access_policy_form)
+
+        SiteSettingsAccessor(site).save_access_policy(privacy="private")
+
+        save_body = site.amc_request.call_args_list[1][0][0][0]
+        assert save_body["privacy"] == "private"
 
 
 class TestSingleShotSettings:

--- a/tests/unit/test_site_settings.py
+++ b/tests/unit/test_site_settings.py
@@ -22,7 +22,7 @@ def _make_site(categories_response: dict | None = None) -> MagicMock:
 
 
 class TestUpdateCategories:
-    """update_categoriesが毎回fetch->mutate->saveの順で呼ばれること"""
+    """update_categoriesが指定モジュールから毎回fetch->mutate->saveの順で呼ばれること"""
 
     def test_fetch_then_save_two_requests(self, site_categories_single):
         site = _make_site(site_categories_single)
@@ -33,7 +33,9 @@ class TestUpdateCategories:
         def mutator(cats: SiteCategoryCollection) -> None:
             called.append(cats["_default"].category_id)
 
-        accessor.update_categories("ManageSiteAction", "savePermissions", mutator)
+        accessor.update_categories(
+            "managesite/ManageSitePermissionsModule", "ManageSiteAction", "savePermissions", mutator
+        )
 
         assert called == [30228632]
         assert site.amc_request.call_count == 2
@@ -43,13 +45,29 @@ class TestUpdateCategories:
         assert save_body["action"] == "ManageSiteAction"
         assert save_body["event"] == "savePermissions"
 
+    def test_fetches_from_the_module_name_passed_in(self, site_categories_single):
+        # 各領域が自分のモジュールから fetch すること（Permissionsモジュール固定に戻さない）
+        site = _make_site(site_categories_single)
+        accessor = SiteSettingsAccessor(site)
+
+        accessor.update_categories(
+            "managesite/ManageSiteLicenseModule", "ManageSiteAction", "saveLicense", lambda cats: None
+        )
+
+        fetch_call = site.amc_request.call_args_list[0][0][0]
+        assert fetch_call == [{"moduleName": "managesite/ManageSiteLicenseModule"}]
+
     def test_no_caching_refetches_every_call(self, site_categories_single):
         # 2回呼べば2回ともfetchされること（キャッシュされていないこと）
         site = _make_site(site_categories_single)
         accessor = SiteSettingsAccessor(site)
 
-        accessor.update_categories("ManageSiteAction", "savePermissions", lambda cats: None)
-        accessor.update_categories("ManageSiteAction", "saveLicense", lambda cats: None)
+        accessor.update_categories(
+            "managesite/ManageSitePermissionsModule", "ManageSiteAction", "savePermissions", lambda cats: None
+        )
+        accessor.update_categories(
+            "managesite/ManageSiteLicenseModule", "ManageSiteAction", "saveLicense", lambda cats: None
+        )
 
         assert site.amc_request.call_count == 4  # fetch+save が2セット
 
@@ -62,6 +80,8 @@ class TestPermissions:
 
         accessor.set_page_permissions("_default", new_perms)
 
+        fetch_body = site.amc_request.call_args_list[0][0][0]
+        assert fetch_body == [{"moduleName": "managesite/ManageSitePermissionsModule"}]
         save_body = site.amc_request.call_args_list[1][0][0][0]
         assert save_body["event"] == "savePermissions"
         assert "v:arm" in save_body["categories"]
@@ -87,12 +107,14 @@ class TestPermissions:
 
 
 class TestLicense:
-    def test_set_license(self, site_categories_single):
+    def test_set_license_fetches_from_license_module(self, site_categories_single):
         site = _make_site(site_categories_single)
         accessor = SiteSettingsAccessor(site)
 
         accessor.set_license("_default", SiteLicense.CC_ATTRIBUTION_3_0)
 
+        fetch_body = site.amc_request.call_args_list[0][0][0]
+        assert fetch_body == [{"moduleName": "managesite/ManageSiteLicenseModule"}]
         save_body = site.amc_request.call_args_list[1][0][0][0]
         assert save_body["event"] == "saveLicense"
         assert '"license_id": 13' in save_body["categories"] or '"license_id":13' in save_body["categories"]
@@ -114,29 +136,37 @@ class TestLicense:
 
 
 class TestNavigationTemplatesPageRatePerPageDiscussionAppearance:
-    def test_set_navigation(self, site_categories_single):
+    def test_set_navigation_fetches_from_navigation_module(self, site_categories_single):
         site = _make_site(site_categories_single)
         SiteSettingsAccessor(site).set_navigation("_default", "nav:top", "nav:side2")
+        fetch_body = site.amc_request.call_args_list[0][0][0]
+        assert fetch_body == [{"moduleName": "managesite/ManageSiteNavigationModule"}]
         save_body = site.amc_request.call_args_list[1][0][0][0]
         assert save_body["event"] == "saveNavigation"
 
-    def test_set_template(self, site_categories_single):
+    def test_set_template_fetches_from_templates_module(self, site_categories_single):
         site = _make_site(site_categories_single)
         SiteSettingsAccessor(site).set_template("_default", 42)
+        fetch_body = site.amc_request.call_args_list[0][0][0]
+        assert fetch_body == [{"moduleName": "managesite/ManageSiteTemplatesModule"}]
         save_body = site.amc_request.call_args_list[1][0][0][0]
         assert save_body["event"] == "saveTemplates"
         assert '"template_id": 42' in save_body["categories"] or '"template_id":42' in save_body["categories"]
 
-    def test_set_page_rate_settings(self, site_categories_single):
+    def test_set_page_rate_settings_fetches_from_pagerate_module(self, site_categories_single):
         site = _make_site(site_categories_single)
         rating = RatingSettings.decode("emaS")
         SiteSettingsAccessor(site).set_page_rate_settings("_default", rating)
+        fetch_body = site.amc_request.call_args_list[0][0][0]
+        assert fetch_body == [{"moduleName": "managesite/pagerate/ManageSitePageRateSettingsModule"}]
         save_body = site.amc_request.call_args_list[1][0][0][0]
         assert save_body["event"] == "savePageRateSettings"
 
-    def test_set_per_page_discussion_explicit(self, site_categories_single):
+    def test_set_per_page_discussion_explicit_fetches_from_perpagediscussion_module(self, site_categories_single):
         site = _make_site(site_categories_single)
         SiteSettingsAccessor(site).set_per_page_discussion("_default", False)
+        fetch_body = site.amc_request.call_args_list[0][0][0]
+        assert fetch_body == [{"moduleName": "managesite/ManageSitePerPageDiscussionModule"}]
         save_body = site.amc_request.call_args_list[1][0][0][0]
         assert save_body["action"] == "ManageSiteForumAction"
         assert save_body["event"] == "savePerPageDiscussion"
@@ -149,9 +179,11 @@ class TestNavigationTemplatesPageRatePerPageDiscussionAppearance:
             '"per_page_discussion_default":true' in save_body["categories"]
         )
 
-    def test_set_appearance_theme(self, site_categories_single):
+    def test_set_appearance_theme_fetches_from_appearance_module(self, site_categories_single):
         site = _make_site(site_categories_single)
         SiteSettingsAccessor(site).set_appearance_theme("_default", 7)
+        fetch_body = site.amc_request.call_args_list[0][0][0]
+        assert fetch_body == [{"moduleName": "managesite/themes/ManageSiteAppearanceModule"}]
         save_body = site.amc_request.call_args_list[1][0][0][0]
         assert save_body["action"] == "ManageSiteThemeAction"
         assert save_body["event"] == "saveAppearance"

--- a/tests/unit/test_site_settings.py
+++ b/tests/unit/test_site_settings.py
@@ -1,0 +1,362 @@
+"""site_settingsモジュールのユニットテスト"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from wikidot.common.exceptions import FormErrorsException
+from wikidot.module.site_category import SiteCategoryCollection, SiteLicense
+from wikidot.module.site_permissions import PagePermissions, RatingSettings
+from wikidot.module.site_settings import SiteSettingsAccessor
+
+
+def _make_site(categories_response: dict | None = None) -> MagicMock:
+    """categories 応答を返す amc_request を積んだ MagicMock の Site"""
+    site = MagicMock()
+    if categories_response is not None:
+        fetch_response = MagicMock()
+        fetch_response.json.return_value = categories_response
+        # 1回目=fetch, 2回目=save のレスポンスとして両方同じMagicMockでよい
+        site.amc_request.return_value = [fetch_response]
+    return site
+
+
+class TestUpdateCategories:
+    """update_categoriesが毎回fetch->mutate->saveの順で呼ばれること"""
+
+    def test_fetch_then_save_two_requests(self, site_categories_single):
+        site = _make_site(site_categories_single)
+        accessor = SiteSettingsAccessor(site)
+
+        called = []
+
+        def mutator(cats: SiteCategoryCollection) -> None:
+            called.append(cats["_default"].category_id)
+
+        accessor.update_categories("ManageSiteAction", "savePermissions", mutator)
+
+        assert called == [30228632]
+        assert site.amc_request.call_count == 2
+        fetch_call, save_call = site.amc_request.call_args_list
+        assert fetch_call[0][0] == [{"moduleName": "managesite/ManageSitePermissionsModule"}]
+        save_body = save_call[0][0][0]
+        assert save_body["action"] == "ManageSiteAction"
+        assert save_body["event"] == "savePermissions"
+
+    def test_no_caching_refetches_every_call(self, site_categories_single):
+        # 2回呼べば2回ともfetchされること（キャッシュされていないこと）
+        site = _make_site(site_categories_single)
+        accessor = SiteSettingsAccessor(site)
+
+        accessor.update_categories("ManageSiteAction", "savePermissions", lambda cats: None)
+        accessor.update_categories("ManageSiteAction", "saveLicense", lambda cats: None)
+
+        assert site.amc_request.call_count == 4  # fetch+save が2セット
+
+
+class TestPermissions:
+    def test_set_page_permissions_clears_default_flag(self, site_categories_single):
+        site = _make_site(site_categories_single)
+        accessor = SiteSettingsAccessor(site)
+        new_perms = PagePermissions.decode("v:arm;c:m;e:m;m:m;d:m;a:m;r:m;z:m;o:m")
+
+        accessor.set_page_permissions("_default", new_perms)
+
+        save_body = site.amc_request.call_args_list[1][0][0][0]
+        assert save_body["event"] == "savePermissions"
+        assert "v:arm" in save_body["categories"]
+
+    def test_use_default_page_permissions(self, site_categories_single):
+        site = _make_site(site_categories_single)
+        accessor = SiteSettingsAccessor(site)
+
+        accessor.use_default_page_permissions("_default")
+
+        save_body = site.amc_request.call_args_list[1][0][0][0]
+        assert (
+            '"permissions_default": true' in save_body["categories"]
+            or '"permissions_default":true' in save_body["categories"]
+        )
+
+    def test_category_not_found_propagates_keyerror(self, site_categories_single):
+        site = _make_site(site_categories_single)
+        accessor = SiteSettingsAccessor(site)
+
+        with pytest.raises(KeyError):
+            accessor.set_page_permissions("nonexistent", PagePermissions())
+
+
+class TestLicense:
+    def test_set_license(self, site_categories_single):
+        site = _make_site(site_categories_single)
+        accessor = SiteSettingsAccessor(site)
+
+        accessor.set_license("_default", SiteLicense.CC_ATTRIBUTION_3_0)
+
+        save_body = site.amc_request.call_args_list[1][0][0][0]
+        assert save_body["event"] == "saveLicense"
+        assert '"license_id": 13' in save_body["categories"] or '"license_id":13' in save_body["categories"]
+
+    def test_other_without_text_raises(self, site_categories_single):
+        site = _make_site(site_categories_single)
+        accessor = SiteSettingsAccessor(site)
+
+        with pytest.raises(ValueError, match="license_other"):
+            accessor.set_license("_default", SiteLicense.OTHER)
+
+    def test_other_with_text_ok(self, site_categories_single):
+        site = _make_site(site_categories_single)
+        accessor = SiteSettingsAccessor(site)
+
+        accessor.set_license("_default", SiteLicense.OTHER, other="My custom license")
+
+        assert site.amc_request.call_count == 2
+
+
+class TestNavigationTemplatesPageRatePerPageDiscussionAppearance:
+    def test_set_navigation(self, site_categories_single):
+        site = _make_site(site_categories_single)
+        SiteSettingsAccessor(site).set_navigation("_default", "nav:top", "nav:side2")
+        save_body = site.amc_request.call_args_list[1][0][0][0]
+        assert save_body["event"] == "saveNavigation"
+
+    def test_set_template(self, site_categories_single):
+        site = _make_site(site_categories_single)
+        SiteSettingsAccessor(site).set_template("_default", 42)
+        save_body = site.amc_request.call_args_list[1][0][0][0]
+        assert save_body["event"] == "saveTemplates"
+        assert '"template_id": 42' in save_body["categories"] or '"template_id":42' in save_body["categories"]
+
+    def test_set_page_rate_settings(self, site_categories_single):
+        site = _make_site(site_categories_single)
+        rating = RatingSettings.decode("emaS")
+        SiteSettingsAccessor(site).set_page_rate_settings("_default", rating)
+        save_body = site.amc_request.call_args_list[1][0][0][0]
+        assert save_body["event"] == "savePageRateSettings"
+
+    def test_set_per_page_discussion_explicit(self, site_categories_single):
+        site = _make_site(site_categories_single)
+        SiteSettingsAccessor(site).set_per_page_discussion("_default", False)
+        save_body = site.amc_request.call_args_list[1][0][0][0]
+        assert save_body["action"] == "ManageSiteForumAction"
+        assert save_body["event"] == "savePerPageDiscussion"
+
+    def test_set_per_page_discussion_default(self, site_categories_single):
+        site = _make_site(site_categories_single)
+        SiteSettingsAccessor(site).set_per_page_discussion("_default", None)
+        save_body = site.amc_request.call_args_list[1][0][0][0]
+        assert '"per_page_discussion_default": true' in save_body["categories"] or (
+            '"per_page_discussion_default":true' in save_body["categories"]
+        )
+
+    def test_set_appearance_theme(self, site_categories_single):
+        site = _make_site(site_categories_single)
+        SiteSettingsAccessor(site).set_appearance_theme("_default", 7)
+        save_body = site.amc_request.call_args_list[1][0][0][0]
+        assert save_body["action"] == "ManageSiteThemeAction"
+        assert save_body["event"] == "saveAppearance"
+
+    def test_set_appearance_external_theme_sends_empty_string_theme_id(self, site_categories_single):
+        site = _make_site(site_categories_single)
+        SiteSettingsAccessor(site).set_appearance_external_theme("_default", "https://example.com/theme.css")
+        save_body = site.amc_request.call_args_list[1][0][0][0]
+        assert '"theme_id": ""' in save_body["categories"] or '"theme_id":""' in save_body["categories"]
+
+
+class TestGeneralDomainAccessPolicy:
+    def test_save_general_success_no_unixname(self):
+        site = MagicMock()
+        response = MagicMock()
+        response.json.return_value = {"status": "ok", "CURRENT_TIMESTAMP": 1785204323, "callbackIndex": None}
+        site.amc_request.return_value = [response]
+
+        result = SiteSettingsAccessor(site).save_general(name="Test Site")
+
+        assert result is None
+        body = site.amc_request.call_args[0][0][0]
+        assert body["action"] == "ManageSiteAction"
+        assert body["event"] == "saveGeneral"
+        assert body["name"] == "Test Site"
+
+    def test_save_general_returns_new_unixname(self):
+        site = MagicMock()
+        response = MagicMock()
+        response.json.return_value = {"status": "ok", "unixName": "new-name"}
+        site.amc_request.return_value = [response]
+
+        result = SiteSettingsAccessor(site).save_general(name="Test Site")
+
+        assert result == "new-name"
+
+    def test_save_general_empty_name_raises_form_errors(self):
+        site = MagicMock()
+        site.amc_request.side_effect = FormErrorsException(
+            "form_errors",
+            "form_errors",
+            {
+                "status": "form_errors",
+                "formErrors": {"name": "Please provide the site title", "defaultPage": "..."},
+                "message": "Form errors",
+            },
+        )
+
+        with pytest.raises(FormErrorsException) as exc_info:
+            SiteSettingsAccessor(site).save_general(name="")
+
+        assert exc_info.value.errors["name"] == "Please provide the site title"
+
+    def test_save_domain_too_many_redirects_raises(self):
+        site = MagicMock()
+        with pytest.raises(ValueError, match="10"):
+            SiteSettingsAccessor(site).save_domain("example.com", redirects=[f"r{i}.com" for i in range(11)])
+
+    def test_save_domain_joins_redirects_with_semicolon(self):
+        site = MagicMock()
+        response = MagicMock()
+        response.json.return_value = {"status": "ok"}
+        site.amc_request.return_value = [response]
+
+        SiteSettingsAccessor(site).save_domain("example.com", redirects=["a.com", "b.com"])
+
+        body = site.amc_request.call_args[0][0][0]
+        assert body["redirects"] == "a.com;b.com"
+
+    def test_save_access_policy_viewers_from_ids(self):
+        site = MagicMock()
+        response = MagicMock()
+        response.json.return_value = {"status": "ok"}
+        site.amc_request.return_value = [response]
+
+        SiteSettingsAccessor(site).save_access_policy("private", viewers=[111, 222])
+
+        body = site.amc_request.call_args[0][0][0]
+        assert body["viewers"] == "111,222"
+        assert body["privacy"] == "private"
+
+    def test_save_access_policy_omits_unchecked_checkboxes(self):
+        site = MagicMock()
+        response = MagicMock()
+        response.json.return_value = {"status": "ok"}
+        site.amc_request.return_value = [response]
+
+        SiteSettingsAccessor(site).save_access_policy("open")
+
+        body = site.amc_request.call_args[0][0][0]
+        assert "by_apply" not in body
+        assert "allowHotlink" not in body
+
+
+class TestSingleShotSettings:
+    def _response(self, site: MagicMock, payload: dict | None = None) -> None:
+        response = MagicMock()
+        response.json.return_value = payload or {"status": "ok"}
+        site.amc_request.return_value = [response]
+
+    def test_save_custom_footer_omits_use_when_false(self):
+        site = MagicMock()
+        self._response(site)
+        SiteSettingsAccessor(site).save_custom_footer("footer text")
+        body = site.amc_request.call_args[0][0][0]
+        assert body["source"] == "footer text"
+        assert "use" not in body
+
+    def test_save_custom_footer_sends_use_true(self):
+        site = MagicMock()
+        self._response(site)
+        SiteSettingsAccessor(site).save_custom_footer("footer text", use=True)
+        body = site.amc_request.call_args[0][0][0]
+        assert body["use"] == "true"
+
+    def test_save_toolbars_preference(self):
+        site = MagicMock()
+        self._response(site)
+        SiteSettingsAccessor(site).save_toolbars_preference(toolbar_top=True)
+        body = site.amc_request.call_args[0][0][0]
+        assert body["toolbarTop"] == "on"
+        assert "toolbarBottom" not in body
+
+    def test_save_api_settings_uses_dashed_keys(self):
+        site = MagicMock()
+        self._response(site)
+        SiteSettingsAccessor(site).save_api_settings(enabled=True, read_1=True)
+        body = site.amc_request.call_args[0][0][0]
+        assert body["sm-api-enable"] == "on"
+        assert body["read-1"] == "on"
+        assert "write-1" not in body
+
+    def test_add_autonumeration(self):
+        site = MagicMock()
+        self._response(site)
+        SiteSettingsAccessor(site).add_autonumeration("_default", override=True)
+        body = site.amc_request.call_args[0][0][0]
+        assert body["categoryName"] == "_default"
+        assert body["override"] == "true"
+
+    def test_add_pingbacks_without_override_omits_key(self):
+        site = MagicMock()
+        self._response(site)
+        SiteSettingsAccessor(site).add_pingbacks("_default")
+        body = site.amc_request.call_args[0][0][0]
+        assert "override" not in body
+
+    def test_save_openid_always_sends_enable_flag(self):
+        site = MagicMock()
+        self._response(site)
+        SiteSettingsAccessor(site).save_openid(False)
+        body = site.amc_request.call_args[0][0][0]
+        assert body["enableOpenID"] == "false"
+
+    def test_request_backup(self):
+        site = MagicMock()
+        self._response(site)
+        SiteSettingsAccessor(site).request_backup(backup_sources=True, backup_type="tar")
+        body = site.amc_request.call_args[0][0][0]
+        assert body["event"] == "requestBackup"
+        assert body["backupSources"] == "on"
+        assert body["backupType"] == "tar"
+
+    def test_delete_backup_requires_confirm(self):
+        site = MagicMock()
+        with pytest.raises(ValueError, match="confirm"):
+            SiteSettingsAccessor(site).delete_backup(confirm=False)
+
+    def test_delete_backup_with_confirm_sends_request(self):
+        site = MagicMock()
+        self._response(site)
+        SiteSettingsAccessor(site).delete_backup(confirm=True)
+        body = site.amc_request.call_args[0][0][0]
+        assert body["event"] == "deleteBackup"
+
+    def test_set_windows_icon_background_color_uses_exact_typo_event_name(self):
+        site = MagicMock()
+        self._response(site)
+        SiteSettingsAccessor(site).set_windows_icon_background_color("#ffffff")
+        body = site.amc_request.call_args[0][0][0]
+        assert body["event"] == "windowsIconBackroundColor"
+
+    def test_preview_newsletter(self):
+        site = MagicMock()
+        response = MagicMock()
+        response.json.return_value = {"status": "ok", "title": "Rendered", "content": "<p>hi</p>"}
+        site.amc_request.return_value = [response]
+
+        title, content = SiteSettingsAccessor(site).preview_newsletter("T", "C")
+
+        assert title == "Rendered"
+        assert content == "<p>hi</p>"
+
+    def test_send_newsletter_others_as_list_for_bracket_encoding(self):
+        site = MagicMock()
+        self._response(site)
+        SiteSettingsAccessor(site).send_newsletter("T", "C", admins=True, others=[1, 2, 3])
+        body = site.amc_request.call_args[0][0][0]
+        assert body["admins"] == "true"
+        assert body["moderators"] == "false"
+        assert body["others"] == [1, 2, 3]
+
+    def test_send_newsletter_others_empty_by_default(self):
+        site = MagicMock()
+        self._response(site)
+        SiteSettingsAccessor(site).send_newsletter("T", "C")
+        body = site.amc_request.call_args[0][0][0]
+        assert body["others"] == []


### PR DESCRIPTION
## Summary

`_admin` のサイト設定を `site.settings` から操作できるようにする。

> スタック PR。base は `feature/amc-transport-fixes`。AMC 層の修正を先に入れないと `form_errors` を扱えないため分けている。

## Related Issue

なし

## Changes

- `SiteCategory` を追加し、`categories` の取得→変更→保存を1メソッドに閉じる
- ページ権限・レーティング・フォーラム権限の文字列エンコーダを追加
- General / Domain / Access policy の取得と保存
- Permissions / License / Navigation / Templates / PageRate / PerPageDiscussion / Appearance
- CustomFooter / Toolbars / GAnalytics / Autonumerate / Pingbacks / API / OpenID / Backup / Icons / Newsletter

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring
- [x] Test addition/modification
- [ ] CI/CD or build related

## Testing

- [x] `make format` passes
- [x] `make lint` passes
- [x] `make test` passes

## Checklist

- [x] Code follows the project's style guidelines
- [ ] Documentation has been updated as needed
- [x] Tests have been added for the changes (if applicable)

## Additional Information

- `categories` に部分更新 API は存在せず全カテゴリ配列を毎回送るため、未知フィールドを保持したまま往復させている。落とすとサイト設定が壊れる
- 領域ごとに対応するモジュールから `categories` を取得する（モジュールによって含まれるフィールドが異なるため）
- 保存系は全引数を未指定既定にした取得→変更→保存。未指定は現在値を維持、空文字は空にする
- `license_id` の全15値は実サイトの `select` を実測して確定した
- サイトの rename / delete / clone は不可逆のため対象外

README と `llms.txt` は追加した API を反映していない。リリース前にまとめて追随させる。
