### PR TITLE
メンバー管理(site.member)の追加

### DIFF
--- a/src/wikidot/module/site.py
+++ b/src/wikidot/module/site.py
@@ -25,6 +25,7 @@ from .forum_thread import ForumThread, ForumThreadCollection
 from .page import Page, PageCollection, SearchPagesQuery, SearchPagesQueryParams
 from .site_application import SiteApplication
 from .site_member import SiteMember
+from .site_member_admin import MemberAccessor
 from .site_settings import SiteSettingsAccessor
 
 if TYPE_CHECKING:
@@ -285,6 +286,7 @@ class Site:
     page: "SitePageAccessor" = field(init=False, repr=False)
     forum: "SiteForumAccessor" = field(init=False, repr=False)
     settings: "SiteSettingsAccessor" = field(init=False, repr=False)
+    member: "MemberAccessor" = field(init=False, repr=False)
 
     # キャッシュ属性
     _members: list["SiteMember"] | None = field(init=False, default=None, repr=False)
@@ -301,6 +303,7 @@ class Site:
         self.page = SitePageAccessor(self)
         self.forum = SiteForumAccessor(self)
         self.settings = SiteSettingsAccessor(self)
+        self.member = MemberAccessor(self)
 
     def __str__(self) -> str:
         """

--- a/src/wikidot/module/site_block.py
+++ b/src/wikidot/module/site_block.py
@@ -1,0 +1,133 @@
+"""
+Module for parsing Wikidot site user/IP block listings
+
+`managesite/blocks/{ManageSiteUserBlocksModule,ManageSiteIpBlocksModule}`
+render these lists; there is no pagination parameter for either (unlike the
+member lists in site_member_admin.py) per this project's JS research
+(`managesite_blocks_ManageSiteUserBlocksModule.js` /
+`managesite_blocks_ManageSiteIpBlocksModule.js` take no `page` argument).
+
+Access these through `Site.member.get_blocked_users()` /
+`Site.member.get_blocked_ips()`, not directly.
+"""
+
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from bs4 import BeautifulSoup
+
+from ..util.parser import user as user_parser
+
+if TYPE_CHECKING:
+    from .site import Site
+    from .user import AbstractUser
+
+#: Matches the `deleteBlock(event, <id>, ...)` onclick handlers Wikidot's
+#: client embeds per row (see forum_post_revision.py's showRevision(event, id)
+#: for the same onclick-parsing pattern used elsewhere in this codebase).
+_DELETE_BLOCK_ID_RE = re.compile(r"deleteBlock\s*\(\s*event\s*,\s*(\d+)")
+
+
+@dataclass
+class UserBlock:
+    """
+    A single blocked-user entry
+
+    **Row markup is not directly measured** (no admin-panel HTML sample was
+    captured for this module; only the client-side JS handlers were). Row
+    parsing reuses the `span.printuser` convention validated elsewhere in
+    this codebase (e.g. `SiteMember._parse`, `ForumPostRevision`), since
+    `managesite_blocks_ManageSiteUserBlocksModule.js` confirms each row's
+    "unblock" control passes the user ID via `deleteBlock(event, userId, ...)`
+    -- the same onclick-argument shape as other admin listings in this
+    project. Verify against a live site before relying on `reason` parsing.
+
+    Attributes
+    ----------
+    site : Site
+        The site the block applies to
+    user : AbstractUser
+        The blocked user
+    reason : str
+        Block reason, as rendered (best-effort; row markup unverified)
+    """
+
+    site: "Site"
+    user: "AbstractUser"
+    reason: str
+
+    @staticmethod
+    def _parse_all(site: "Site", html: BeautifulSoup) -> list["UserBlock"]:
+        """Internal method to extract blocked-user entries from list HTML"""
+        blocks: list[UserBlock] = []
+
+        for row in html.select("table tr"):
+            user_elem = row.select_one("span.printuser")
+            if user_elem is None:
+                continue
+
+            user = user_parser(site.client, user_elem)
+
+            cells = row.select("td")
+            reason = cells[-1].get_text(strip=True) if cells else ""
+
+            blocks.append(UserBlock(site, user, reason))
+
+        return blocks
+
+
+@dataclass
+class IpBlock:
+    """
+    A single blocked-IP entry
+
+    **Row markup is not directly measured** (same caveat as `UserBlock`).
+    `block_id` is extracted from the `deleteBlock(event, blockId, ...)`
+    onclick handler (`managesite_blocks_ManageSiteIpBlocksModule.js`
+    confirms this argument is a block ID, not the IP itself -- asymmetric
+    with `UserBlock`, whose equivalent argument is a user ID; see
+    site_member_admin.py's `unblock_user`/`unblock_ip` docstrings).
+
+    Attributes
+    ----------
+    site : Site
+        The site the block applies to
+    block_id : int
+        Block ID (required by `unblock_ip`)
+    ip : str
+        Blocked IP address/range, as rendered (best-effort; row markup
+        unverified)
+    reason : str
+        Block reason, as rendered (best-effort; row markup unverified)
+    """
+
+    site: "Site"
+    block_id: int
+    ip: str
+    reason: str
+
+    @staticmethod
+    def _parse_all(site: "Site", html: BeautifulSoup) -> list["IpBlock"]:
+        """Internal method to extract blocked-IP entries from list HTML"""
+        blocks: list[IpBlock] = []
+
+        for row in html.select("table tr"):
+            link = row.select_one("a[onclick*='deleteBlock']")
+            if link is None:
+                continue
+
+            match = _DELETE_BLOCK_ID_RE.search(str(link.get("onclick", "")))
+            if match is None:
+                continue
+            block_id = int(match.group(1))
+
+            cells = row.select("td")
+            if not cells:
+                continue
+            ip = cells[0].get_text(strip=True)
+            reason = cells[-1].get_text(strip=True) if len(cells) > 1 else ""
+
+            blocks.append(IpBlock(site, block_id, ip, reason))
+
+        return blocks

--- a/src/wikidot/module/site_member.py
+++ b/src/wikidot/module/site_member.py
@@ -50,6 +50,14 @@ class SiteMember:
         """
         Internal method to extract member information from member list page HTML
 
+        Also reused (via MemberAccessor in site_member_admin.py) for the
+        admin-panel `managesite/members/*` listings, which render a 3rd
+        options-dropdown `td` alongside name/join-date (confirmed
+        2026-07-29, see 40_admin-managesite.md). Rows are skipped (not
+        indexed) when they have no `td` at all -- Wikidot's admin-panel
+        table has a leading `th`-only header row that would otherwise raise
+        IndexError here.
+
         Parameters
         ----------
         site : Site
@@ -66,6 +74,11 @@ class SiteMember:
 
         for row in html.select("table tr"):
             tds = row.select("td")
+            if not tds:
+                # Header row (th only, e.g. the admin panel's "Name" / "Member
+                # since" row) -- nothing to parse
+                continue
+
             user_elem = tds[0].select_one(".printuser")
 
             if user_elem is None:
@@ -73,8 +86,9 @@ class SiteMember:
 
             user = user_parser(site.client, user_elem)
 
-            # tdsが2つあったら加入日時がある
-            if len(tds) == 2:
+            # 2列目があれば加入日時 (admin panel rows have a 3rd options-dropdown
+            # td after it, so this checks >= 2 rather than == 2)
+            if len(tds) >= 2:
                 joined_at_elem = tds[1].select_one(".odate")
                 if joined_at_elem is None:
                     joined_at = None

--- a/src/wikidot/module/site_member_admin.py
+++ b/src/wikidot/module/site_member_admin.py
@@ -95,16 +95,25 @@ class MemberAccessor:
 
         Notes
         -----
-        **Row markup is not directly measured** for this project's research
-        (the test site's admin panel HTML was not captured; only the
-        client-side JS handlers were). This reuses the same `table tr` /
-        `span.printuser` / `div.pager` parsing already validated for the
-        public-facing `membership/MembersListModule` (`SiteMember._parse`),
-        since Wikidot's server templates consistently render member rows
-        through the shared `WIKIDOT.render.printuser` partial across
-        contexts (also true of the admin block lists, see site_block.py).
-        Verify against a live admin panel before depending on this for
-        anything beyond user identity (e.g. exact join-date semantics).
+        Row markup for `ManageSiteMembersListModule` was confirmed live
+        2026-07-29 (see 40_admin-managesite.md): 1st `td` is
+        `span.printuser`, 2nd is `span.odate` (join date), 3rd is a
+        Bootstrap options dropdown; a leading `th`-only header row is
+        skipped by `SiteMember._parse`. `ManageSiteModeratorsModule` /
+        `ManageSiteAdminsModule` were **not** confirmed (the test site had
+        no moderators/admins to render), but are assumed to share this
+        shape since Wikidot's server templates consistently render member
+        rows through the shared `WIKIDOT.render.printuser` partial.
+
+        **Pagination is unconfirmed.** The test site's 6 members did not
+        render a `div.pager` at all, so whether the admin panel uses the
+        same `div.pager` markup as the public `membership/MembersListModule`
+        (vs. Bootstrap-style pagination) could not be verified -- Wikidot's
+        own client (`loadMemberList`) just re-requests with `page` and does
+        not itself track a total page count. The `page` parameter is
+        confirmed correct either way; single-page results (the common case)
+        are unaffected. Re-verify against a site with enough members to
+        paginate before relying on multi-page results.
         """
         members: list[SiteMember] = []
 
@@ -180,9 +189,11 @@ class MemberAccessor:
         user : AbstractUser | int
             Member to remove (or their user ID)
         ban : bool, default False
-            Also ban the user from rejoining. Sent as `ban="yes"` when True;
-            omitted entirely when False (Wikidot's own client only sets
-            `ban` at all on the "remove and ban" flow)
+            **`ban=True` removes the member and blocks them in one call**
+            (Wikidot's own client calls this combined flow "remove and
+            ban" -- it is not merely a removal reason). Sent as `ban="yes"`
+            when True; omitted entirely when False. If you only want to
+            remove membership without blocking, leave this False
         """
         body = omit_falsy(ban="yes" if ban else False)
         self.site.amc_request(
@@ -281,13 +292,12 @@ class MemberAccessor:
         """
         Search for users to invite (`users/UserSearchModule`)
 
-        **未実測 (レスポンス形状)**: 40_admin-managesite.md records this
-        module returns `body`, `count`, `userIds`, `userNames` but the
-        research did not capture a live response, so the exact JSON shape
-        of `userIds`/`userNames` (parallel arrays vs. another encoding) is
-        assumed rather than confirmed. Implemented as parallel JSON arrays,
-        matching how every other list-shaped AMC field in this codebase is
-        encoded.
+        Confirmed live 2026-07-29 (see 40_admin-managesite.md): `userIds`
+        is a JSON array of IDs, but `userNames` is **not** a parallel
+        array -- it's an object keyed by the user ID *as a string*
+        (`{"3396310": "ukwhatn", ...}`). There is also no `count` key
+        (the initial research's notes were wrong on both points); use
+        `len(result)` if a count is needed.
 
         Parameters
         ----------
@@ -302,8 +312,8 @@ class MemberAccessor:
         response = self.site.amc_request([{"moduleName": module_name, "query": query}])[0]
         data = response.json()
         ids = data.get("userIds") or []
-        names = data.get("userNames") or []
-        return [UserSearchResult(id=i, name=n) for i, n in zip(ids, names, strict=False)]
+        names_by_id = data.get("userNames") or {}
+        return [UserSearchResult(id=i, name=names_by_id.get(str(i), "")) for i in ids]
 
     def send_email_invitations(self, addresses: list[tuple[str, str, bool]], message: str = "") -> None:
         """

--- a/src/wikidot/module/site_member_admin.py
+++ b/src/wikidot/module/site_member_admin.py
@@ -1,0 +1,660 @@
+"""
+Module for Wikidot site member administration (Manage Site's members/
+invitations/abuse panels)
+
+Access through `Site.member` (singular; complements the existing plural
+`Site.members` / `Site.moderators` / `Site.admins` properties, which read
+from the public-facing `membership/MembersListModule` and are unaffected by
+this module). `Site.member` groups administrative operations that require
+site-admin permissions: removing/promoting/demoting members, moderator
+permissions, invitations, membership-application handling (delegated to
+`SiteApplication`, unchanged), members auto-watching, and abuse-flag
+clearing. Site user/IP blocks are a separate but related concern, exposed
+here too (see `site_block.py` for the underlying parsing).
+
+See plan/32_tasks.md Task 2-1..2-6 for the task breakdown this follows.
+"""
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from bs4 import BeautifulSoup
+
+from ..connector.ajax import require_body
+from ..util.amc_body import checkbox, flag, json_param, omit_falsy
+from .site_block import IpBlock, UserBlock
+from .site_member import SiteMember
+
+if TYPE_CHECKING:
+    from .site import Site
+    from .user import AbstractUser
+
+
+def _user_id(user: "AbstractUser | int") -> int:
+    """Resolve a user-or-id argument to a plain int, matching the
+    AbstractUser | int convenience pattern already used elsewhere
+    (e.g. site_settings.py's `viewers` / `others` parameters)"""
+    if isinstance(user, int):
+        return user
+    if user.id is None:
+        raise ValueError(f"User has no id: {user}")
+    return user.id
+
+
+@dataclass
+class UserSearchResult:
+    """
+    A single result row from `users/UserSearchModule`
+
+    Attributes
+    ----------
+    id : int
+        User ID
+    name : str
+        Username
+    """
+
+    id: int
+    name: str
+
+
+class MemberAccessor:
+    """
+    Accessor for site member administration (Manage Site panel)
+
+    Access through `Site.member`.
+    """
+
+    def __init__(self, site: "Site"):
+        """
+        Initialize method
+
+        Parameters
+        ----------
+        site : Site
+            Parent site instance
+        """
+        self.site = site
+
+    # ------------------------------------------------------------------
+    # Task 2-1: admin-view member listing (paginated)
+    # ------------------------------------------------------------------
+
+    def _get_paginated(self, module_name: str) -> list[SiteMember]:
+        """
+        Internal helper: fetch a paginated `managesite/members/*` listing
+
+        Parameters
+        ----------
+        module_name : str
+            One of the three `managesite/members/*` modules
+
+        Returns
+        -------
+        list[SiteMember]
+
+        Notes
+        -----
+        **Row markup is not directly measured** for this project's research
+        (the test site's admin panel HTML was not captured; only the
+        client-side JS handlers were). This reuses the same `table tr` /
+        `span.printuser` / `div.pager` parsing already validated for the
+        public-facing `membership/MembersListModule` (`SiteMember._parse`),
+        since Wikidot's server templates consistently render member rows
+        through the shared `WIKIDOT.render.printuser` partial across
+        contexts (also true of the admin block lists, see site_block.py).
+        Verify against a live admin panel before depending on this for
+        anything beyond user identity (e.g. exact join-date semantics).
+        """
+        members: list[SiteMember] = []
+
+        first_response = self.site.amc_request([{"moduleName": module_name, "page": 1}])[0]
+        first_body = require_body(first_response, module_name)
+        first_html = BeautifulSoup(first_body, "lxml")
+        members.extend(SiteMember._parse(self.site, first_html))
+
+        pager = first_html.select_one("div.pager")
+        if pager is None:
+            return members
+
+        last_page = int(pager.select("a")[-2].text)
+        if last_page == 1:
+            return members
+
+        responses = self.site.amc_request(
+            [{"moduleName": module_name, "page": page} for page in range(2, last_page + 1)]
+        )
+        for response in responses:
+            body = require_body(response, module_name)
+            html = BeautifulSoup(body, "lxml")
+            members.extend(SiteMember._parse(self.site, html))
+
+        return members
+
+    def get_members(self) -> list[SiteMember]:
+        """
+        Get the admin-panel view of all site members
+
+        Uses `managesite/members/ManageSiteMembersListModule`, distinct from
+        `Site.members` (public `membership/MembersListModule`): this is the
+        view rendered inside `_admin`, requires site-admin permissions, and
+        is what Wikidot's own client re-fetches after remove/promote/demote
+        actions to refresh the panel.
+
+        Returns
+        -------
+        list[SiteMember]
+        """
+        return self._get_paginated("managesite/members/ManageSiteMembersListModule")
+
+    def get_moderators(self) -> list[SiteMember]:
+        """
+        Get the admin-panel view of site moderators
+
+        Returns
+        -------
+        list[SiteMember]
+        """
+        return self._get_paginated("managesite/members/ManageSiteModeratorsModule")
+
+    def get_admins(self) -> list[SiteMember]:
+        """
+        Get the admin-panel view of site administrators
+
+        Returns
+        -------
+        list[SiteMember]
+        """
+        return self._get_paginated("managesite/members/ManageSiteAdminsModule")
+
+    # ------------------------------------------------------------------
+    # Task 2-2: member removal / ownership transfer / moderator perms
+    # ------------------------------------------------------------------
+
+    def remove(self, user: "AbstractUser | int", *, ban: bool = False) -> None:
+        """
+        Remove a member from the site. Destructive
+
+        Parameters
+        ----------
+        user : AbstractUser | int
+            Member to remove (or their user ID)
+        ban : bool, default False
+            Also ban the user from rejoining. Sent as `ban="yes"` when True;
+            omitted entirely when False (Wikidot's own client only sets
+            `ban` at all on the "remove and ban" flow)
+        """
+        body = omit_falsy(ban="yes" if ban else False)
+        self.site.amc_request(
+            [
+                {
+                    "action": "ManageSiteMembershipAction",
+                    "event": "removeMember",
+                    "user_id": _user_id(user),
+                    "moduleName": "Empty",
+                    **body,
+                }
+            ]
+        )
+
+    def change_master(self, user: "AbstractUser | int") -> None:
+        """
+        Transfer site master-admin ownership to another admin
+
+        Destructive from the caller's perspective: the caller loses master
+        status. Uses `userId` (camelCase) -- unlike every other
+        `ManageSiteMembershipAction` event in this module (which use
+        `user_id`), Wikidot's own client sends this one parameter name in
+        camelCase for `changeMaster` specifically (see 40_admin-managesite.md).
+
+        Parameters
+        ----------
+        user : AbstractUser | int
+            New master admin (must already be a site admin; or their user ID)
+        """
+        self.site.amc_request(
+            [
+                {
+                    "action": "ManageSiteMembershipAction",
+                    "event": "changeMaster",
+                    "userId": _user_id(user),
+                    "moduleName": "Empty",
+                }
+            ]
+        )
+
+    def get_moderator_permissions_form(self, moderator_id: int) -> dict[str, Any]:
+        """
+        Fetch the raw `sm-mod-perms-form` HTML for a moderator
+
+        **未実測**: the test site used for this research had no moderators,
+        so `sm-mod-perms-form`'s field names could not be captured (see
+        35_form-fields.md). Returns the raw rendered HTML body instead of a
+        typed structure -- inspect it yourself and pass the exact field
+        names to `save_moderator_permissions`.
+
+        Parameters
+        ----------
+        moderator_id : int
+            Moderator's user ID (obtainable from `get_moderators()`)
+
+        Returns
+        -------
+        dict[str, Any]
+            `{"body": <raw HTML string>}`
+        """
+        module_name = "managesite/ManageSiteModeratorPermissionsModule"
+        response = self.site.amc_request([{"moduleName": module_name, "moderatorId": moderator_id}])[0]
+        return {"body": require_body(response, module_name)}
+
+    def save_moderator_permissions(self, **fields: Any) -> None:
+        """
+        Save moderator permissions (`saveModeratorPermissions`)
+
+        **未実測**: `sm-mod-perms-form`'s field names are unknown (see
+        `get_moderator_permissions_form`). Pass the exact field names/values
+        Wikidot's form uses as keyword arguments; this method does not
+        validate, transform, or default them (unlike the typed
+        `site.settings.*` methods).
+
+        Parameters
+        ----------
+        **fields : Any
+            Raw form fields to submit verbatim
+        """
+        self.site.amc_request(
+            [
+                {
+                    "action": "ManageSiteMembershipAction",
+                    "event": "saveModeratorPermissions",
+                    "moduleName": "Empty",
+                    **fields,
+                }
+            ]
+        )
+
+    # ------------------------------------------------------------------
+    # Task 2-4: invitations
+    # ------------------------------------------------------------------
+
+    def search_users(self, query: str) -> list[UserSearchResult]:
+        """
+        Search for users to invite (`users/UserSearchModule`)
+
+        **未実測 (レスポンス形状)**: 40_admin-managesite.md records this
+        module returns `body`, `count`, `userIds`, `userNames` but the
+        research did not capture a live response, so the exact JSON shape
+        of `userIds`/`userNames` (parallel arrays vs. another encoding) is
+        assumed rather than confirmed. Implemented as parallel JSON arrays,
+        matching how every other list-shaped AMC field in this codebase is
+        encoded.
+
+        Parameters
+        ----------
+        query : str
+            Search query (part of a username)
+
+        Returns
+        -------
+        list[UserSearchResult]
+        """
+        module_name = "users/UserSearchModule"
+        response = self.site.amc_request([{"moduleName": module_name, "query": query}])[0]
+        data = response.json()
+        ids = data.get("userIds") or []
+        names = data.get("userNames") or []
+        return [UserSearchResult(id=i, name=n) for i, n in zip(ids, names, strict=False)]
+
+    def send_email_invitations(self, addresses: list[tuple[str, str, bool]], message: str = "") -> None:
+        """
+        Send email invitations to join the site
+
+        Parameters
+        ----------
+        addresses : list[tuple[str, str, bool]]
+            `(email, name, is_contact)` tuples. Encoded as
+            `addresses=[[email, name, isContact], ...]` (JSON), matching
+            Wikidot's own client
+        message : str, default ""
+            Message included with the invitation
+        """
+        body = {
+            "addresses": json_param([list(address) for address in addresses]),
+            "message": message,
+        }
+        self.site.amc_request(
+            [
+                {
+                    "action": "ManageSiteMembershipAction",
+                    "event": "sendEmailInvitations",
+                    "moduleName": "Empty",
+                    **body,
+                }
+            ]
+        )
+
+    def delete_email_invitation(self, invitation_id: int) -> None:
+        """
+        Delete a pending email invitation
+
+        Parameters
+        ----------
+        invitation_id : int
+        """
+        self.site.amc_request(
+            [
+                {
+                    "action": "ManageSiteMembershipAction",
+                    "event": "deleteEmailInvitation",
+                    "invitationId": invitation_id,
+                    "moduleName": "Empty",
+                }
+            ]
+        )
+
+    def resend_email_invitation(self, invitation_id: int, message: str = "") -> None:
+        """
+        Resend a pending email invitation
+
+        Parameters
+        ----------
+        invitation_id : int
+        message : str, default ""
+        """
+        self.site.amc_request(
+            [
+                {
+                    "action": "ManageSiteMembershipAction",
+                    "event": "resendEmailInvitation",
+                    "invitationId": invitation_id,
+                    "message": message,
+                    "moduleName": "Empty",
+                }
+            ]
+        )
+
+    def set_let_users_invite(self, enabled: bool) -> None:
+        """
+        Allow/disallow regular members to invite others via email
+
+        Parameters
+        ----------
+        enabled : bool
+            Sent as the literal string "true"/"false" (always present, not
+            omitted when False -- matches `enableLetUsersInvite(bool)`'s
+            plain-boolean notation in 40_admin-managesite.md, the same
+            always-sent convention as `site.settings.save_openid`'s
+            `enableOpenID`)
+        """
+        self.site.amc_request(
+            [
+                {
+                    "action": "ManageSiteMembershipAction",
+                    "event": "letUsersInviteSave",
+                    "enableLetUsersInvite": "true" if enabled else "false",
+                    "moduleName": "Empty",
+                }
+            ]
+        )
+
+    def invite_admin(self, user: "AbstractUser | int") -> int | None:
+        """
+        Invite a user to become a site admin
+
+        Parameters
+        ----------
+        user : AbstractUser | int
+            User to invite (or their user ID)
+
+        Returns
+        -------
+        int | None
+            The invited user's ID, if returned by Wikidot
+        """
+        response = self.site.amc_request(
+            [
+                {
+                    "action": "ManageSiteAction",
+                    "event": "inviteAdmin",
+                    "user_id": _user_id(user),
+                    "moduleName": "Empty",
+                }
+            ]
+        )[0]
+        result = response.json().get("userId")
+        return result if isinstance(result, int) else None
+
+    # ------------------------------------------------------------------
+    # Task 2-5: user / IP blocks
+    # ------------------------------------------------------------------
+
+    def get_blocked_users(self) -> list[UserBlock]:
+        """
+        Get the list of blocked users
+
+        Returns
+        -------
+        list[UserBlock]
+        """
+        module_name = "managesite/blocks/ManageSiteUserBlocksModule"
+        response = self.site.amc_request([{"moduleName": module_name}])[0]
+        html = BeautifulSoup(require_body(response, module_name), "lxml")
+        return UserBlock._parse_all(self.site, html)
+
+    def get_blocked_ips(self) -> list[IpBlock]:
+        """
+        Get the list of blocked IP addresses/ranges
+
+        Returns
+        -------
+        list[IpBlock]
+        """
+        module_name = "managesite/blocks/ManageSiteIpBlocksModule"
+        response = self.site.amc_request([{"moduleName": module_name}])[0]
+        html = BeautifulSoup(require_body(response, module_name), "lxml")
+        return IpBlock._parse_all(self.site, html)
+
+    def block_user(self, user: "AbstractUser | int", reason: str = "") -> None:
+        """
+        Block a user from the site
+
+        Parameters
+        ----------
+        user : AbstractUser | int
+            User to block (or their user ID)
+        reason : str, default ""
+            Block reason (200 characters max per Wikidot's form)
+        """
+        self.site.amc_request(
+            [
+                {
+                    "action": "ManageSiteBlockAction",
+                    "event": "blockUser",
+                    "userId": _user_id(user),
+                    "reason": reason,
+                    "moduleName": "Empty",
+                }
+            ]
+        )
+
+    def unblock_user(self, user: "AbstractUser | int") -> None:
+        """
+        Remove a user block
+
+        Parameters
+        ----------
+        user : AbstractUser | int
+            Blocked user (or their user ID). `deleteBlock`'s `userId` really
+            is a user ID (confirmed 2026-07-29 from
+            `managesite_blocks_ManageSiteUserBlocksModule.js`) -- do not
+            confuse with `unblock_ip`'s `blockId`, which is a block ID
+        """
+        self.site.amc_request(
+            [
+                {
+                    "action": "ManageSiteBlockAction",
+                    "event": "deleteBlock",
+                    "userId": _user_id(user),
+                    "moduleName": "Empty",
+                }
+            ]
+        )
+
+    def block_ip(self, ips: str, reason: str = "") -> None:
+        """
+        Block one or more IP addresses/ranges
+
+        Parameters
+        ----------
+        ips : str
+            IP addresses/ranges, one per line (matches the `ips` textarea)
+        reason : str, default ""
+            Block reason (200 characters max per Wikidot's form)
+        """
+        self.site.amc_request(
+            [
+                {
+                    "action": "ManageSiteBlockAction",
+                    "event": "blockIp",
+                    "ips": ips,
+                    "reason": reason,
+                    "moduleName": "Empty",
+                }
+            ]
+        )
+
+    def unblock_ip(self, block_id: int) -> None:
+        """
+        Remove an IP block
+
+        Parameters
+        ----------
+        block_id : int
+            Block ID (from `get_blocked_ips()`). `deleteIpBlock`'s `blockId`
+            is a block ID, not an IP or user ID -- asymmetric with
+            `unblock_user`'s `userId`, do not confuse the two
+        """
+        self.site.amc_request(
+            [
+                {
+                    "action": "ManageSiteBlockAction",
+                    "event": "deleteIpBlock",
+                    "blockId": block_id,
+                    "moduleName": "Empty",
+                }
+            ]
+        )
+
+    # ------------------------------------------------------------------
+    # Task 2-6: abuse-flag clearing / members auto-watching / block-link
+    # ------------------------------------------------------------------
+
+    def clear_user_flags(self, user: "AbstractUser | int") -> None:
+        """
+        Clear abuse flags reported against a user
+
+        Parameters
+        ----------
+        user : AbstractUser | int
+            User to clear (or their user ID)
+        """
+        self.site.amc_request(
+            [
+                {
+                    "action": "ManageSiteAbuseAction",
+                    "event": "clearUserFlags",
+                    "userId": _user_id(user),
+                    "moduleName": "Empty",
+                }
+            ]
+        )
+
+    def clear_page_flags(self, path: str) -> None:
+        """
+        Clear abuse flags reported against a page
+
+        Parameters
+        ----------
+        path : str
+            Page path
+        """
+        self.site.amc_request(
+            [{"action": "ManageSiteAbuseAction", "event": "clearPageFlags", "path": path, "moduleName": "Empty"}]
+        )
+
+    def clear_anonymous_flags(self, address: str, proxy: bool = False) -> None:
+        """
+        Clear abuse flags reported against an anonymous (IP) address
+
+        Parameters
+        ----------
+        address : str
+            IP address
+        proxy : bool, default False
+            Sent as `proxy="yes"` when True (matching the `?("yes")`
+            notation in 40_admin-managesite.md, the same value Wikidot uses
+            for `removeMember`'s `ban`); omitted when False
+        """
+        body = omit_falsy(proxy="yes" if proxy else False)
+        self.site.amc_request(
+            [
+                {
+                    "action": "ManageSiteAbuseAction",
+                    "event": "clearAnonymousFlags",
+                    "address": address,
+                    "moduleName": "Empty",
+                    **body,
+                }
+            ]
+        )
+
+    def set_members_watching(self, watch_all: bool = False, selected_categories: list[int] | None = None) -> None:
+        """
+        Configure members' automatic watching of new pages
+
+        Parameters
+        ----------
+        watch_all : bool, default False
+            Watch all categories automatically
+        selected_categories : list[int] | None, default None
+            Category IDs to watch when `watch_all` is False. Sent as
+            `selected_categories[]=<id>&...` (the AMC client auto-expands
+            list values into bracket notation; see 30_plan.md D2)
+        """
+        body = omit_falsy(watch_all=checkbox(watch_all))
+        if selected_categories is not None:
+            body["selected_categories"] = selected_categories
+        self.site.amc_request(
+            [
+                {
+                    "action": "ManageSiteMembershipAction",
+                    "event": "saveMembersWatching",
+                    "moduleName": "Empty",
+                    **body,
+                }
+            ]
+        )
+
+    def set_block_link(self, karma_level: int, block_link: bool = False) -> None:
+        """
+        Configure automatic link-blocking by karma level
+
+        Parameters
+        ----------
+        karma_level : int
+            Karma threshold (0-5)
+        block_link : bool, default False
+            Whether to actually block links below the threshold
+        """
+        body = omit_falsy(blockLink=flag(block_link))
+        self.site.amc_request(
+            [
+                {
+                    "action": "ManageSiteAction",
+                    "event": "saveBlockLink",
+                    "karmaLevel": karma_level,
+                    "moduleName": "Empty",
+                    **body,
+                }
+            ]
+        )

--- a/tests/unit/test_site_member.py
+++ b/tests/unit/test_site_member.py
@@ -95,6 +95,41 @@ class TestSiteMemberParse:
             assert len(members) == 1
             assert members[0].joined_at is None
 
+    def test_parse_skips_header_only_row(self):
+        """thのみの見出し行(tdなし)はIndexErrorを起こさずスキップされる
+
+        管理パネル(managesite/members/*)の一覧が持つ先頭のth見出し行を想定
+        (2026-07-29実測)"""
+        html = BeautifulSoup(
+            """
+            <table>
+                <tr><th>Name</th><th>Member since</th><th></th></tr>
+                <tr>
+                    <td><span class="printuser">
+                        <a onclick="WIKIDOT.page.listeners.userInfo(12345)" href="#">Test User</a>
+                    </span></td>
+                    <td><span class="odate time_123456789">2024-01-01</span></td>
+                    <td><div class="btn-group">options</div></td>
+                </tr>
+            </table>
+            """,
+            "lxml",
+        )
+        site = MagicMock()
+        mock_user = MagicMock()
+
+        with (
+            patch("wikidot.module.site_member.user_parser") as mock_user_parser,
+            patch("wikidot.module.site_member.odate_parser") as mock_odate_parser,
+        ):
+            mock_user_parser.return_value = mock_user
+            mock_odate_parser.return_value = datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+            members = SiteMember._parse(site, html)
+
+            assert len(members) == 1
+            assert members[0].joined_at == datetime(2024, 1, 1, tzinfo=timezone.utc)
+
     def test_parse_skips_rows_without_printuser(self):
         """printuserがない行はスキップ"""
         html = BeautifulSoup(

--- a/tests/unit/test_site_member_admin.py
+++ b/tests/unit/test_site_member_admin.py
@@ -144,15 +144,33 @@ class TestRemoveAndChangeMaster:
 class TestInvitations:
     """Task 2-4: 招待"""
 
-    def test_search_users_zips_ids_and_names(self):
+    def test_search_users_looks_up_names_by_id_string(self):
+        """userNames is an object keyed by user ID as a string, not a parallel array
+        (confirmed live 2026-07-29; see 40_admin-managesite.md)"""
         site = MagicMock()
         response = MagicMock()
-        response.json.return_value = {"userIds": [1, 2], "userNames": ["a", "b"]}
+        response.json.return_value = {
+            "userIds": [3396310, 9625925],
+            "userNames": {"3396310": "ukwhatn", "9625925": "ukwhatn Bot - test"},
+        }
         site.amc_request.return_value = [response]
 
         results = MemberAccessor(site).search_users("a")
 
-        assert results == [UserSearchResult(id=1, name="a"), UserSearchResult(id=2, name="b")]
+        assert results == [
+            UserSearchResult(id=3396310, name="ukwhatn"),
+            UserSearchResult(id=9625925, name="ukwhatn Bot - test"),
+        ]
+
+    def test_search_users_missing_name_falls_back_to_empty_string(self):
+        site = MagicMock()
+        response = MagicMock()
+        response.json.return_value = {"userIds": [1], "userNames": {}}
+        site.amc_request.return_value = [response]
+
+        results = MemberAccessor(site).search_users("a")
+
+        assert results == [UserSearchResult(id=1, name="")]
 
     def test_send_email_invitations_encodes_addresses_as_json_array_of_arrays(self):
         site = MagicMock()

--- a/tests/unit/test_site_member_admin.py
+++ b/tests/unit/test_site_member_admin.py
@@ -1,0 +1,351 @@
+"""MemberAccessor（site.member）のユニットテスト"""
+
+from unittest.mock import MagicMock, patch
+
+from wikidot.module.site_block import IpBlock, UserBlock
+from wikidot.module.site_member_admin import MemberAccessor, UserSearchResult, _user_id
+
+
+class TestUserId:
+    """_user_id ヘルパのテスト"""
+
+    def test_int_passthrough(self):
+        assert _user_id(42) == 42
+
+    def test_user_object(self):
+        user = MagicMock()
+        user.id = 42
+        assert _user_id(user) == 42
+
+
+class TestGetPaginated:
+    """管理ビューの一覧取得（Task 2-1）のテスト"""
+
+    def test_single_page(self):
+        site = MagicMock()
+        response = MagicMock()
+        response.json.return_value = {
+            "body": """
+                <table>
+                    <tr>
+                        <td><span class="printuser">
+                            <a onclick="WIKIDOT.page.listeners.userInfo(12345)" href="#">User1</a>
+                        </span></td>
+                    </tr>
+                </table>
+            """
+        }
+        site.amc_request.return_value = [response]
+
+        accessor = MemberAccessor(site)
+        with patch("wikidot.module.site_member.user_parser") as mock_user_parser:
+            mock_user_parser.return_value = MagicMock()
+            members = accessor.get_members()
+
+        assert len(members) == 1
+        call_body = site.amc_request.call_args[0][0][0]
+        assert call_body["moduleName"] == "managesite/members/ManageSiteMembersListModule"
+        assert call_body["page"] == 1
+
+    def test_pagination(self):
+        site = MagicMock()
+        first_response = MagicMock()
+        first_response.json.return_value = {
+            "body": """
+                <table><tr><td><span class="printuser">
+                    <a onclick="WIKIDOT.page.listeners.userInfo(1)" href="#">User1</a>
+                </span></td></tr></table>
+                <div class="pager"><a href="#">1</a><a href="#">2</a><a href="#">next</a></div>
+            """
+        }
+        second_response = MagicMock()
+        second_response.json.return_value = {
+            "body": """
+                <table><tr><td><span class="printuser">
+                    <a onclick="WIKIDOT.page.listeners.userInfo(2)" href="#">User2</a>
+                </span></td></tr></table>
+            """
+        }
+        site.amc_request.side_effect = [[first_response], [second_response]]
+
+        accessor = MemberAccessor(site)
+        with patch("wikidot.module.site_member.user_parser") as mock_user_parser:
+            mock_user_parser.return_value = MagicMock()
+            moderators = accessor.get_moderators()
+
+        assert len(moderators) == 2
+        assert site.amc_request.call_count == 2
+
+    def test_get_admins_uses_admins_module(self):
+        site = MagicMock()
+        response = MagicMock()
+        response.json.return_value = {"body": "<table></table>"}
+        site.amc_request.return_value = [response]
+
+        MemberAccessor(site).get_admins()
+
+        call_body = site.amc_request.call_args[0][0][0]
+        assert call_body["moduleName"] == "managesite/members/ManageSiteAdminsModule"
+
+
+class TestRemoveAndChangeMaster:
+    """Task 2-2: removeMember / changeMaster / moderator permissions"""
+
+    def test_remove_without_ban_omits_key(self):
+        site = MagicMock()
+        MemberAccessor(site).remove(42)
+
+        body = site.amc_request.call_args[0][0][0]
+        assert body["action"] == "ManageSiteMembershipAction"
+        assert body["event"] == "removeMember"
+        assert body["user_id"] == 42
+        assert "ban" not in body
+
+    def test_remove_with_ban_sends_yes(self):
+        site = MagicMock()
+        MemberAccessor(site).remove(42, ban=True)
+
+        body = site.amc_request.call_args[0][0][0]
+        assert body["ban"] == "yes"
+
+    def test_change_master_uses_camel_case_userid(self):
+        site = MagicMock()
+        MemberAccessor(site).change_master(99)
+
+        body = site.amc_request.call_args[0][0][0]
+        assert body["event"] == "changeMaster"
+        assert body["userId"] == 99
+        assert "user_id" not in body
+
+    def test_get_moderator_permissions_form_returns_raw_body(self):
+        site = MagicMock()
+        response = MagicMock()
+        response.json.return_value = {"body": "<form>raw</form>"}
+        site.amc_request.return_value = [response]
+
+        result = MemberAccessor(site).get_moderator_permissions_form(7)
+
+        assert result == {"body": "<form>raw</form>"}
+        call_body = site.amc_request.call_args[0][0][0]
+        assert call_body["moduleName"] == "managesite/ManageSiteModeratorPermissionsModule"
+        assert call_body["moderatorId"] == 7
+
+    def test_save_moderator_permissions_passes_fields_verbatim(self):
+        site = MagicMock()
+        MemberAccessor(site).save_moderator_permissions(foo="bar", baz=1)
+
+        body = site.amc_request.call_args[0][0][0]
+        assert body["action"] == "ManageSiteMembershipAction"
+        assert body["event"] == "saveModeratorPermissions"
+        assert body["foo"] == "bar"
+        assert body["baz"] == 1
+
+
+class TestInvitations:
+    """Task 2-4: 招待"""
+
+    def test_search_users_zips_ids_and_names(self):
+        site = MagicMock()
+        response = MagicMock()
+        response.json.return_value = {"userIds": [1, 2], "userNames": ["a", "b"]}
+        site.amc_request.return_value = [response]
+
+        results = MemberAccessor(site).search_users("a")
+
+        assert results == [UserSearchResult(id=1, name="a"), UserSearchResult(id=2, name="b")]
+
+    def test_send_email_invitations_encodes_addresses_as_json_array_of_arrays(self):
+        site = MagicMock()
+        MemberAccessor(site).send_email_invitations([("a@example.com", "A", True)], message="hi")
+
+        body = site.amc_request.call_args[0][0][0]
+        assert body["addresses"] == '[["a@example.com", "A", true]]'
+        assert body["message"] == "hi"
+
+    def test_delete_email_invitation(self):
+        site = MagicMock()
+        MemberAccessor(site).delete_email_invitation(123)
+
+        body = site.amc_request.call_args[0][0][0]
+        assert body["event"] == "deleteEmailInvitation"
+        assert body["invitationId"] == 123
+
+    def test_resend_email_invitation(self):
+        site = MagicMock()
+        MemberAccessor(site).resend_email_invitation(123, message="again")
+
+        body = site.amc_request.call_args[0][0][0]
+        assert body["event"] == "resendEmailInvitation"
+        assert body["invitationId"] == 123
+        assert body["message"] == "again"
+
+    def test_set_let_users_invite_always_sends_string_bool(self):
+        site = MagicMock()
+        MemberAccessor(site).set_let_users_invite(False)
+
+        body = site.amc_request.call_args[0][0][0]
+        assert body["enableLetUsersInvite"] == "false"
+
+    def test_invite_admin_returns_user_id(self):
+        site = MagicMock()
+        response = MagicMock()
+        response.json.return_value = {"result": "invited", "userId": 55}
+        site.amc_request.return_value = [response]
+
+        result = MemberAccessor(site).invite_admin(55)
+
+        assert result == 55
+        body = site.amc_request.call_args[0][0][0]
+        assert body["action"] == "ManageSiteAction"
+        assert body["event"] == "inviteAdmin"
+        assert body["user_id"] == 55
+
+
+class TestBlocks:
+    """Task 2-5: ブロック"""
+
+    def test_get_blocked_users_parses_rows(self):
+        site = MagicMock()
+        response = MagicMock()
+        response.json.return_value = {
+            "body": """
+                <table><tr>
+                    <td><span class="printuser">
+                        <a onclick="WIKIDOT.page.listeners.userInfo(1)" href="#">U1</a>
+                    </span></td>
+                    <td>spam</td>
+                </tr></table>
+            """
+        }
+        site.amc_request.return_value = [response]
+
+        with patch("wikidot.module.site_block.user_parser") as mock_user_parser:
+            mock_user_parser.return_value = MagicMock()
+            blocks = MemberAccessor(site).get_blocked_users()
+
+        assert len(blocks) == 1
+        assert isinstance(blocks[0], UserBlock)
+        assert blocks[0].reason == "spam"
+        call_body = site.amc_request.call_args[0][0][0]
+        assert call_body["moduleName"] == "managesite/blocks/ManageSiteUserBlocksModule"
+
+    def test_get_blocked_ips_extracts_block_id_from_onclick(self):
+        site = MagicMock()
+        response = MagicMock()
+        response.json.return_value = {
+            "body": """
+                <table><tr>
+                    <td>1.2.3.4</td>
+                    <td>
+                        <a onclick="WIKIDOT.modules.ManageSiteIpBlocksModule.listeners.deleteBlock(event, 999, 'x')">unblock</a>
+                    </td>
+                    <td>abuse</td>
+                </tr></table>
+            """
+        }
+        site.amc_request.return_value = [response]
+
+        blocks = MemberAccessor(site).get_blocked_ips()
+
+        assert len(blocks) == 1
+        assert isinstance(blocks[0], IpBlock)
+        assert blocks[0].block_id == 999
+        assert blocks[0].ip == "1.2.3.4"
+        assert blocks[0].reason == "abuse"
+
+    def test_block_user(self):
+        site = MagicMock()
+        MemberAccessor(site).block_user(1, reason="spam")
+
+        body = site.amc_request.call_args[0][0][0]
+        assert body["action"] == "ManageSiteBlockAction"
+        assert body["event"] == "blockUser"
+        assert body["userId"] == 1
+        assert body["reason"] == "spam"
+
+    def test_unblock_user_uses_user_id_not_block_id(self):
+        site = MagicMock()
+        MemberAccessor(site).unblock_user(1)
+
+        body = site.amc_request.call_args[0][0][0]
+        assert body["event"] == "deleteBlock"
+        assert body["userId"] == 1
+
+    def test_block_ip(self):
+        site = MagicMock()
+        MemberAccessor(site).block_ip("1.2.3.4", reason="abuse")
+
+        body = site.amc_request.call_args[0][0][0]
+        assert body["event"] == "blockIp"
+        assert body["ips"] == "1.2.3.4"
+
+    def test_unblock_ip_uses_block_id_not_user_id(self):
+        site = MagicMock()
+        MemberAccessor(site).unblock_ip(999)
+
+        body = site.amc_request.call_args[0][0][0]
+        assert body["event"] == "deleteIpBlock"
+        assert body["blockId"] == 999
+        assert "userId" not in body
+
+
+class TestAbuseAndWatching:
+    """Task 2-6: フラグ解除・自動監視・ブロックリンク"""
+
+    def test_clear_user_flags(self):
+        site = MagicMock()
+        MemberAccessor(site).clear_user_flags(1)
+
+        body = site.amc_request.call_args[0][0][0]
+        assert body["action"] == "ManageSiteAbuseAction"
+        assert body["event"] == "clearUserFlags"
+        assert body["userId"] == 1
+
+    def test_clear_page_flags(self):
+        site = MagicMock()
+        MemberAccessor(site).clear_page_flags("component:scp-173")
+
+        body = site.amc_request.call_args[0][0][0]
+        assert body["event"] == "clearPageFlags"
+        assert body["path"] == "component:scp-173"
+
+    def test_clear_anonymous_flags_without_proxy_omits_key(self):
+        site = MagicMock()
+        MemberAccessor(site).clear_anonymous_flags("1.2.3.4")
+
+        body = site.amc_request.call_args[0][0][0]
+        assert body["address"] == "1.2.3.4"
+        assert "proxy" not in body
+
+    def test_clear_anonymous_flags_with_proxy_sends_yes(self):
+        site = MagicMock()
+        MemberAccessor(site).clear_anonymous_flags("1.2.3.4", proxy=True)
+
+        body = site.amc_request.call_args[0][0][0]
+        assert body["proxy"] == "yes"
+
+    def test_set_members_watching_with_categories(self):
+        site = MagicMock()
+        MemberAccessor(site).set_members_watching(watch_all=False, selected_categories=[1, 2])
+
+        body = site.amc_request.call_args[0][0][0]
+        assert body["event"] == "saveMembersWatching"
+        assert body["selected_categories"] == [1, 2]
+        assert "watch_all" not in body
+
+    def test_set_members_watching_watch_all(self):
+        site = MagicMock()
+        MemberAccessor(site).set_members_watching(watch_all=True)
+
+        body = site.amc_request.call_args[0][0][0]
+        assert body["watch_all"] == "on"
+
+    def test_set_block_link(self):
+        site = MagicMock()
+        MemberAccessor(site).set_block_link(3, block_link=True)
+
+        body = site.amc_request.call_args[0][0][0]
+        assert body["action"] == "ManageSiteAction"
+        assert body["event"] == "saveBlockLink"
+        assert body["karmaLevel"] == 3
+        assert body["blockLink"] == "true"


### PR DESCRIPTION
## Summary

サイトのメンバー・招待・ブロックを `site.member` から操作できるようにする。

> スタック PR。base は `feature/site-settings`。

## Related Issue

なし

## Changes

- 管理ビューのメンバー / モデレータ / 管理者一覧をページング取得
- メンバー削除、マスター管理者の移譲、モデレータ権限の保存
- 招待（ユーザ検索、メール招待の送信・削除・再送、一般ユーザへの招待許可）
- ユーザ / IP のブロックと解除
- 不正報告フラグの解除、メンバー自動監視、リンクブロック設定

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring
- [x] Test addition/modification
- [ ] CI/CD or build related

## Testing

- [x] `make format` passes
- [x] `make lint` passes
- [x] `make test` passes

## Checklist

- [x] Code follows the project's style guidelines
- [ ] Documentation has been updated as needed
- [x] Tests have been added for the changes (if applicable)

## Additional Information

- `deleteBlock` はユーザ ID、`deleteIpBlock` はブロック ID を取る（非対称）
- `users/UserSearchModule` の `userNames` は `userIds` と並列の配列ではなく、ユーザ ID をキーにしたマップ
- 既存の `SiteMember` パーサがヘッダ行で `IndexError` になる不具合と、3列構造で `joined_at` が常に `None` になる不具合を併せて修正
- ブロック一覧・モデレータ一覧・メンバー一覧のページャは、テストサイトに該当データが無く未実測

README と `llms.txt` は追加した API を反映していない。リリース前にまとめて追随させる。
