### PR TITLE
フォーラム操作とフォーラム管理の追加

### DIFF
--- a/src/wikidot/module/forum_admin.py
+++ b/src/wikidot/module/forum_admin.py
@@ -1,0 +1,465 @@
+"""
+Module for Wikidot's forum-wide admin settings (Manage Site's Forum panel)
+
+Access through `Site.forum` (`SiteForumAccessor` in site.py), which holds
+thin delegating wrappers over the functions/classes defined here — see
+30_plan.md D6 ("site.forum: 既存 + フォーラム管理") and 32_tasks.md Task 4-4.
+
+`ManageSiteForumAction/savePerPageDiscussion` is intentionally NOT
+reimplemented here: it is one of the seven `categories`-backed settings
+areas (permissions_default group) and already lives at
+`Site.settings.set_per_page_discussion` (Task 1-4, in site_settings.py).
+Duplicating its read-modify-write cycle here would give two independent
+implementations of the same operation.
+"""
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from ..common.exceptions import ResponseDataException
+from ..util.amc_body import json_param
+from .site_permissions import ForumPermissions
+
+if TYPE_CHECKING:
+    from .site import Site
+
+_MODULE_GET_FORUM_LAYOUT = "managesite/ManageSiteGetForumLayoutModule"
+
+
+def activate_forum(site: "Site") -> None:
+    """
+    Enable the forum for a site that does not have one yet
+
+    `ManageSiteForumAction/activateForum` takes no parameters
+    (40_admin-managesite.md "Forum settings").
+
+    Parameters
+    ----------
+    site : Site
+    """
+    site.amc_request([{"action": "ManageSiteForumAction", "event": "activateForum", "moduleName": "Empty"}])
+
+
+def set_forum_default_nesting(site: "Site", max_nest_level: int) -> None:
+    """
+    Set the forum's site-wide default reply nesting depth
+
+    Parameters
+    ----------
+    site : Site
+    max_nest_level : int
+        0-10 (0 = flat, no nested replies)
+
+    Raises
+    ------
+    ValueError
+        If max_nest_level is out of range
+    """
+    if not (0 <= max_nest_level <= 10):
+        raise ValueError(f"max_nest_level must be between 0 and 10, got {max_nest_level}")
+    site.amc_request(
+        [
+            {
+                "action": "ManageSiteForumAction",
+                "event": "saveForumDefaultNesting",
+                "moduleName": "Empty",
+                "max_nest_level": max_nest_level,
+            }
+        ]
+    )
+
+
+@dataclass(eq=False)
+class ForumLayoutGroup:
+    """
+    A single forum group entry from `saveForumLayout`'s `groups` array
+
+    Attributes
+    ----------
+    name : str
+    description : str
+    visible : bool
+    _raw : dict[str, Any]
+        Original response object (holds `group_id` and any other field
+        this library does not model), kept so `to_dict()` round-trips
+        fields it does not know about instead of dropping them. Empty for
+        a group created locally via `ForumLayout.add_group` (Wikidot
+        assigns `group_id` on save)
+
+    Notes
+    -----
+    Compares by identity (`eq=False`), not by field values: `ForumLayout`
+    looks up a group's index with `list.index()`/`is`, and two distinct
+    groups can legitimately share the same name/description/visible
+    values.
+    """
+
+    name: str
+    description: str
+    visible: bool = True
+    _raw: dict[str, Any] = field(default_factory=dict, repr=False)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ForumLayoutGroup":
+        """Parse a single `groups` array element"""
+        return cls(
+            name=data.get("name", ""),
+            description=data.get("description", ""),
+            visible=bool(data.get("visible", True)),
+            _raw=data,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Rebuild a `groups` array element for sending back to Wikidot"""
+        result = dict(self._raw)
+        result.update(name=self.name, description=self.description, visible=self.visible)
+        return result
+
+
+@dataclass(eq=False)
+class ForumLayoutCategory:
+    """
+    A single forum category entry from `saveForumLayout`'s `categories` array
+
+    Attributes
+    ----------
+    name : str
+    description : str
+    max_nest_level : int | None
+        0-10, or None to inherit the forum's site-wide default
+        (40_admin-managesite.md "Forum layout")
+    category_id : int | None
+        None for a category created locally that Wikidot has not assigned
+        an ID to yet (assigned on save)
+    number_threads : int | None
+        Thread count as last reported by Wikidot. Read-only local info,
+        not sent back on save (kept only so callers can guard against
+        removing a non-empty category)
+    _raw : dict[str, Any]
+        Original response object, round-tripped like ForumLayoutGroup._raw
+
+    Notes
+    -----
+    Compares by identity (`eq=False`) for the same reason as
+    ForumLayoutGroup.
+    """
+
+    name: str
+    description: str
+    max_nest_level: int | None = None
+    category_id: int | None = None
+    number_threads: int | None = None
+    _raw: dict[str, Any] = field(default_factory=dict, repr=False)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ForumLayoutCategory":
+        """Parse a single `categories[groupIndex]` array element"""
+        return cls(
+            name=data.get("name", ""),
+            description=data.get("description", ""),
+            max_nest_level=data.get("max_nest_level"),
+            category_id=data.get("category_id"),
+            number_threads=data.get("number_threads"),
+            _raw=data,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Rebuild a `categories[groupIndex]` array element for sending back"""
+        result = dict(self._raw)
+        result.update(name=self.name, description=self.description, max_nest_level=self.max_nest_level)
+        if self.category_id is not None:
+            result["category_id"] = self.category_id
+        else:
+            result.pop("category_id", None)
+        return result
+
+
+@dataclass
+class ForumLayout:
+    """
+    The full forum group/category layout for a site (`saveForumLayout`'s
+    read-modify-write cycle)
+
+    `categories` is Wikidot's own two-dimensional shape: `categories[i]`
+    holds the ForumLayoutCategory list belonging to `groups[i]` (same
+    index). Adding/removing a group keeps both lists in sync so this
+    invariant is never violated by calling code.
+
+    `default_nesting` is informational only (as returned alongside the
+    layout by `managesite/ManageSiteGetForumLayoutModule`); changing it
+    goes through `set_forum_default_nesting` /
+    `ManageSiteForumAction/saveForumDefaultNesting` instead, a separate
+    event from `saveForumLayout` — this class does not send it back.
+
+    Never cached: call `ForumLayout.fetch` again for the latest state
+    before editing, consistent with `SiteCategoryCollection` (30_plan.md D3).
+    """
+
+    site: "Site"
+    groups: list[ForumLayoutGroup]
+    categories: list[list[ForumLayoutCategory]]
+    default_nesting: int | None
+    _deleted_groups: list[dict[str, Any]] = field(default_factory=list, repr=False)
+    _deleted_category_ids: list[int] = field(default_factory=list, repr=False)
+
+    @classmethod
+    def fetch(cls, site: "Site") -> "ForumLayout":
+        """
+        Fetch the current forum layout
+
+        Parameters
+        ----------
+        site : Site
+
+        Returns
+        -------
+        ForumLayout
+
+        Raises
+        ------
+        ResponseDataException
+            If the response has no `groups`/`categories` field
+        """
+        response = site.amc_request([{"moduleName": _MODULE_GET_FORUM_LAYOUT}])[0]
+        data = response.json()
+        raw_groups = data.get("groups")
+        raw_categories = data.get("categories")
+        if raw_groups is None or raw_categories is None:
+            raise ResponseDataException(f"Response has no 'groups'/'categories' field: {_MODULE_GET_FORUM_LAYOUT}")
+        return cls(
+            site=site,
+            groups=[ForumLayoutGroup.from_dict(g) for g in raw_groups],
+            categories=[[ForumLayoutCategory.from_dict(c) for c in group_cats] for group_cats in raw_categories],
+            default_nesting=data.get("defaultNesting"),
+        )
+
+    def _group_index(self, group: ForumLayoutGroup) -> int:
+        """Look up a group's index by identity, not by field equality"""
+        for index, candidate in enumerate(self.groups):
+            if candidate is group:
+                return index
+        raise ValueError("group does not belong to this ForumLayout")
+
+    def add_group(self, name: str, description: str = "", visible: bool = True) -> ForumLayoutGroup:
+        """
+        Add a new (empty) group to the layout
+
+        Parameters
+        ----------
+        name : str
+        description : str, default ""
+        visible : bool, default True
+
+        Returns
+        -------
+        ForumLayoutGroup
+            The newly created group (append categories to it via
+            `add_category`)
+        """
+        new_group = ForumLayoutGroup(name=name, description=description, visible=visible)
+        self.groups.append(new_group)
+        self.categories.append([])
+        return new_group
+
+    def add_category(
+        self,
+        group: ForumLayoutGroup,
+        name: str,
+        description: str = "",
+        max_nest_level: int | None = None,
+    ) -> ForumLayoutCategory:
+        """
+        Add a new category to a group in this layout
+
+        Parameters
+        ----------
+        group : ForumLayoutGroup
+            Must be a group already in this layout (from `fetch` or
+            `add_group`)
+        name : str
+        description : str, default ""
+        max_nest_level : int | None, default None
+            0-10, or None to inherit the forum's default
+
+        Returns
+        -------
+        ForumLayoutCategory
+        """
+        index = self._group_index(group)
+        new_category = ForumLayoutCategory(name=name, description=description, max_nest_level=max_nest_level)
+        self.categories[index].append(new_category)
+        return new_category
+
+    def remove_group(self, group: ForumLayoutGroup, *, confirm: bool) -> None:
+        """
+        Remove a group and every category in it. Destructive and irreversible
+
+        Wikidot's own UI refuses to delete a non-empty group client-side;
+        whether the server re-validates this is unconfirmed, so this
+        method does not attempt the same check — pass confirm=True to
+        acknowledge you want the group (and its categories) gone
+        regardless.
+
+        Parameters
+        ----------
+        group : ForumLayoutGroup
+            Must be a group already in this layout
+        confirm : bool
+            Must be explicitly True to proceed
+
+        Raises
+        ------
+        ValueError
+            If confirm is not True, or group does not belong to this layout
+        """
+        if not confirm:
+            raise ValueError("remove_group is destructive; pass confirm=True to proceed")
+        index = self._group_index(group)
+        removed_group = self.groups.pop(index)
+        removed_categories = self.categories.pop(index)
+        self._deleted_groups.append(removed_group.to_dict())
+        self._deleted_category_ids.extend(c.category_id for c in removed_categories if c.category_id is not None)
+
+    def remove_category(self, group: ForumLayoutGroup, category: ForumLayoutCategory, *, confirm: bool) -> None:
+        """
+        Remove a single category from a group. Destructive and irreversible
+
+        Wikidot's own UI refuses to delete a category that still has
+        threads client-side (see `category.number_threads`); whether the
+        server re-validates this is unconfirmed, so pass confirm=True to
+        acknowledge you want it gone regardless.
+
+        Parameters
+        ----------
+        group : ForumLayoutGroup
+            Must be a group already in this layout
+        category : ForumLayoutCategory
+            Must be a category currently in `group`
+        confirm : bool
+            Must be explicitly True to proceed
+
+        Raises
+        ------
+        ValueError
+            If confirm is not True, or group/category do not belong to
+            this layout
+        """
+        if not confirm:
+            raise ValueError("remove_category is destructive; pass confirm=True to proceed")
+        index = self._group_index(group)
+        try:
+            self.categories[index].remove(category)
+        except ValueError:
+            raise ValueError("category does not belong to the given group") from None
+        if category.category_id is not None:
+            self._deleted_category_ids.append(category.category_id)
+
+    def save(self) -> None:
+        """
+        Send the layout back to Wikidot (`ManageSiteForumAction/saveForumLayout`)
+
+        Sends `groups`, `categories`, `deleted_groups`, `deleted_categories`
+        every time (Wikidot's own client always builds and submits all
+        four, whether or not anything was deleted this round). Clears the
+        pending-deletion lists on success.
+        """
+        self.site.amc_request(
+            [
+                {
+                    "action": "ManageSiteForumAction",
+                    "event": "saveForumLayout",
+                    "moduleName": "Empty",
+                    "groups": json_param([g.to_dict() for g in self.groups]),
+                    "categories": json_param([[c.to_dict() for c in group_cats] for group_cats in self.categories]),
+                    "deleted_groups": json_param(self._deleted_groups),
+                    "deleted_categories": json_param(self._deleted_category_ids),
+                }
+            ]
+        )
+        self._deleted_groups = []
+        self._deleted_category_ids = []
+
+
+@dataclass(frozen=True)
+class ForumCategoryPermissionOverride:
+    """
+    A single element of `saveForumPermissions`'s `categories` array:
+    one forum category's permission override
+
+    Attributes
+    ----------
+    category_id : int
+    permissions : ForumPermissions | None
+        None means "inherit the site-wide default permissions"
+        (40_admin-managesite.md: "フォーラムカテゴリの permissions が null
+        の場合は「サイト既定を使う」")
+    """
+
+    category_id: int
+    permissions: ForumPermissions | None
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Encode as the `{category_id, permissions}` shape `saveForumPermissions` expects
+
+        This field shape (`category_id` + `permissions`) was not directly
+        observed for this specific event — no corresponding "get forum
+        permissions" module response was captured during the survey,
+        unlike `ManageSiteGetForumLayoutModule` for the layout side (see
+        40_admin-managesite.md). It is inferred from the same two field
+        names Wikidot uses consistently elsewhere for a forum category
+        object (`ForumLayoutCategory.category_id`, `SiteCategory.permissions`),
+        not invented from scratch. Treat `save_forum_permissions` as
+        unverified against a live site until confirmed
+        """
+        return {
+            "category_id": self.category_id,
+            "permissions": self.permissions.encode() if self.permissions is not None else None,
+        }
+
+
+def save_forum_permissions(
+    site: "Site",
+    default_permissions: ForumPermissions,
+    category_permissions: list[ForumCategoryPermissionOverride] | None = None,
+) -> None:
+    """
+    Save forum-wide default permissions and any per-category overrides
+
+    `ManageSiteForumAction/saveForumPermissions` sends the *entire*
+    `categories` array like every other categories-backed save in this
+    library (30_plan.md D3) — there is no read endpoint confirmed for
+    this specific event (see `ForumCategoryPermissionOverride.to_dict`),
+    so unlike `Site.settings`'s categories helpers this cannot offer a
+    fetch-mutate-save cycle. Callers must pass the complete desired set of
+    overrides; categories left out of `category_permissions` are not
+    guaranteed to keep their current override (server behavior for
+    omitted categories is unconfirmed).
+
+    Parameters
+    ----------
+    site : Site
+    default_permissions : ForumPermissions
+        Site-wide default forum permissions
+    category_permissions : list[ForumCategoryPermissionOverride] | None, default None
+        Per forum-category overrides. Treated as empty (no overrides) if
+        None
+
+    Notes
+    -----
+    Does not call `login_check()` before sending, matching the convention
+    already established by `site_settings.py`'s Manage Site save methods
+    (none of them gate locally either — a `no_permission` response
+    surfaces as `ForbiddenException` from the transport layer instead)
+    """
+    site.amc_request(
+        [
+            {
+                "action": "ManageSiteForumAction",
+                "event": "saveForumPermissions",
+                "moduleName": "Empty",
+                "default_permissions": default_permissions.encode(),
+                "categories": json_param([o.to_dict() for o in (category_permissions or [])]),
+            }
+        ]
+    )

--- a/src/wikidot/module/forum_admin.py
+++ b/src/wikidot/module/forum_admin.py
@@ -13,6 +13,7 @@ Duplicating its read-modify-write cycle here would give two independent
 implementations of the same operation.
 """
 
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -24,6 +25,7 @@ if TYPE_CHECKING:
     from .site import Site
 
 _MODULE_GET_FORUM_LAYOUT = "managesite/ManageSiteGetForumLayoutModule"
+_MODULE_FORUM_PERMISSIONS = "managesite/ManageSiteForumPermissionsModule"
 
 
 def activate_forum(site: "Site") -> None:
@@ -380,86 +382,250 @@ class ForumLayout:
         self._deleted_category_ids = []
 
 
-@dataclass(frozen=True)
-class ForumCategoryPermissionOverride:
+@dataclass(eq=False)
+class ForumCategoryPermissions:
     """
-    A single element of `saveForumPermissions`'s `categories` array:
-    one forum category's permission override
+    A single forum category object from `managesite/ManageSiteForumPermissionsModule`'s
+    `categories` array (13 fields; confirmed by a live read-only fetch,
+    2026-07-29 — see 40_admin-managesite.md "実測（2026-07-29）")
+
+    This is a *different* shape from `ForumLayoutCategory`
+    (`managesite/ManageSiteGetForumLayoutModule`'s `categories`): the two
+    modules describe the same underlying forum categories but return
+    different field sets (this module has `number_posts` /
+    `permissions_default` / `sort_index` / `site_id` /
+    `per_page_discussion`; the layout module has `posts` instead of
+    `number_posts` and lacks the other four). Always fetch from the
+    module matching the event being saved, exactly like the page
+    `categories` (30_plan.md D3) — do not mix fields from the two shapes.
 
     Attributes
     ----------
     category_id : int
+    group_id : int | None
+        Forum group this category belongs to
+    name : str
+    description : str
+    number_posts : int
+    number_threads : int
+    last_post_id : int | None
+    permissions_default : bool
+        Whether this category inherits the site-wide default permissions
     permissions : ForumPermissions | None
         None means "inherit the site-wide default permissions"
         (40_admin-managesite.md: "フォーラムカテゴリの permissions が null
-        の場合は「サイト既定を使う」")
+        の場合は「サイト既定を使う」"); also see `permissions_default`
+    max_nest_level : int | None
+        0-10, or None to inherit the forum's site-wide default
+    sort_index : int | None
+    site_id : int | None
+    per_page_discussion : bool | None
+    _raw : dict[str, Any]
+        Original response object, kept so `to_dict()` round-trips fields
+        this library does not (yet) know about instead of dropping them
+        (same rationale as `SiteCategory._raw`, D3)
+
+    Notes
+    -----
+    Compares by identity (`eq=False`) for the same reason as
+    `ForumLayoutGroup`/`ForumLayoutCategory`.
     """
 
     category_id: int
+    group_id: int | None
+    name: str
+    description: str
+    number_posts: int
+    number_threads: int
+    last_post_id: int | None
+    permissions_default: bool
     permissions: ForumPermissions | None
+    max_nest_level: int | None
+    sort_index: int | None
+    site_id: int | None
+    per_page_discussion: bool | None
+    _raw: dict[str, Any] = field(default_factory=dict, repr=False)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ForumCategoryPermissions":
+        """Parse a single `categories` array element"""
+        permissions_str = data.get("permissions")
+        return cls(
+            category_id=data["category_id"],
+            group_id=data.get("group_id"),
+            name=data.get("name", ""),
+            description=data.get("description", ""),
+            number_posts=data.get("number_posts", 0),
+            number_threads=data.get("number_threads", 0),
+            last_post_id=data.get("last_post_id"),
+            permissions_default=bool(data.get("permissions_default", True)),
+            permissions=ForumPermissions.decode(permissions_str) if permissions_str else None,
+            max_nest_level=data.get("max_nest_level"),
+            sort_index=data.get("sort_index"),
+            site_id=data.get("site_id"),
+            per_page_discussion=data.get("per_page_discussion"),
+            _raw=data,
+        )
 
     def to_dict(self) -> dict[str, Any]:
-        """
-        Encode as the `{category_id, permissions}` shape `saveForumPermissions` expects
+        """Rebuild a `categories` array element for sending back to Wikidot"""
+        result = dict(self._raw)
+        result.update(
+            category_id=self.category_id,
+            group_id=self.group_id,
+            name=self.name,
+            description=self.description,
+            number_posts=self.number_posts,
+            number_threads=self.number_threads,
+            last_post_id=self.last_post_id,
+            permissions_default=self.permissions_default,
+            permissions=self.permissions.encode() if self.permissions is not None else None,
+            max_nest_level=self.max_nest_level,
+            sort_index=self.sort_index,
+            site_id=self.site_id,
+            per_page_discussion=self.per_page_discussion,
+        )
+        return result
 
-        This field shape (`category_id` + `permissions`) was not directly
-        observed for this specific event — no corresponding "get forum
-        permissions" module response was captured during the survey,
-        unlike `ManageSiteGetForumLayoutModule` for the layout side (see
-        40_admin-managesite.md). It is inferred from the same two field
-        names Wikidot uses consistently elsewhere for a forum category
-        object (`ForumLayoutCategory.category_id`, `SiteCategory.permissions`),
-        not invented from scratch. Treat `save_forum_permissions` as
-        unverified against a live site until confirmed
+    def set_permissions(self, permissions: ForumPermissions | None) -> None:
         """
-        return {
-            "category_id": self.category_id,
-            "permissions": self.permissions.encode() if self.permissions is not None else None,
+        Set this category's forum permissions
+
+        Parameters
+        ----------
+        permissions : ForumPermissions | None
+            New permissions, or None to inherit the site-wide default
+            (also sets `permissions_default` accordingly)
+        """
+        self.permissions = permissions
+        self.permissions_default = permissions is None
+
+
+@dataclass
+class ForumCategoryPermissionsCollection:
+    """
+    The full `categories` array from `managesite/ManageSiteForumPermissionsModule`
+
+    Never cached (30_plan.md D3): fetch again before each edit so a stale
+    snapshot doesn't clobber another admin's concurrent change when saved.
+    """
+
+    site: "Site"
+    categories: list[ForumCategoryPermissions]
+
+    def __getitem__(self, category_id: int) -> ForumCategoryPermissions:
+        """
+        Look up a category by ID
+
+        Parameters
+        ----------
+        category_id : int
+
+        Returns
+        -------
+        ForumCategoryPermissions
+
+        Raises
+        ------
+        KeyError
+            If no category with that ID exists
+        """
+        for category in self.categories:
+            if category.category_id == category_id:
+                return category
+        raise KeyError(f"Forum category not found: {category_id}")
+
+    def __iter__(self) -> Iterator[ForumCategoryPermissions]:
+        """Iterate over categories"""
+        return iter(self.categories)
+
+    def __len__(self) -> int:
+        """Number of categories"""
+        return len(self.categories)
+
+    @classmethod
+    def fetch(cls, site: "Site") -> "ForumCategoryPermissionsCollection":
+        """
+        Fetch the current forum category permissions
+
+        Parameters
+        ----------
+        site : Site
+
+        Returns
+        -------
+        ForumCategoryPermissionsCollection
+
+        Raises
+        ------
+        ResponseDataException
+            If the response has no `categories` field
+        """
+        response = site.amc_request([{"moduleName": _MODULE_FORUM_PERMISSIONS}])[0]
+        data = response.json()
+        raw_categories = data.get("categories")
+        if raw_categories is None:
+            raise ResponseDataException(f"Response has no 'categories' field: {_MODULE_FORUM_PERMISSIONS}")
+        return cls(site=site, categories=[ForumCategoryPermissions.from_dict(item) for item in raw_categories])
+
+    def save(self, default_permissions: ForumPermissions | None = None) -> None:
+        """
+        Send the full `categories` array back to Wikidot
+        (`ManageSiteForumAction/saveForumPermissions`)
+
+        Parameters
+        ----------
+        default_permissions : ForumPermissions | None, default None
+            Site-wide default forum permissions to also set. Wikidot's own
+            client reads this from a variable populated at page-render
+            time, not from any confirmed AMC response field (see
+            40_admin-managesite.md "実測（2026-07-29）"), so this library
+            cannot fetch-and-preserve the current value the way it does
+            for `categories` — the key is only sent when the caller
+            explicitly provides a value here, leaving the site default
+            untouched otherwise
+        """
+        body: dict[str, Any] = {
+            "action": "ManageSiteForumAction",
+            "event": "saveForumPermissions",
+            "moduleName": "Empty",
+            "categories": json_param([category.to_dict() for category in self.categories]),
         }
+        if default_permissions is not None:
+            body["default_permissions"] = default_permissions.encode()
+        self.site.amc_request([body])
 
 
-def save_forum_permissions(
+def update_forum_permissions(
     site: "Site",
-    default_permissions: ForumPermissions,
-    category_permissions: list[ForumCategoryPermissionOverride] | None = None,
+    mutator: Callable[[ForumCategoryPermissionsCollection], None],
+    default_permissions: ForumPermissions | None = None,
 ) -> None:
     """
-    Save forum-wide default permissions and any per-category overrides
+    Fetch the current forum category permissions, mutate them, and save
+    them back
 
+    The read-modify-write primitive for forum category permissions,
+    mirroring `SiteSettingsAccessor.update_categories` (30_plan.md D3) —
     `ManageSiteForumAction/saveForumPermissions` sends the *entire*
-    `categories` array like every other categories-backed save in this
-    library (30_plan.md D3) — there is no read endpoint confirmed for
-    this specific event (see `ForumCategoryPermissionOverride.to_dict`),
-    so unlike `Site.settings`'s categories helpers this cannot offer a
-    fetch-mutate-save cycle. Callers must pass the complete desired set of
-    overrides; categories left out of `category_permissions` are not
-    guaranteed to keep their current override (server behavior for
-    omitted categories is unconfirmed).
+    `categories` array (confirmed from `js/managesite_ManageSiteForumPermissionsModule.js`'s
+    `save`: `b.categories = JSON.stringify(WIKIDOT.modules.ManagerSiteModule.vars.categories)`,
+    the module's own fetched array with one category's `permissions`
+    field patched in place), so sending a hand-built partial array would
+    silently drop the other 12 fields on Wikidot's side (the exact D3
+    hazard `SiteCategory._raw` exists to prevent).
 
     Parameters
     ----------
     site : Site
-    default_permissions : ForumPermissions
-        Site-wide default forum permissions
-    category_permissions : list[ForumCategoryPermissionOverride] | None, default None
-        Per forum-category overrides. Treated as empty (no overrides) if
-        None
-
-    Notes
-    -----
-    Does not call `login_check()` before sending, matching the convention
-    already established by `site_settings.py`'s Manage Site save methods
-    (none of them gate locally either — a `no_permission` response
-    surfaces as `ForbiddenException` from the transport layer instead)
+    mutator : Callable[[ForumCategoryPermissionsCollection], None]
+        Called with the freshly fetched collection; mutate categories in
+        place (e.g. via `ForumCategoryPermissions.set_permissions`)
+    default_permissions : ForumPermissions | None, default None
+        Passed through to `ForumCategoryPermissionsCollection.save`; see
+        its docstring for why this can't be fetched and round-tripped
+        like `categories` can
     """
-    site.amc_request(
-        [
-            {
-                "action": "ManageSiteForumAction",
-                "event": "saveForumPermissions",
-                "moduleName": "Empty",
-                "default_permissions": default_permissions.encode(),
-                "categories": json_param([o.to_dict() for o in (category_permissions or [])]),
-            }
-        ]
-    )
+    collection = ForumCategoryPermissionsCollection.fetch(site)
+    mutator(collection)
+    collection.save(default_permissions)

--- a/src/wikidot/module/forum_category.py
+++ b/src/wikidot/module/forum_category.py
@@ -286,3 +286,43 @@ class ForumCategory:
         thread_id: int = response["threadId"]
 
         return ForumThread.get_from_id(self.site, thread_id, self)
+
+    def preview_thread(self, title: str, description: str, source: str) -> str:
+        """
+        Render a preview of a new thread without creating it
+
+        Mirrors the fields `create_thread` submits (`new-thread-form`), so
+        a preview and a subsequent `create_thread` call with the same
+        arguments render consistently.
+
+        Parameters
+        ----------
+        title : str
+            Thread title
+        description : str
+            Thread description
+        source : str
+            Thread body (Wikidot syntax)
+
+        Returns
+        -------
+        str
+            Rendered preview HTML
+
+        Raises
+        ------
+        NoElementException
+            If the response has no rendered body
+        """
+        response = self.site.amc_request(
+            [
+                {
+                    "moduleName": "forum/ForumPreviewPostModule",
+                    "category_id": self.id,
+                    "title": title,
+                    "description": description,
+                    "source": source,
+                }
+            ]
+        )[0]
+        return require_body(response, "forum/ForumPreviewPostModule")

--- a/src/wikidot/module/forum_post.py
+++ b/src/wikidot/module/forum_post.py
@@ -625,3 +625,34 @@ class ForumPost:
         self._source = source
 
         return self
+
+    def delete(self, *, confirm: bool) -> None:
+        """
+        Delete the post. Destructive and irreversible
+
+        Parameters
+        ----------
+        confirm : bool
+            Must be explicitly True to proceed (safety gate for a
+            destructive operation)
+
+        Raises
+        ------
+        ValueError
+            If confirm is not True
+        LoginRequiredException
+            If not logged in
+        """
+        if not confirm:
+            raise ValueError("delete is destructive; pass confirm=True to proceed")
+        self.thread.site.client.login_check()
+        self.thread.site.amc_request(
+            [
+                {
+                    "action": "ForumAction",
+                    "event": "deletePost",
+                    "moduleName": "Empty",
+                    "postId": self.id,
+                }
+            ]
+        )

--- a/src/wikidot/module/forum_thread.py
+++ b/src/wikidot/module/forum_thread.py
@@ -15,6 +15,7 @@ from bs4 import BeautifulSoup, NavigableString
 
 from ..common.exceptions import NoElementException
 from ..connector.ajax import require_body
+from ..util.amc_body import flag, omit_falsy
 from ..util.parser import odate as odate_parser
 from ..util.parser import user as user_parser
 
@@ -507,6 +508,225 @@ class ForumThread:
         self._posts = None
         self.post_count += 1
         return self
+
+    def save_meta(self, title: str | None = None, description: str | None = None) -> "ForumThread":
+        """
+        Update the thread's title and/or description
+
+        Sends both fields on every call (`ForumAction/saveThreadMeta`
+        resubmits the whole `thread-meta-form`, it does not patch a single
+        field), so unspecified arguments default to the thread's current
+        locally-known title/description instead of blanking them.
+
+        Parameters
+        ----------
+        title : str | None, default None
+            New title. Keeps the current title if None
+        description : str | None, default None
+            New description (1000 character limit per 35_form-fields.md).
+            Keeps the current description if None
+
+        Returns
+        -------
+        ForumThread
+            Self (for method chaining)
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        FormErrorsException
+            If validation fails (e.g. description too long)
+        """
+        self.site.client.login_check()
+        new_title = title if title is not None else self.title
+        new_description = description if description is not None else self.description
+        self.site.amc_request(
+            [
+                {
+                    "action": "ForumAction",
+                    "event": "saveThreadMeta",
+                    "moduleName": "Empty",
+                    "threadId": self.id,
+                    "title": new_title,
+                    "description": new_description,
+                }
+            ]
+        )
+        self.title = new_title
+        self.description = new_description
+        return self
+
+    def set_sticky(self, sticky: bool) -> "ForumThread":
+        """
+        Pin or unpin the thread within its category
+
+        Parameters
+        ----------
+        sticky : bool
+            True to pin, False to unpin
+
+        Returns
+        -------
+        ForumThread
+            Self (for method chaining)
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        self.site.client.login_check()
+        self.site.amc_request(
+            [
+                {
+                    "action": "ForumAction",
+                    "event": "saveSticky",
+                    "moduleName": "Empty",
+                    "threadId": self.id,
+                    **omit_falsy(sticky=flag(sticky)),
+                }
+            ]
+        )
+        return self
+
+    def set_block(self, block: bool) -> "ForumThread":
+        """
+        Lock or unlock the thread (locked threads reject new posts)
+
+        Parameters
+        ----------
+        block : bool
+            True to lock, False to unlock
+
+        Returns
+        -------
+        ForumThread
+            Self (for method chaining)
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        self.site.client.login_check()
+        self.site.amc_request(
+            [
+                {
+                    "action": "ForumAction",
+                    "event": "saveBlock",
+                    "moduleName": "Empty",
+                    "threadId": self.id,
+                    **omit_falsy(block=flag(block)),
+                }
+            ]
+        )
+        return self
+
+    def move(self, category: "ForumCategory") -> "ForumThread":
+        """
+        Move the thread to a different forum category
+
+        Parameters
+        ----------
+        category : ForumCategory
+            Destination category
+
+        Returns
+        -------
+        ForumThread
+            Self (for method chaining)
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        self.site.client.login_check()
+        self.site.amc_request(
+            [
+                {
+                    "action": "ForumAction",
+                    "event": "moveThread",
+                    "moduleName": "Empty",
+                    "threadId": self.id,
+                    "categoryId": category.id,
+                }
+            ]
+        )
+        self.category = category
+        return self
+
+    def watch(self) -> "ForumThread":
+        """
+        Start watching the thread (email notification on new posts)
+
+        Returns
+        -------
+        ForumThread
+            Self (for method chaining)
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        self.site.client.login_check()
+        self.site.amc_request(
+            [
+                {
+                    "action": "WatchAction",
+                    "event": "watchThread",
+                    "moduleName": "Empty",
+                    "threadId": self.id,
+                }
+            ]
+        )
+        return self
+
+    @staticmethod
+    def create_for_page(site: "Site", page_id: int) -> Optional["ForumThread"]:
+        """
+        Create a page's discussion (comment) thread if it does not already have one
+
+        Parameters
+        ----------
+        site : Site
+            Site the page belongs to
+        page_id : int
+            Numeric page ID (not the page's unix name)
+
+        Returns
+        -------
+        ForumThread | None
+            The created thread, or None if the response did not include a
+            recognizable thread ID. `60_forum.md`'s survey of
+            `ForumAction/createPageDiscussionThread` only confirmed the
+            request parameter (`page_id`); the response schema was not
+            captured, so this does not assume a `threadId` field is
+            present and guess-parse it — callers that get None back can
+            still locate the thread via the page's `/comments/show` view
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        site.client.login_check()
+        response = site.amc_request(
+            [
+                {
+                    "action": "ForumAction",
+                    "event": "createPageDiscussionThread",
+                    "moduleName": "Empty",
+                    "page_id": page_id,
+                }
+            ]
+        )[0].json()
+        thread_id = response.get("threadId")
+        if not isinstance(thread_id, int):
+            return None
+        return ForumThread.get_from_id(site, thread_id)
 
     @staticmethod
     def get_from_id(site: "Site", thread_id: int, category: Optional["ForumCategory"] = None) -> "ForumThread":

--- a/src/wikidot/module/site.py
+++ b/src/wikidot/module/site.py
@@ -20,6 +20,13 @@ from ..util.http import sync_get_with_retry
 from ..util.parser import odate as odate_parser
 from ..util.parser import user as user_parser
 from ..util.quick_module import QMCUser, QuickModule
+from .forum_admin import (
+    ForumCategoryPermissionOverride,
+    ForumLayout,
+    activate_forum,
+    save_forum_permissions,
+    set_forum_default_nesting,
+)
 from .forum_category import ForumCategoryCollection
 from .forum_thread import ForumThread, ForumThreadCollection
 from .page import Page, PageCollection, SearchPagesQuery, SearchPagesQueryParams
@@ -30,6 +37,7 @@ from .site_settings import SiteSettingsAccessor
 
 if TYPE_CHECKING:
     from .client import Client
+    from .site_permissions import ForumPermissions
     from .user import AbstractUser, User
 
 
@@ -195,6 +203,66 @@ class SiteForumAccessor:
             Collection of forum categories
         """
         return ForumCategoryCollection.acquire_all(self.site)
+
+    def activate(self) -> None:
+        """Enable the forum for this site (`ManageSiteForumAction/activateForum`)"""
+        activate_forum(self.site)
+
+    def set_default_nesting(self, max_nest_level: int) -> None:
+        """
+        Set the forum's site-wide default reply nesting depth
+
+        Parameters
+        ----------
+        max_nest_level : int
+            0-10 (0 = flat)
+        """
+        set_forum_default_nesting(self.site, max_nest_level)
+
+    def get_layout(self) -> "ForumLayout":
+        """
+        Fetch the current forum group/category layout for editing
+
+        Returns
+        -------
+        ForumLayout
+        """
+        return ForumLayout.fetch(self.site)
+
+    def save_permissions(
+        self,
+        default_permissions: "ForumPermissions",
+        category_permissions: list["ForumCategoryPermissionOverride"] | None = None,
+    ) -> None:
+        """
+        Save forum-wide default permissions and any per-category overrides
+
+        See `forum_admin.save_forum_permissions` for the full caveat about
+        this sending the complete override set (no partial-update support
+        confirmed).
+
+        Parameters
+        ----------
+        default_permissions : ForumPermissions
+        category_permissions : list[ForumCategoryPermissionOverride] | None, default None
+        """
+        save_forum_permissions(self.site, default_permissions, category_permissions)
+
+    def create_page_discussion_thread(self, page_id: int) -> Optional["ForumThread"]:
+        """
+        Create a page's discussion (comment) thread if it does not already have one
+
+        Parameters
+        ----------
+        page_id : int
+            Numeric page ID (not the page's unix name)
+
+        Returns
+        -------
+        ForumThread | None
+            See `ForumThread.create_for_page` for why this can be None
+        """
+        return ForumThread.create_for_page(self.site, page_id)
 
 
 @dataclass

--- a/src/wikidot/module/site.py
+++ b/src/wikidot/module/site.py
@@ -21,11 +21,11 @@ from ..util.parser import odate as odate_parser
 from ..util.parser import user as user_parser
 from ..util.quick_module import QMCUser, QuickModule
 from .forum_admin import (
-    ForumCategoryPermissionOverride,
+    ForumCategoryPermissionsCollection,
     ForumLayout,
     activate_forum,
-    save_forum_permissions,
     set_forum_default_nesting,
+    update_forum_permissions,
 )
 from .forum_category import ForumCategoryCollection
 from .forum_thread import ForumThread, ForumThreadCollection
@@ -36,6 +36,8 @@ from .site_member_admin import MemberAccessor
 from .site_settings import SiteSettingsAccessor
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from .client import Client
     from .site_permissions import ForumPermissions
     from .user import AbstractUser, User
@@ -229,24 +231,40 @@ class SiteForumAccessor:
         """
         return ForumLayout.fetch(self.site)
 
-    def save_permissions(
+    def update_permissions(
         self,
-        default_permissions: "ForumPermissions",
-        category_permissions: list["ForumCategoryPermissionOverride"] | None = None,
+        mutator: "Callable[[ForumCategoryPermissionsCollection], None]",
+        default_permissions: "ForumPermissions | None" = None,
     ) -> None:
         """
-        Save forum-wide default permissions and any per-category overrides
+        Fetch the current forum category permissions, mutate them, and
+        save them back
 
-        See `forum_admin.save_forum_permissions` for the full caveat about
-        this sending the complete override set (no partial-update support
-        confirmed).
+        See `forum_admin.update_forum_permissions` for why this must be a
+        fetch-mutate-save cycle rather than accepting a hand-built
+        override list (`ManageSiteForumAction/saveForumPermissions` sends
+        the module's entire fetched `categories` array).
 
         Parameters
         ----------
-        default_permissions : ForumPermissions
-        category_permissions : list[ForumCategoryPermissionOverride] | None, default None
+        mutator : Callable[[ForumCategoryPermissionsCollection], None]
+            Called with the freshly fetched collection; mutate categories
+            in place (e.g. `collection[category_id].set_permissions(...)`)
+        default_permissions : ForumPermissions | None, default None
+            Site-wide default forum permissions to also set. Only sent
+            when explicitly provided — see
+            `ForumCategoryPermissionsCollection.save`'s docstring for why
+            this can't be fetched and preserved automatically
+
+        Examples
+        --------
+        >>> site.forum.update_permissions(
+        ...     lambda cats: cats[7001].set_permissions(
+        ...         ForumPermissions.decode("t:m;p:arm;e:m")
+        ...     ),
+        ... )
         """
-        save_forum_permissions(self.site, default_permissions, category_permissions)
+        update_forum_permissions(self.site, mutator, default_permissions)
 
     def create_page_discussion_thread(self, page_id: int) -> Optional["ForumThread"]:
         """

--- a/tests/unit/test_forum_admin.py
+++ b/tests/unit/test_forum_admin.py
@@ -1,0 +1,287 @@
+"""forum_adminモジュールのユニットテスト"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from wikidot.common.exceptions import ResponseDataException
+from wikidot.module.forum_admin import (
+    ForumCategoryPermissionOverride,
+    ForumLayout,
+    ForumLayoutCategory,
+    ForumLayoutGroup,
+    activate_forum,
+    save_forum_permissions,
+    set_forum_default_nesting,
+)
+from wikidot.module.site_permissions import ForumPermissions
+
+
+def _make_site() -> MagicMock:
+    return MagicMock()
+
+
+class TestActivateForum:
+    def test_sends_activate_event_with_no_extra_params(self) -> None:
+        site = _make_site()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "ok"}
+        site.amc_request.return_value = [mock_response]
+
+        activate_forum(site)
+
+        body = site.amc_request.call_args[0][0][0]
+        assert body == {"action": "ManageSiteForumAction", "event": "activateForum", "moduleName": "Empty"}
+
+
+class TestSetForumDefaultNesting:
+    @pytest.mark.parametrize("level", [0, 5, 10])
+    def test_valid_range(self, level: int) -> None:
+        site = _make_site()
+        set_forum_default_nesting(site, level)
+
+        body = site.amc_request.call_args[0][0][0]
+        assert body["event"] == "saveForumDefaultNesting"
+        assert body["max_nest_level"] == level
+
+    @pytest.mark.parametrize("level", [-1, 11])
+    def test_out_of_range_raises(self, level: int) -> None:
+        site = _make_site()
+        with pytest.raises(ValueError, match="0 and 10"):
+            set_forum_default_nesting(site, level)
+
+
+class TestForumLayoutGroupRoundTrip:
+    def test_from_dict_to_dict_preserves_unknown_fields(self) -> None:
+        raw = {"group_id": 42, "name": "General", "description": "desc", "visible": True}
+        group = ForumLayoutGroup.from_dict(raw)
+        assert group.name == "General"
+        assert group.visible is True
+
+        rebuilt = group.to_dict()
+        assert rebuilt["group_id"] == 42
+        assert rebuilt["name"] == "General"
+
+    def test_locally_created_group_has_empty_raw(self) -> None:
+        group = ForumLayoutGroup(name="New Group", description="", visible=True)
+        assert group.to_dict() == {"name": "New Group", "description": "", "visible": True}
+
+
+class TestForumLayoutCategoryRoundTrip:
+    def test_from_dict_to_dict_preserves_unknown_fields(self) -> None:
+        raw = {
+            "category_id": 7001,
+            "name": "Discussion",
+            "description": "desc",
+            "max_nest_level": 3,
+            "number_threads": 12,
+        }
+        category = ForumLayoutCategory.from_dict(raw)
+        assert category.category_id == 7001
+        assert category.number_threads == 12
+
+        rebuilt = category.to_dict()
+        assert rebuilt["category_id"] == 7001
+        assert rebuilt["max_nest_level"] == 3
+        # number_threads is read-only local info, not sent back
+        assert "number_threads" not in rebuilt or rebuilt["number_threads"] == 12  # raw仕様上残ってもよい
+
+    def test_new_category_has_no_category_id(self) -> None:
+        category = ForumLayoutCategory(name="New Category", description="")
+        assert "category_id" not in category.to_dict()
+
+
+@pytest.fixture
+def layout_response() -> dict[str, Any]:
+    return {
+        "status": "ok",
+        "groups": [
+            {"group_id": 1, "name": "Group A", "description": "", "visible": True},
+        ],
+        "categories": [
+            [
+                {"category_id": 7001, "name": "Cat A1", "description": "", "max_nest_level": None, "number_threads": 5},
+            ],
+        ],
+        "defaultNesting": 3,
+    }
+
+
+class TestForumLayoutFetch:
+    def test_fetch_parses_groups_categories_and_nesting(self, layout_response: dict[str, Any]) -> None:
+        site = _make_site()
+        mock_response = MagicMock()
+        mock_response.json.return_value = layout_response
+        site.amc_request.return_value = [mock_response]
+
+        layout = ForumLayout.fetch(site)
+
+        assert len(layout.groups) == 1
+        assert layout.groups[0].name == "Group A"
+        assert len(layout.categories) == 1
+        assert len(layout.categories[0]) == 1
+        assert layout.categories[0][0].category_id == 7001
+        assert layout.default_nesting == 3
+
+        fetch_body = site.amc_request.call_args[0][0][0]
+        assert fetch_body == {"moduleName": "managesite/ManageSiteGetForumLayoutModule"}
+
+    def test_fetch_raises_when_fields_missing(self) -> None:
+        site = _make_site()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "ok"}
+        site.amc_request.return_value = [mock_response]
+
+        with pytest.raises(ResponseDataException):
+            ForumLayout.fetch(site)
+
+
+class TestForumLayoutMutation:
+    def test_add_group_keeps_categories_index_in_sync(self, layout_response: dict[str, Any]) -> None:
+        site = _make_site()
+        mock_response = MagicMock()
+        mock_response.json.return_value = layout_response
+        site.amc_request.return_value = [mock_response]
+        layout = ForumLayout.fetch(site)
+
+        new_group = layout.add_group("Group B")
+
+        assert layout.groups[-1] is new_group
+        assert layout.categories[-1] == []
+
+    def test_add_category_appends_to_correct_group(self, layout_response: dict[str, Any]) -> None:
+        site = _make_site()
+        mock_response = MagicMock()
+        mock_response.json.return_value = layout_response
+        site.amc_request.return_value = [mock_response]
+        layout = ForumLayout.fetch(site)
+        group_b = layout.add_group("Group B")
+
+        new_category = layout.add_category(group_b, "Cat B1")
+
+        assert layout.categories[0] != [new_category]  # group A側は変化しない
+        assert layout.categories[1] == [new_category]
+
+    def test_add_category_to_group_not_in_layout_raises(self, layout_response: dict[str, Any]) -> None:
+        site = _make_site()
+        mock_response = MagicMock()
+        mock_response.json.return_value = layout_response
+        site.amc_request.return_value = [mock_response]
+        layout = ForumLayout.fetch(site)
+        foreign_group = ForumLayoutGroup(name="Foreign", description="")
+
+        with pytest.raises(ValueError):
+            layout.add_category(foreign_group, "Cat")
+
+    def test_remove_group_requires_confirm(self, layout_response: dict[str, Any]) -> None:
+        site = _make_site()
+        mock_response = MagicMock()
+        mock_response.json.return_value = layout_response
+        site.amc_request.return_value = [mock_response]
+        layout = ForumLayout.fetch(site)
+
+        with pytest.raises(ValueError, match="confirm"):
+            layout.remove_group(layout.groups[0], confirm=False)
+
+    def test_remove_group_moves_group_and_categories_to_deleted_lists(self, layout_response: dict[str, Any]) -> None:
+        site = _make_site()
+        mock_response = MagicMock()
+        mock_response.json.return_value = layout_response
+        site.amc_request.return_value = [mock_response]
+        layout = ForumLayout.fetch(site)
+        group = layout.groups[0]
+
+        layout.remove_group(group, confirm=True)
+
+        assert layout.groups == []
+        assert layout.categories == []
+        assert layout._deleted_groups[0]["name"] == "Group A"
+        assert layout._deleted_category_ids == [7001]
+
+    def test_remove_category_requires_confirm(self, layout_response: dict[str, Any]) -> None:
+        site = _make_site()
+        mock_response = MagicMock()
+        mock_response.json.return_value = layout_response
+        site.amc_request.return_value = [mock_response]
+        layout = ForumLayout.fetch(site)
+
+        with pytest.raises(ValueError, match="confirm"):
+            layout.remove_category(layout.groups[0], layout.categories[0][0], confirm=False)
+
+    def test_remove_category_records_id(self, layout_response: dict[str, Any]) -> None:
+        site = _make_site()
+        mock_response = MagicMock()
+        mock_response.json.return_value = layout_response
+        site.amc_request.return_value = [mock_response]
+        layout = ForumLayout.fetch(site)
+        group = layout.groups[0]
+        category = layout.categories[0][0]
+
+        layout.remove_category(group, category, confirm=True)
+
+        assert layout.categories[0] == []
+        assert layout._deleted_category_ids == [7001]
+
+
+class TestForumLayoutSave:
+    def test_save_sends_all_four_fields_and_clears_deletion_lists(self, layout_response: dict[str, Any]) -> None:
+        site = _make_site()
+        fetch_response = MagicMock()
+        fetch_response.json.return_value = layout_response
+        site.amc_request.return_value = [fetch_response]
+        layout = ForumLayout.fetch(site)
+        layout.remove_category(layout.groups[0], layout.categories[0][0], confirm=True)
+
+        layout.save()
+
+        save_body = site.amc_request.call_args[0][0][0]
+        assert save_body["action"] == "ManageSiteForumAction"
+        assert save_body["event"] == "saveForumLayout"
+        assert "groups" in save_body
+        assert "categories" in save_body
+        assert save_body["deleted_categories"] == "[7001]"
+        assert layout._deleted_category_ids == []
+        assert layout._deleted_groups == []
+
+
+class TestForumCategoryPermissionOverride:
+    def test_to_dict_with_explicit_permissions(self) -> None:
+        perms = ForumPermissions.decode("t:m;p:arm;e:m")
+        override = ForumCategoryPermissionOverride(category_id=7001, permissions=perms)
+
+        result = override.to_dict()
+
+        assert result["category_id"] == 7001
+        assert result["permissions"] == perms.encode()
+
+    def test_to_dict_with_none_means_inherit_default(self) -> None:
+        override = ForumCategoryPermissionOverride(category_id=7001, permissions=None)
+
+        assert override.to_dict() == {"category_id": 7001, "permissions": None}
+
+
+class TestSaveForumPermissions:
+    def test_sends_default_and_category_overrides(self) -> None:
+        site = _make_site()
+        default_permissions = ForumPermissions.decode("t:m;p:arm;e:m")
+        overrides = [ForumCategoryPermissionOverride(category_id=7001, permissions=None)]
+
+        save_forum_permissions(site, default_permissions, overrides)
+
+        body = site.amc_request.call_args[0][0][0]
+        assert body["action"] == "ManageSiteForumAction"
+        assert body["event"] == "saveForumPermissions"
+        assert body["default_permissions"] == default_permissions.encode()
+        assert body["categories"] == '[{"category_id": 7001, "permissions": null}]'
+
+    def test_none_category_permissions_sends_empty_array(self) -> None:
+        site = _make_site()
+        default_permissions = ForumPermissions.decode("t:m;p:arm;e:m")
+
+        save_forum_permissions(site, default_permissions, None)
+
+        body = site.amc_request.call_args[0][0][0]
+        assert body["categories"] == "[]"

--- a/tests/unit/test_forum_admin.py
+++ b/tests/unit/test_forum_admin.py
@@ -9,13 +9,14 @@ import pytest
 
 from wikidot.common.exceptions import ResponseDataException
 from wikidot.module.forum_admin import (
-    ForumCategoryPermissionOverride,
+    ForumCategoryPermissions,
+    ForumCategoryPermissionsCollection,
     ForumLayout,
     ForumLayoutCategory,
     ForumLayoutGroup,
     activate_forum,
-    save_forum_permissions,
     set_forum_default_nesting,
+    update_forum_permissions,
 )
 from wikidot.module.site_permissions import ForumPermissions
 
@@ -247,41 +248,151 @@ class TestForumLayoutSave:
         assert layout._deleted_groups == []
 
 
-class TestForumCategoryPermissionOverride:
-    def test_to_dict_with_explicit_permissions(self) -> None:
+def _raw_permissions_category(**overrides: Any) -> dict[str, Any]:
+    """13-field category object as returned by ManageSiteForumPermissionsModule (実測 2026-07-29)"""
+    base: dict[str, Any] = {
+        "category_id": 7001,
+        "group_id": 1,
+        "name": "Cat A1",
+        "description": "desc",
+        "number_posts": 42,
+        "number_threads": 5,
+        "last_post_id": 99999,
+        "permissions_default": True,
+        "permissions": None,
+        "max_nest_level": None,
+        "sort_index": 0,
+        "site_id": 3632981,
+        "per_page_discussion": None,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestForumCategoryPermissionsRoundTrip:
+    def test_from_dict_to_dict_preserves_all_13_fields(self) -> None:
+        raw = _raw_permissions_category(permissions="t:m;p:arm;e:m", permissions_default=False)
+        category = ForumCategoryPermissions.from_dict(raw)
+
+        assert category.category_id == 7001
+        assert category.group_id == 1
+        assert category.number_posts == 42
+        assert category.number_threads == 5
+        assert category.last_post_id == 99999
+        assert category.permissions_default is False
+        assert category.permissions is not None
+        assert category.sort_index == 0
+        assert category.site_id == 3632981
+
+        result = category.to_dict()
+        # 元の13フィールドが全て往復すること（{category_id, permissions}だけの部分オブジェクトにならない）
+        for key in raw:
+            if key == "permissions":
+                continue
+            assert result[key] == raw[key]
+        assert result["permissions"] == "t:m;p:arm;e:m"
+
+    def test_preserves_unknown_fields_via_raw(self) -> None:
+        raw = _raw_permissions_category(some_future_field="x")
+        category = ForumCategoryPermissions.from_dict(raw)
+        assert category.to_dict()["some_future_field"] == "x"
+
+    def test_set_permissions_updates_default_flag(self) -> None:
+        category = ForumCategoryPermissions.from_dict(_raw_permissions_category())
         perms = ForumPermissions.decode("t:m;p:arm;e:m")
-        override = ForumCategoryPermissionOverride(category_id=7001, permissions=perms)
 
-        result = override.to_dict()
+        category.set_permissions(perms)
+        assert category.permissions == perms
+        assert category.permissions_default is False
 
-        assert result["category_id"] == 7001
-        assert result["permissions"] == perms.encode()
-
-    def test_to_dict_with_none_means_inherit_default(self) -> None:
-        override = ForumCategoryPermissionOverride(category_id=7001, permissions=None)
-
-        assert override.to_dict() == {"category_id": 7001, "permissions": None}
+        category.set_permissions(None)
+        assert category.permissions is None
+        assert category.permissions_default is True
 
 
-class TestSaveForumPermissions:
-    def test_sends_default_and_category_overrides(self) -> None:
+class TestForumCategoryPermissionsCollectionFetch:
+    def test_fetch_parses_categories_from_permissions_module(self) -> None:
         site = _make_site()
-        default_permissions = ForumPermissions.decode("t:m;p:arm;e:m")
-        overrides = [ForumCategoryPermissionOverride(category_id=7001, permissions=None)]
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "ok", "categories": [_raw_permissions_category()]}
+        site.amc_request.return_value = [mock_response]
 
-        save_forum_permissions(site, default_permissions, overrides)
+        collection = ForumCategoryPermissionsCollection.fetch(site)
 
-        body = site.amc_request.call_args[0][0][0]
-        assert body["action"] == "ManageSiteForumAction"
-        assert body["event"] == "saveForumPermissions"
-        assert body["default_permissions"] == default_permissions.encode()
-        assert body["categories"] == '[{"category_id": 7001, "permissions": null}]'
+        assert len(collection) == 1
+        assert collection[7001].category_id == 7001
+        fetch_body = site.amc_request.call_args[0][0][0]
+        assert fetch_body == {"moduleName": "managesite/ManageSiteForumPermissionsModule"}
 
-    def test_none_category_permissions_sends_empty_array(self) -> None:
+    def test_fetch_raises_when_categories_missing(self) -> None:
         site = _make_site()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "ok"}
+        site.amc_request.return_value = [mock_response]
+
+        with pytest.raises(ResponseDataException):
+            ForumCategoryPermissionsCollection.fetch(site)
+
+    def test_getitem_missing_raises_key_error(self) -> None:
+        collection = ForumCategoryPermissionsCollection(
+            site=_make_site(), categories=[ForumCategoryPermissions.from_dict(_raw_permissions_category())]
+        )
+        with pytest.raises(KeyError):
+            collection[999999]
+
+
+class TestForumCategoryPermissionsCollectionSave:
+    def test_save_sends_full_category_objects_not_partial(self) -> None:
+        site = _make_site()
+        collection = ForumCategoryPermissionsCollection(
+            site=site, categories=[ForumCategoryPermissions.from_dict(_raw_permissions_category())]
+        )
+
+        collection.save()
+
+        save_body = site.amc_request.call_args[0][0][0]
+        assert save_body["action"] == "ManageSiteForumAction"
+        assert save_body["event"] == "saveForumPermissions"
+        import json
+
+        sent_categories = json.loads(save_body["categories"])
+        assert len(sent_categories[0]) == 13  # 2フィールドの部分オブジェクトに戻っていないこと
+        assert "number_posts" in sent_categories[0]
+        assert "sort_index" in sent_categories[0]
+
+    def test_default_permissions_omitted_when_not_provided(self) -> None:
+        site = _make_site()
+        collection = ForumCategoryPermissionsCollection(site=site, categories=[])
+
+        collection.save()
+
+        save_body = site.amc_request.call_args[0][0][0]
+        assert "default_permissions" not in save_body
+
+    def test_default_permissions_sent_when_explicitly_provided(self) -> None:
+        site = _make_site()
+        collection = ForumCategoryPermissionsCollection(site=site, categories=[])
         default_permissions = ForumPermissions.decode("t:m;p:arm;e:m")
 
-        save_forum_permissions(site, default_permissions, None)
+        collection.save(default_permissions)
 
-        body = site.amc_request.call_args[0][0][0]
-        assert body["categories"] == "[]"
+        save_body = site.amc_request.call_args[0][0][0]
+        assert save_body["default_permissions"] == default_permissions.encode()
+
+
+class TestUpdateForumPermissions:
+    def test_fetch_then_mutate_then_save(self) -> None:
+        site = _make_site()
+        fetch_response = MagicMock()
+        fetch_response.json.return_value = {"status": "ok", "categories": [_raw_permissions_category()]}
+        site.amc_request.return_value = [fetch_response]
+        new_perms = ForumPermissions.decode("t:m;p:arm;e:m")
+
+        update_forum_permissions(site, lambda cats: cats[7001].set_permissions(new_perms))
+
+        assert site.amc_request.call_count == 2
+        fetch_call, save_call = site.amc_request.call_args_list
+        assert fetch_call[0][0] == [{"moduleName": "managesite/ManageSiteForumPermissionsModule"}]
+        save_body = save_call[0][0][0]
+        assert save_body["event"] == "saveForumPermissions"
+        assert new_perms.encode() in save_body["categories"]

--- a/tests/unit/test_forum_category.py
+++ b/tests/unit/test_forum_category.py
@@ -160,3 +160,26 @@ class TestForumCategoryCreateThread:
 
         assert thread.id == 3001
         assert thread.category == mock_forum_category_no_http
+
+
+class TestForumCategoryPreviewThread:
+    """ForumCategory.preview_threadのテスト"""
+
+    def test_preview_sends_new_thread_form_fields(
+        self, mock_forum_category_no_http: ForumCategory, amc_ok_response: dict[str, Any]
+    ) -> None:
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "ok", "body": "<div>preview</div>"}
+        mock_forum_category_no_http.site.amc_request = MagicMock(return_value=[mock_response])
+
+        body = mock_forum_category_no_http.preview_thread(
+            title="Preview Title", description="Preview description", source="Preview source"
+        )
+
+        assert body == "<div>preview</div>"
+        request_body = mock_forum_category_no_http.site.amc_request.call_args[0][0][0]
+        assert request_body["moduleName"] == "forum/ForumPreviewPostModule"
+        assert request_body["category_id"] == mock_forum_category_no_http.id
+        assert request_body["title"] == "Preview Title"
+        assert request_body["description"] == "Preview description"
+        assert request_body["source"] == "Preview source"

--- a/tests/unit/test_forum_post.py
+++ b/tests/unit/test_forum_post.py
@@ -310,3 +310,32 @@ class TestForumPostEdit:
 
         assert mock_forum_post_no_http.title == "New Title"
         assert mock_forum_post_no_http._source == "Updated source"
+
+
+class TestForumPostDelete:
+    """ForumPost.deleteのテスト"""
+
+    def test_requires_confirm(self, mock_forum_post_no_http: ForumPost) -> None:
+        """confirm=Trueを渡さないとValueError"""
+        with pytest.raises(ValueError, match="confirm"):
+            mock_forum_post_no_http.delete(confirm=False)
+
+    def test_not_logged_in(self, mock_forum_post_no_http: ForumPost) -> None:
+        mock_forum_post_no_http.thread.site.client.login_check = MagicMock(
+            side_effect=exceptions.LoginRequiredException("Login required")
+        )
+        with pytest.raises(exceptions.LoginRequiredException):
+            mock_forum_post_no_http.delete(confirm=True)
+
+    def test_delete_success(self, mock_forum_post_no_http: ForumPost, amc_ok_response: dict[str, Any]) -> None:
+        mock_forum_post_no_http.thread.site.client.login_check = MagicMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = amc_ok_response
+        mock_forum_post_no_http.thread.site.amc_request = MagicMock(return_value=[mock_response])
+
+        mock_forum_post_no_http.delete(confirm=True)
+
+        body = mock_forum_post_no_http.thread.site.amc_request.call_args[0][0][0]
+        assert body["action"] == "ForumAction"
+        assert body["event"] == "deletePost"
+        assert body["postId"] == mock_forum_post_no_http.id

--- a/tests/unit/test_forum_thread.py
+++ b/tests/unit/test_forum_thread.py
@@ -262,6 +262,206 @@ class TestForumThreadReply:
         assert call_args["parentId"] == "5001"
 
 
+class TestForumThreadSaveMeta:
+    """ForumThread.save_metaのテスト"""
+
+    def _prepare(self, thread: ForumThread, amc_ok_response: dict[str, Any]) -> MagicMock:
+        thread.site.client.is_logged_in = True
+        thread.site.client.login_check = MagicMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = amc_ok_response
+        thread.site.amc_request = MagicMock(return_value=[mock_response])
+        return thread.site.amc_request
+
+    def test_not_logged_in(self, mock_forum_thread_no_http: ForumThread) -> None:
+        mock_forum_thread_no_http.site.client.login_check = MagicMock(
+            side_effect=exceptions.LoginRequiredException("Login required")
+        )
+        with pytest.raises(exceptions.LoginRequiredException):
+            mock_forum_thread_no_http.save_meta(title="New title")
+
+    def test_unspecified_fields_keep_current_value(
+        self, mock_forum_thread_no_http: ForumThread, amc_ok_response: dict[str, Any]
+    ) -> None:
+        """title/descriptionを指定しない場合、現在値のまま送られる（空欄で上書きされない）"""
+        amc_request = self._prepare(mock_forum_thread_no_http, amc_ok_response)
+        original_title = mock_forum_thread_no_http.title
+        original_description = mock_forum_thread_no_http.description
+
+        mock_forum_thread_no_http.save_meta()
+
+        body = amc_request.call_args[0][0][0]
+        assert body["title"] == original_title
+        assert body["description"] == original_description
+
+    def test_explicit_values_are_sent_and_cached(
+        self, mock_forum_thread_no_http: ForumThread, amc_ok_response: dict[str, Any]
+    ) -> None:
+        amc_request = self._prepare(mock_forum_thread_no_http, amc_ok_response)
+
+        result = mock_forum_thread_no_http.save_meta(title="New title", description="New description")
+
+        body = amc_request.call_args[0][0][0]
+        assert body["action"] == "ForumAction"
+        assert body["event"] == "saveThreadMeta"
+        assert body["threadId"] == mock_forum_thread_no_http.id
+        assert body["title"] == "New title"
+        assert body["description"] == "New description"
+        assert result is mock_forum_thread_no_http
+        assert mock_forum_thread_no_http.title == "New title"
+        assert mock_forum_thread_no_http.description == "New description"
+
+
+class TestForumThreadSetSticky:
+    """ForumThread.set_stickyのテスト"""
+
+    def test_sticky_true_sends_flag(
+        self, mock_forum_thread_no_http: ForumThread, amc_ok_response: dict[str, Any]
+    ) -> None:
+        mock_forum_thread_no_http.site.client.login_check = MagicMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = amc_ok_response
+        mock_forum_thread_no_http.site.amc_request = MagicMock(return_value=[mock_response])
+
+        mock_forum_thread_no_http.set_sticky(True)
+
+        body = mock_forum_thread_no_http.site.amc_request.call_args[0][0][0]
+        assert body["event"] == "saveSticky"
+        assert body["sticky"] == "true"
+
+    def test_sticky_false_omits_key(
+        self, mock_forum_thread_no_http: ForumThread, amc_ok_response: dict[str, Any]
+    ) -> None:
+        mock_forum_thread_no_http.site.client.login_check = MagicMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = amc_ok_response
+        mock_forum_thread_no_http.site.amc_request = MagicMock(return_value=[mock_response])
+
+        mock_forum_thread_no_http.set_sticky(False)
+
+        body = mock_forum_thread_no_http.site.amc_request.call_args[0][0][0]
+        assert "sticky" not in body
+
+
+class TestForumThreadSetBlock:
+    """ForumThread.set_blockのテスト"""
+
+    def test_block_true_sends_flag(
+        self, mock_forum_thread_no_http: ForumThread, amc_ok_response: dict[str, Any]
+    ) -> None:
+        mock_forum_thread_no_http.site.client.login_check = MagicMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = amc_ok_response
+        mock_forum_thread_no_http.site.amc_request = MagicMock(return_value=[mock_response])
+
+        mock_forum_thread_no_http.set_block(True)
+
+        body = mock_forum_thread_no_http.site.amc_request.call_args[0][0][0]
+        assert body["event"] == "saveBlock"
+        assert body["block"] == "true"
+
+    def test_block_false_omits_key(
+        self, mock_forum_thread_no_http: ForumThread, amc_ok_response: dict[str, Any]
+    ) -> None:
+        mock_forum_thread_no_http.site.client.login_check = MagicMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = amc_ok_response
+        mock_forum_thread_no_http.site.amc_request = MagicMock(return_value=[mock_response])
+
+        mock_forum_thread_no_http.set_block(False)
+
+        body = mock_forum_thread_no_http.site.amc_request.call_args[0][0][0]
+        assert "block" not in body
+
+
+class TestForumThreadMove:
+    """ForumThread.moveのテスト"""
+
+    def test_move_sends_category_id_and_updates_local_state(
+        self,
+        mock_forum_thread_no_http: ForumThread,
+        mock_forum_category_no_http: Any,
+        amc_ok_response: dict[str, Any],
+    ) -> None:
+        mock_forum_thread_no_http.site.client.login_check = MagicMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = amc_ok_response
+        mock_forum_thread_no_http.site.amc_request = MagicMock(return_value=[mock_response])
+
+        destination = mock_forum_category_no_http
+        destination.id = 2002
+        result = mock_forum_thread_no_http.move(destination)
+
+        body = mock_forum_thread_no_http.site.amc_request.call_args[0][0][0]
+        assert body["action"] == "ForumAction"
+        assert body["event"] == "moveThread"
+        assert body["threadId"] == mock_forum_thread_no_http.id
+        assert body["categoryId"] == 2002
+        assert result is mock_forum_thread_no_http
+        assert mock_forum_thread_no_http.category is destination
+
+
+class TestForumThreadWatch:
+    """ForumThread.watchのテスト"""
+
+    def test_watch_sends_watch_action(
+        self, mock_forum_thread_no_http: ForumThread, amc_ok_response: dict[str, Any]
+    ) -> None:
+        mock_forum_thread_no_http.site.client.login_check = MagicMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = amc_ok_response
+        mock_forum_thread_no_http.site.amc_request = MagicMock(return_value=[mock_response])
+
+        result = mock_forum_thread_no_http.watch()
+
+        body = mock_forum_thread_no_http.site.amc_request.call_args[0][0][0]
+        assert body["action"] == "WatchAction"
+        assert body["event"] == "watchThread"
+        assert body["threadId"] == mock_forum_thread_no_http.id
+        assert result is mock_forum_thread_no_http
+
+
+class TestForumThreadCreateForPage:
+    """ForumThread.create_for_pageのテスト"""
+
+    def test_not_logged_in(self, mock_site_no_http: Site) -> None:
+        mock_site_no_http.client.login_check = MagicMock(
+            side_effect=exceptions.LoginRequiredException("Login required")
+        )
+        with pytest.raises(exceptions.LoginRequiredException):
+            ForumThread.create_for_page(mock_site_no_http, 999)
+
+    def test_returns_thread_when_thread_id_present(
+        self, mock_site_no_http: Site, forum_thread_detail: dict[str, Any]
+    ) -> None:
+        mock_site_no_http.client.login_check = MagicMock()
+        create_response = MagicMock()
+        create_response.json.return_value = {"status": "ok", "threadId": 3001}
+        fetch_response = MagicMock()
+        fetch_response.json.return_value = forum_thread_detail
+        mock_site_no_http.amc_request = MagicMock(side_effect=[[create_response], [fetch_response]])
+
+        thread = ForumThread.create_for_page(mock_site_no_http, 999)
+
+        assert thread is not None
+        assert thread.id == 3001
+        create_call_body = mock_site_no_http.amc_request.call_args_list[0][0][0][0]
+        assert create_call_body["action"] == "ForumAction"
+        assert create_call_body["event"] == "createPageDiscussionThread"
+        assert create_call_body["page_id"] == 999
+
+    def test_returns_none_when_thread_id_missing(self, mock_site_no_http: Site) -> None:
+        """レスポンススキーマが未確認のため、threadIdが無ければNoneを返す（推測しない）"""
+        mock_site_no_http.client.login_check = MagicMock()
+        create_response = MagicMock()
+        create_response.json.return_value = {"status": "ok"}
+        mock_site_no_http.amc_request = MagicMock(return_value=[create_response])
+
+        thread = ForumThread.create_for_page(mock_site_no_http, 999)
+
+        assert thread is None
+
+
 class TestForumThreadGetFromId:
     """ForumThread.get_from_idのテスト"""
 


### PR DESCRIPTION
## Summary

フォーラムのスレッド操作とフォーラム管理を追加する。

> スタック PR。base は `feature/member-admin`。

## Related Issue

なし

## Changes

- スレッドのメタ編集 / sticky / ロック / 移動 / 監視、投稿の削除
- 新規スレッドのプレビュー
- ページのコメントスレッド作成
- フォーラムの有効化 / 既定ネストレベル / レイアウト / 権限の操作を新設

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring
- [x] Test addition/modification
- [ ] CI/CD or build related

## Testing

- [x] `make format` passes
- [x] `make lint` passes
- [x] `make test` passes

## Checklist

- [x] Code follows the project's style guidelines
- [ ] Documentation has been updated as needed
- [x] Tests have been added for the changes (if applicable)

## Additional Information

- `saveForumPermissions` の `categories` は13フィールドを持つ。部分オブジェクトを送ると欠落するため、未知フィールドを保持したまま往復させている
- `default_permissions` はモジュール応答に含まれず取得元が未特定のため、明示的に渡したときだけ送る
- フォーラム権限モジュールとレイアウトモジュールはカテゴリのフィールド集合が異なる（前者13・後者7）ため、取得元を使い分けている
- ページ単位ディスカッションの設定はサイト設定側に既にあるため重複実装していない

README と `llms.txt` は追加した API を反映していない。リリース前にまとめて追随させる。
