### PR TITLE
ページ操作の拡充

### DIFF
--- a/src/wikidot/connector/ajax.py
+++ b/src/wikidot/connector/ajax.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from typing import Any, Literal, overload
 
 import httpx
+from bs4 import BeautifulSoup
 
 from ..common import wd_logger
 from ..common.exceptions import (
@@ -267,6 +268,36 @@ def _encode_amc_body(body: dict[str, Any]) -> dict[str, Any]:
         return body
 
     return {(f"{key}[]" if isinstance(value, list) else key): value for key, value in body.items()}
+
+
+def _parse_upload_target_response(html: str) -> dict[str, str]:
+    """
+    Parse the HTML fragment returned by /default--flow/files__UploadTarget
+
+    UNVERIFIED AGAINST A LIVE WIKIDOT INSTANCE. This endpoint does not
+    respond with the usual AMC JSON envelope; per 10_transport.md (wire
+    format research based on reading Wikidot's client-side JS, not an
+    observed live upload) it returns an HTML fragment of the shape
+    `<div id="status">ok</div><div id="message">..</div><div id="filename">..</div>`.
+
+    Parameters
+    ----------
+    html : str
+        Raw response body
+
+    Returns
+    -------
+    dict[str, str]
+        Values keyed by "status" / "message" / "filename", for whichever
+        of those elements were present in the response
+    """
+    soup = BeautifulSoup(html, "lxml")
+    result: dict[str, str] = {}
+    for key in ("status", "message", "filename"):
+        elem = soup.select_one(f"#{key}")
+        if elem is not None:
+            result[key] = elem.get_text().strip()
+    return result
 
 
 class AjaxModuleConnectorClient:
@@ -599,3 +630,84 @@ class AjaxModuleConnectorClient:
             r if isinstance(r, httpx.Response) else r if isinstance(r, Exception) else Exception(str(r))
             for r in results
         )
+
+    def upload_file(
+        self,
+        page_id: int,
+        filename: str,
+        content: bytes,
+        *,
+        site_name: str | None = None,
+        site_ssl_supported: bool | None = None,
+        multikey: str | None = None,
+    ) -> dict[str, str]:
+        """
+        Upload a file to a page via the multipart upload endpoint
+
+        UNVERIFIED AGAINST A LIVE WIKIDOT INSTANCE. This is a separate
+        wire path from `request()`: it posts multipart/form-data to
+        `/default--flow/files__UploadTarget` (not ajax-module-connector.php)
+        and gets back an HTML fragment, not the usual AMC JSON envelope, so
+        it cannot go through `request()`'s JSON parsing. The endpoint,
+        parameters (`action=FileAction`, `event=uploadFile`, `page_id`,
+        `source=multiflash`, `multikey?`, file under the `userfile` field),
+        and response shape were all determined by reading Wikidot's
+        client-side JS, not by observing a real upload -- see 30_plan.md D8
+        and 32_tasks.md Task 3-5b in the sibling wikidot.py repo's memory
+        directory. Confirm against a real site before relying on this for
+        anything important.
+
+        Parameters
+        ----------
+        page_id : int
+            ID of the page to attach the file to
+        filename : str
+            File name as it will appear on the page
+        content : bytes
+            File content
+        site_name : str | None, default None
+            Target site name. Uses the site name specified at
+            initialization if None
+        site_ssl_supported : bool | None, default None
+            Site's SSL support status. Uses the result confirmed at
+            initialization if None
+        multikey : str | None, default None
+            Multi-file upload session key. Required by
+            FileAction/multiUploadComplete when uploading more than one
+            file in the same batch
+
+        Returns
+        -------
+        dict[str, str]
+            Parsed response fields among "status" / "message" / "filename"
+            (see _parse_upload_target_response)
+        """
+        site_name = site_name if site_name is not None else self.site_name
+        site_ssl_supported = site_ssl_supported if site_ssl_supported is not None else self.ssl_supported
+
+        url = f"http{'s' if site_ssl_supported else ''}://{site_name}.wikidot.com/default--flow/files__UploadTarget"
+
+        data: dict[str, Any] = {
+            "action": "FileAction",
+            "event": "uploadFile",
+            "page_id": page_id,
+            "source": "multiflash",
+            "wikidot_token7": 123456,
+        }
+        if multikey is not None:
+            data["multikey"] = multikey
+
+        async def _upload() -> httpx.Response:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    url,
+                    headers=self.header.get_header(),
+                    data=data,
+                    files={"userfile": (filename, content)},
+                    timeout=self.config.request_timeout,
+                )
+                response.raise_for_status()
+                return response
+
+        response = run_coroutine(_upload())
+        return _parse_upload_target_response(response.text)

--- a/src/wikidot/module/page.py
+++ b/src/wikidot/module/page.py
@@ -13,12 +13,14 @@ if sys.version_info >= (3, 12):
 else:
     from typing_extensions import TypedDict, Unpack
 
-from ..common import exceptions, wd_logger
+from ..common import exceptions
 from ..connector.ajax import require_body
+from ..util.amc_body import flag, omit_falsy
 from ..util.parser import odate as odate_parser
 from ..util.parser import user as user_parser
 from ..util.requestutil import RequestUtil
-from .page_revision import PageRevision, PageRevisionCollection
+from .page_edit_session import EditMode, PageEditSession
+from .page_revision import PageRevision, PageRevisionCollection, parse_revision_list_html
 from .page_source import PageSource
 from .page_votes import PageVote, PageVoteCollection
 
@@ -698,40 +700,8 @@ class PageCollection(list["Page"]):
             if response is None:
                 continue
             body = require_body(response, "history/PageRevisionListModule")
-            revs = []
             body_html = BeautifulSoup(body, "lxml")
-            for rev_element in body_html.select("table.page-history > tr[id^=revision-row-]"):
-                rev_id = int(str(rev_element["id"]).removeprefix("revision-row-"))
-
-                tds = rev_element.select("td")
-                rev_no = int(tds[0].text.strip().removesuffix("."))
-                created_by_elem = tds[4].select_one("span.printuser")
-                if created_by_elem is None:
-                    raise exceptions.NoElementException(
-                        f"Cannot find created by element for page: {page.fullname}, revision: {rev_id}"
-                    )
-                created_by = user_parser(page.site.client, created_by_elem)
-
-                created_at_elem = tds[5].select_one("span.odate")
-                if created_at_elem is None:
-                    raise exceptions.NoElementException(
-                        f"Cannot find created at element for page: {page.fullname}, revision: {rev_id}"
-                    )
-                created_at = odate_parser(created_at_elem)
-
-                comment = tds[6].text.strip()
-
-                revs.append(
-                    PageRevision(
-                        page=page,
-                        id=rev_id,
-                        rev_no=rev_no,
-                        created_by=created_by,
-                        created_at=created_at,
-                        comment=comment,
-                    )
-                )
-            page.revisions = PageRevisionCollection(page, revs)
+            page.revisions = PageRevisionCollection(page, parse_revision_list_html(page, body_html))
 
         return pages
 
@@ -868,57 +838,6 @@ class PageCollection(list["Page"]):
         """
         PageCollection._acquire_page_files(self.site, self)
         return self
-
-
-def _release_page_edit_lock(
-    site: "Site",
-    fullname: str,
-    page_id: int | None,
-    lock_id: Any,
-    lock_secret: Any,
-) -> None:
-    """
-    Release a page edit lock acquired via edit/PageEditModule
-
-    Wikidot holds the lock for up to 15 minutes once edit/PageEditModule is
-    requested. Any code path that acquires the lock but does not reach a
-    successful savePage must call this, or the page stays uneditable for
-    other users until the lock expires.
-
-    Parameters
-    ----------
-    site : Site
-        Site the page belongs to
-    fullname : str
-        Fullname of the page
-    page_id : int | None
-        Page ID, if known (omitted from the request when None, matching
-        the client-side behavior of only sending page_id when available)
-    lock_id : Any
-        Lock ID returned by edit/PageEditModule
-    lock_secret : Any
-        Lock secret returned by edit/PageEditModule
-
-    Notes
-    -----
-    Failure to release is logged, not raised, so it never masks the
-    original exception that triggered the release attempt.
-    """
-    release_body: dict[str, Any] = {
-        "action": "WikiPageAction",
-        "event": "removePageEditLock",
-        "moduleName": "Empty",
-        "lock_id": lock_id,
-        "lock_secret": lock_secret,
-        "wiki_page": fullname,
-    }
-    if page_id is not None:
-        release_body["page_id"] = page_id
-
-    try:
-        site.amc_request([release_body])
-    except Exception:
-        wd_logger.exception(f"Failed to release page edit lock for {fullname} (lock_id={lock_id})")
 
 
 @dataclass
@@ -1109,6 +1028,28 @@ class Page:
             Source code object to set
         """
         self._source = value
+
+    def get_template_source(self) -> str:
+        """
+        Get this page's source for use as a page-creation template (edit/TemplateSourceModule)
+
+        Distinct from the `source` property: this is the wire endpoint
+        Wikidot uses when populating a new page's editor from a template
+        page (`parentPage`/template selection), not general source
+        retrieval.
+
+        Returns
+        -------
+        str
+            Template source body
+
+        Raises
+        ------
+        ResponseDataException
+            When the response has no "body" field
+        """
+        response = self.site.amc_request([{"moduleName": "edit/TemplateSourceModule", "page_id": self.id}])[0]
+        return require_body(response, "edit/TemplateSourceModule")
 
     @property
     def revisions(self) -> PageRevisionCollection:
@@ -1390,6 +1331,182 @@ class Page:
 
         self._metas = value
 
+    def set_meta(self, name: str, content: str, all_pages: bool = False) -> "Page":
+        """
+        Set a single meta tag (WikiPageAction/saveMetaTag)
+
+        Unlike the `metas` property setter (which diffs the whole
+        dictionary against the current state), this sets one tag directly
+        and supports `allPages`, which applies the tag across every page
+        using the same template.
+
+        Parameters
+        ----------
+        name : str
+            Meta tag name
+        content : str
+            Meta tag content
+        all_pages : bool, default False
+            Whether to apply this to all pages sharing the template
+
+        Returns
+        -------
+        Page
+            Self (for method chaining)
+
+        Raises
+        ------
+        LoginRequiredException
+            When not logged in
+        """
+        self.site.client.login_check()
+        self.site.amc_request(
+            [
+                {
+                    "metaName": name,
+                    "metaContent": content,
+                    "action": "WikiPageAction",
+                    "event": "saveMetaTag",
+                    "pageId": self.id,
+                    "moduleName": "edit/EditMetaModule",
+                    **omit_falsy(allPages=flag(all_pages)),
+                }
+            ]
+        )
+        if self._metas is not None:
+            self._metas[name] = content
+        return self
+
+    def delete_meta(self, name: str, all_pages: bool = False) -> "Page":
+        """
+        Delete a single meta tag (WikiPageAction/deleteMetaTag)
+
+        Parameters
+        ----------
+        name : str
+            Meta tag name
+        all_pages : bool, default False
+            Whether to apply this to all pages sharing the template
+
+        Returns
+        -------
+        Page
+            Self (for method chaining)
+
+        Raises
+        ------
+        LoginRequiredException
+            When not logged in
+        """
+        self.site.client.login_check()
+        self.site.amc_request(
+            [
+                {
+                    "metaName": name,
+                    "action": "WikiPageAction",
+                    "event": "deleteMetaTag",
+                    "pageId": self.id,
+                    "moduleName": "edit/EditMetaModule",
+                    **omit_falsy(allPages=flag(all_pages)),
+                }
+            ]
+        )
+        if self._metas is not None:
+            self._metas.pop(name, None)
+        return self
+
+    def get_block_form(self) -> str:
+        """
+        Get the rendered page-block form (pageblock/PageBlockModule)
+
+        Returns
+        -------
+        str
+            Rendered HTML body
+        """
+        response = self.site.amc_request([{"moduleName": "pageblock/PageBlockModule", "page_id": self.id}])[0]
+        return require_body(response, "pageblock/PageBlockModule")
+
+    def set_block(self, block: bool = True) -> "Page":
+        """
+        Set or clear this page's edit-block flag (WikiPageAction/saveBlock)
+
+        A blocked page cannot be edited by non-moderator users.
+
+        Parameters
+        ----------
+        block : bool, default True
+            Whether to block editing
+
+        Returns
+        -------
+        Page
+            Self (for method chaining)
+
+        Raises
+        ------
+        LoginRequiredException
+            When not logged in
+        """
+        self.site.client.login_check()
+        self.site.amc_request(
+            [
+                {
+                    "action": "WikiPageAction",
+                    "event": "saveBlock",
+                    "moduleName": "Empty",
+                    "pageId": self.id,
+                    **omit_falsy(block=flag(block)),
+                }
+            ]
+        )
+        return self
+
+    def get_backlinks(self) -> str:
+        """
+        Get pages linking to this page (backlinks/BacklinksModule)
+
+        Returns the raw HTML rather than a parsed list; the exact markup
+        was not captured during wire-format research (same caveat as
+        get_rename_backlinks(), which uses a different, rename-specific
+        module).
+
+        Returns
+        -------
+        str
+            Rendered HTML body
+        """
+        response = self.site.amc_request([{"moduleName": "backlinks/BacklinksModule", "page_id": self.id}])[0]
+        return require_body(response, "backlinks/BacklinksModule")
+
+    def watch(self) -> None:
+        """
+        Watch this page for changes (WatchAction/watchPage)
+
+        Raises
+        ------
+        LoginRequiredException
+            When not logged in
+        """
+        self.site.client.login_check()
+        self.site.amc_request(
+            [{"action": "WatchAction", "event": "watchPage", "moduleName": "Empty", "pageId": self.id}]
+        )
+
+    def get_watchers(self) -> str:
+        """
+        Get the list of users watching this page (watch/WhoWatchesModule)
+
+        Returns
+        -------
+        str
+            Rendered HTML body
+        """
+        response = self.site.amc_request(
+            [{"moduleName": "watch/WhoWatchesModule", "page_id": self.id, "verbose": True}]
+        )[0]
+        return require_body(response, "watch/WhoWatchesModule")
+
     @staticmethod
     def create_or_edit(
         site: "Site",
@@ -1448,76 +1565,25 @@ class Page:
         """
         site.client.login_check()
 
-        # ページロックを取得しにいく
-        page_lock_request_body = {
-            "mode": "page",
-            "wiki_page": fullname,
-            "moduleName": "edit/PageEditModule",
-        }
-        if force_edit:
-            page_lock_request_body["force_lock"] = "yes"
-
-        page_lock_response = site.amc_request([page_lock_request_body])[0]
-        page_lock_response_data = page_lock_response.json()
-
-        if page_lock_response_data.get("locked") or page_lock_response_data.get("other_locks"):
-            # ロック取得自体に失敗しているので解放不要
-            raise exceptions.TargetErrorException(
-                f"Page {fullname} is locked or other locks exist",
-            )
-
-        # ページが存在するか（page_revision_idがあるか）確認
-        is_exist = "page_revision_id" in page_lock_response_data
-
-        # lock_idとlock_secret、page_revision_id（あれば）を取得
-        # ここから先は編集ロックを保持している状態なので、保存が成立しなかった経路は
-        # 必ずremovePageEditLockで解放する（放置すると最大15分そのページが編集不可になる）
-        lock_id = page_lock_response_data["lock_id"]
-        lock_secret = page_lock_response_data["lock_secret"]
-        page_revision_id = page_lock_response_data.get("page_revision_id")
-
-        save_succeeded = False
-        try:
-            if raise_on_exists and is_exist:
+        # PageEditSessionがロック取得(edit/PageEditModule)から保存(savePage)、
+        # 未保存時の解放(removePageEditLock)までのライフサイクルを保証する(D5)。
+        # 外部シグネチャは維持しつつ、内部実装だけをセッション経由に置き換える。
+        with PageEditSession(site=site, fullname=fullname, page_id=page_id, force_lock=force_edit) as session:
+            if raise_on_exists and session.is_existing_page:
                 raise exceptions.TargetExistsException(f"Page {fullname} already exists")
 
-            if is_exist and page_id is None:
+            if session.is_existing_page and page_id is None:
                 raise ValueError("page_id must be specified when editing existing page")
 
-            # ページの作成または編集
-            edit_request_body = {
-                "action": "WikiPageAction",
-                "event": "savePage",
-                "moduleName": "Empty",
-                "mode": "page",
-                "lock_id": lock_id,
-                "lock_secret": lock_secret,
-                "revision_id": page_revision_id if page_revision_id is not None else "",
-                "wiki_page": fullname,
-                "page_id": page_id if page_id is not None else "",
-                "title": title,
-                "source": source,
-                "comments": comment,
-            }
-            response = site.amc_request([edit_request_body])[0]
-
-            if response.json()["status"] != "ok":
-                raise exceptions.WikidotStatusCodeException(
-                    f"Failed to create or edit page: {fullname}", response.json()["status"]
-                )
-
-            # savePageが成功した時点でWikidot側がロックを解放するため、以降の
-            # NotFoundException（検索側の不整合）では解放を試みない
-            save_succeeded = True
+            # save()が例外を投げなければ保存成功。session.__exit__は_savedを見て
+            # 解放要否を判断するため、ここでのフラグ管理は不要
+            session.save(title=title, source=source, comment=comment)
 
             res = PageCollection.search_pages(site, SearchPagesQuery(fullname=fullname))
             if len(res) == 0:
                 raise exceptions.NotFoundException(f"Page creation failed: {fullname}")
 
             return res[0]
-        finally:
-            if not save_succeeded:
-                _release_page_edit_lock(site, fullname, page_id, lock_id, lock_secret)
 
     def edit(
         self,
@@ -1566,6 +1632,50 @@ class Page:
             force_edit,
         )
 
+    def open_editor(
+        self,
+        mode: "EditMode" = "page",
+        section: int | None = None,
+        force_lock: bool = False,
+    ) -> PageEditSession:
+        """
+        Open a manual edit session for this page
+
+        Unlike `edit()`, which performs a single create-or-edit round trip,
+        this returns an unopened `PageEditSession` for callers that need
+        access to intermediate operations while the lock is held (preview,
+        diff, synchronize, section/append mode, and_continue, ...). Use it
+        as a context manager so the lock is always released unless save()
+        succeeds:
+
+        >>> with page.open_editor() as ed:
+        ...     preview = ed.preview(source="new content")
+        ...     ed.save(source="new content", comment="edit")
+
+        Parameters
+        ----------
+        mode : Literal["page", "section", "append"], default "page"
+            Edit mode
+        section : int | None, default None
+            Section number to edit. Required when mode is "section"
+        force_lock : bool, default False
+            Whether to forcibly take over a lock held by another user
+
+        Returns
+        -------
+        PageEditSession
+            Unopened edit session (call open() or enter via `with` to
+            acquire the lock)
+        """
+        return PageEditSession(
+            site=self.site,
+            fullname=self.fullname,
+            page_id=self._id,
+            mode=mode,
+            section=section,
+            force_lock=force_lock,
+        )
+
     def commit_tags(self) -> "Page":
         """
         Save tag information for the page
@@ -1597,6 +1707,70 @@ class Page:
             ]
         )
         return self
+
+    def get_tags_form(self) -> str:
+        """
+        Get the rendered tags editing form (pagetags/PageTagsModule)
+
+        Returns
+        -------
+        str
+            Rendered HTML body
+        """
+        response = self.site.amc_request([{"moduleName": "pagetags/PageTagsModule", "pageId": self.id}])[0]
+        return require_body(response, "pagetags/PageTagsModule")
+
+    def update_tags_by_button(self, tags: str) -> "Page":
+        """
+        Update tags via the quick-tag button UI (WikiPageAction/updateTagsByButton)
+
+        Distinct from commit_tags(): that saves the current `tags`
+        property in full via WikiPageAction/saveTags. This instead mirrors
+        clicking one of Wikidot's own quick-tag buttons
+        (WikiPageAction/updateTagsByButton), which sends whatever tag
+        string the button computed client-side rather than the page's
+        current tag list.
+
+        Parameters
+        ----------
+        tags : str
+            Space-separated tag string to apply
+
+        Returns
+        -------
+        Page
+            Self (for method chaining)
+
+        Raises
+        ------
+        LoginRequiredException
+            When not logged in
+        """
+        self.site.client.login_check()
+        self.site.amc_request(
+            [
+                {
+                    "action": "WikiPageAction",
+                    "event": "updateTagsByButton",
+                    "moduleName": "Empty",
+                    "pageId": self.id,
+                    "tags": tags,
+                }
+            ]
+        )
+        return self
+
+    def get_parent_form(self) -> str:
+        """
+        Get the rendered parent-page selection form (parent/ParentPageModule)
+
+        Returns
+        -------
+        str
+            Rendered HTML body
+        """
+        response = self.site.amc_request([{"moduleName": "parent/ParentPageModule", "page_id": self.id}])[0]
+        return require_body(response, "parent/ParentPageModule")
 
     def set_parent(self, parent_fullname: str | None) -> "Page":
         """
@@ -1637,7 +1811,38 @@ class Page:
         self.parent_fullname = parent_fullname
         return self
 
-    def rename(self, new_fullname: str) -> "Page":
+    def get_rename_backlinks(self) -> str:
+        """
+        Get pages linking to this page, for building rename()'s fixdeps (rename/RenameBacklinksModule)
+
+        Returns the rendered HTML listing backlink pages with checkboxes;
+        the IDs of the ones a caller wants fixed up are what `rename()`'s
+        `fixdeps` expects. The exact list markup was not captured during
+        wire-format research (only the request/response shape is
+        documented: `{page_id}` in, checked IDs comma-joined into
+        `fixdeps` on rename), so this returns the raw body rather than a
+        parsed ID list; parse the HTML yourself until the markup is
+        confirmed.
+
+        Returns
+        -------
+        str
+            Rendered HTML body listing backlink pages
+
+        Raises
+        ------
+        ResponseDataException
+            When the response has no "body" field
+        """
+        response = self.site.amc_request([{"moduleName": "rename/RenameBacklinksModule", "page_id": self.id}])[0]
+        return require_body(response, "rename/RenameBacklinksModule")
+
+    def rename(
+        self,
+        new_fullname: str,
+        fixdeps: list[int] | None = None,
+        force: bool = False,
+    ) -> "Page":
         """
         Rename the page
 
@@ -1648,6 +1853,12 @@ class Page:
         ----------
         new_fullname : str
             New fullname (e.g., "component:new-name")
+        fixdeps : list[int] | None, default None
+            Backlink page IDs (see get_rename_backlinks()) whose links
+            should be updated to the new name along with the rename
+        force : bool, default False
+            Whether to force the rename despite an active edit lock held
+            by someone else
 
         Returns
         -------
@@ -1659,20 +1870,36 @@ class Page:
         LoginRequiredException
             When not logged in
         WikidotStatusCodeException
-            When renaming the page fails (e.g., when a page with the same name exists)
+            When renaming the page fails (e.g., page_exists/not_allowed/no_new_name)
+        TargetErrorException
+            When the rename did not complete because the page is locked
+            (`locks` in the response) or because backlink dependencies are
+            left unresolved (`leftDeps` in the response, alongside the
+            server-computed `newName`)
         """
         self.site.client.login_check()
-        self.site.amc_request(
-            [
-                {
-                    "action": "WikiPageAction",
-                    "event": "renamePage",
-                    "moduleName": "Empty",
-                    "page_id": self.id,
-                    "new_name": new_fullname,
-                }
-            ]
-        )
+        body = {
+            "action": "WikiPageAction",
+            "event": "renamePage",
+            "moduleName": "Empty",
+            "page_id": self.id,
+            "new_name": new_fullname,
+            **omit_falsy(
+                fixdeps=",".join(str(dep_id) for dep_id in fixdeps) if fixdeps else False,
+                force="yes" if force else False,
+            ),
+        }
+        response = self.site.amc_request([body])[0]
+        data = response.json()
+
+        if data.get("locks"):
+            raise exceptions.TargetErrorException(f"Cannot rename page {self.fullname}: page is locked")
+        if data.get("leftDeps"):
+            raise exceptions.TargetErrorException(
+                f"Cannot rename page {self.fullname}: unresolved backlink dependencies remain "
+                f"(newName={data.get('newName')})"
+            )
+
         self.fullname = new_fullname
         if ":" in new_fullname:
             self.category, self.name = new_fullname.split(":", 1)

--- a/src/wikidot/module/page_edit_session.py
+++ b/src/wikidot/module/page_edit_session.py
@@ -1,0 +1,534 @@
+"""
+Module for managing Wikidot page edit sessions
+
+Wraps the lock lifecycle of `edit/PageEditModule` (acquire on entering the
+session, keep alive via `synchronize`, release via `removePageEditLock`)
+behind a context manager. Wikidot holds the lock for up to 15 minutes once
+`edit/PageEditModule` is requested; any code path that acquires the lock
+but does not reach a successful `savePage` must release it explicitly, or
+the page stays uneditable for other users until the lock expires. See
+`30_plan.md` D5 in the sibling wikidot.py repo's memory directory
+(`.local/memory/260728_wikidot-ajax-modules/`) for the design rationale.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Literal
+
+from ..common import exceptions, wd_logger
+from ..connector.ajax import require_body
+from ..util.amc_body import checkbox, omit_falsy
+
+if TYPE_CHECKING:
+    from .site import Site
+
+#: Edit mode accepted by edit/PageEditModule. "section" requires `section`
+#: to be set; savePage then takes `range_start`/`range_end` instead.
+EditMode = Literal["page", "section", "append"]
+
+
+@dataclass
+class PageEditSession:
+    """
+    A context manager representing a single Wikidot page edit session
+
+    Acquiring the lock (via `open()` or entering the `with` block) talks to
+    `edit/PageEditModule`. From that point on the lock is held until either
+    `save()` succeeds or the session is released (explicitly via
+    `release()`, or automatically on `__exit__` if `save()` never
+    succeeded).
+
+    Parameters
+    ----------
+    site : Site
+        Site the page belongs to
+    fullname : str
+        Fullname of the page being edited
+    page_id : int | None, default None
+        Page ID when editing an existing page (omitted from requests, and
+        must be None, when creating a new page)
+    mode : Literal["page", "section", "append"], default "page"
+        Edit mode
+    section : int | None, default None
+        Section number to edit. Required when mode is "section", used only
+        when acquiring the lock (savePage instead takes range_start/range_end)
+    force_lock : bool, default False
+        Whether to forcibly take over a lock held by another user when
+        opening the session
+
+    Attributes
+    ----------
+    lock_id : str | None
+        Lock ID, set once the session is open
+    lock_secret : str | None
+        Lock secret, set once the session is open
+    revision_id : str
+        Revision ID to submit with save/synchronize requests. Starts as the
+        `page_revision_id` returned when the lock was acquired (empty
+        string for a new page) and is not otherwise updated by this class
+        (Wikidot's `and_continue` response carries a new `revisionId`, but
+        that is returned to the caller from `save()` rather than folded
+        back into the session, since a session is expected to end after a
+        successful save)
+    time_left : int | None
+        Remaining lock time in seconds, last refreshed by open/synchronize/
+        forceLockIntercept/recreateExpiredLock
+    is_existing_page : bool
+        Whether the page already existed when the lock was acquired
+        (`page_revision_id` was present in the lock response)
+    """
+
+    site: Site
+    fullname: str
+    page_id: int | None = None
+    mode: EditMode = "page"
+    section: int | None = None
+    force_lock: bool = False
+
+    lock_id: str | None = field(default=None, init=False)
+    lock_secret: str | None = field(default=None, init=False)
+    revision_id: str = field(default="", init=False)
+    time_left: int | None = field(default=None, init=False)
+    is_existing_page: bool = field(default=False, init=False)
+    _saved: bool = field(default=False, init=False, repr=False)
+    _locked: bool = field(default=False, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if self.mode == "section" and self.section is None:
+            raise ValueError('section must be specified when mode is "section"')
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def open(self) -> PageEditSession:
+        """
+        Acquire the edit lock (edit/PageEditModule)
+
+        Equivalent to entering the session via `with`; provided separately
+        for callers that need finer control over when release() happens
+        than a single `with` block allows.
+
+        Returns
+        -------
+        PageEditSession
+            Self, for chaining (`with PageEditSession(...).open() as ed:`
+            also works, though entering via `with` alone already opens it)
+
+        Raises
+        ------
+        LoginRequiredException
+            When not logged in
+        TargetErrorException
+            When the page is locked by another user (lock was never
+            acquired, so nothing needs releasing)
+        """
+        self.site.client.login_check()
+
+        body: dict[str, Any] = {
+            "mode": self.mode,
+            "wiki_page": self.fullname,
+            "moduleName": "edit/PageEditModule",
+        }
+        if self.page_id is not None:
+            body["page_id"] = self.page_id
+        if self.mode == "section":
+            body["section"] = self.section
+        if self.force_lock:
+            body["force_lock"] = "yes"
+
+        response = self.site.amc_request([body])[0]
+        data = response.json()
+
+        if data.get("locked") or data.get("other_locks"):
+            raise exceptions.TargetErrorException(f"Page {self.fullname} is locked or other locks exist")
+
+        self.is_existing_page = "page_revision_id" in data
+        self.lock_id = data["lock_id"]
+        self.lock_secret = data["lock_secret"]
+        self.revision_id = str(data.get("page_revision_id", ""))
+        self.time_left = data.get("timeLeft")
+        self._locked = True
+        return self
+
+    def __enter__(self) -> PageEditSession:
+        return self.open()
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        if self._locked and not self._saved:
+            self.release()
+
+    def _require_open(self) -> None:
+        if not self._locked:
+            raise exceptions.UnexpectedException("Edit session is not open; call open() or enter it via 'with' first")
+
+    def _lock_params(self) -> dict[str, Any]:
+        """Common lock-identifying params shared by save/synchronize."""
+        self._require_open()
+        params: dict[str, Any] = {
+            "mode": self.mode,
+            "wiki_page": self.fullname,
+            "lock_id": self.lock_id,
+            "lock_secret": self.lock_secret,
+            "revision_id": self.revision_id,
+        }
+        if self.page_id is not None:
+            params["page_id"] = self.page_id
+        return params
+
+    # ------------------------------------------------------------------
+    # Operations
+    # ------------------------------------------------------------------
+
+    def save(
+        self,
+        title: str = "",
+        source: str = "",
+        comment: str = "",
+        and_continue: bool = False,
+        range_start: int | None = None,
+        range_end: int | None = None,
+        tags: str | None = None,
+        parent_page: str | None = None,
+        dont_notify_watchers: bool = False,
+    ) -> dict[str, Any]:
+        """
+        Save the page (WikiPageAction/savePage)
+
+        Parameters
+        ----------
+        title : str, default ""
+            New title
+        source : str, default ""
+            New source code (Wikidot markup)
+        comment : str, default ""
+            Edit comment
+        and_continue : bool, default False
+            Save and keep the lock/editor open (Wikidot returns a fresh
+            `revisionId` in this case, exposed via the returned dict)
+        range_start : int | None, default None
+            Start of the edited range. Only meaningful when mode is "section"
+        range_end : int | None, default None
+            End of the edited range. Only meaningful when mode is "section"
+        tags : str | None, default None
+            Space-separated tags, only used when creating a page via a
+            /tags/... URL
+        parent_page : str | None, default None
+            Parent page fullname, only used when creating a page via a
+            /parentPage/... URL
+        dont_notify_watchers : bool, default False
+            Suppress the "page updated" notification to watchers
+
+        Returns
+        -------
+        dict[str, Any]
+            Raw response data (e.g. `pageUnixName` on rename, `revisionId`
+            when and_continue is set)
+
+        Raises
+        ------
+        FormErrorsException
+            Validation failure (raised by the AMC client layer; the
+            per-field messages are under `errors`)
+        WikidotStatusCodeException
+            Any other non-"ok" status
+        TargetErrorException
+            The lock was lost mid-edit (`noLockError` in the response)
+        """
+        body = {
+            "action": "WikiPageAction",
+            "event": "savePage",
+            "moduleName": "Empty",
+            **self._lock_params(),
+            "title": title,
+            "source": source,
+            "comments": comment,
+            **omit_falsy(
+                and_continue="yes" if and_continue else False,
+                range_start=range_start,
+                range_end=range_end,
+                tags=tags,
+                parentPage=parent_page,
+                dont_notify_watchers=checkbox(dont_notify_watchers),
+            ),
+        }
+
+        response = self.site.amc_request([body])[0]
+        data = response.json()
+
+        if data["status"] != "ok":
+            raise exceptions.WikidotStatusCodeException(f"Failed to save page: {self.fullname}", data["status"], data)
+
+        # Wikidot reports lock loss as `noLockError: true` alongside status
+        # "ok", not as a distinct status value (per 50_page.md), so this is
+        # checked separately from the status branch above.
+        if data.get("noLockError"):
+            raise exceptions.TargetErrorException(
+                f"Edit lock lost while saving page {self.fullname}: {data.get('body', '')}"
+            )
+
+        self._saved = True
+        return data
+
+    def synchronize(self, since_last_input: int = 0) -> dict[str, Any]:
+        """
+        Keep the edit lock alive (WikiPageAction/synchronize)
+
+        Call periodically (Wikidot's own client does so every 60 seconds,
+        or sooner if fewer than 60 seconds remain and there has been
+        input) while the editor stays open without saving.
+
+        Parameters
+        ----------
+        since_last_input : int, default 0
+            Seconds elapsed since the last user input
+
+        Returns
+        -------
+        dict[str, Any]
+            Raw response data (`timeLeft`, `savedDraft`, `lockRecreated`, ...)
+
+        Raises
+        ------
+        TargetErrorException
+            The lock was lost (`noLockError` in the response)
+        """
+        body = {
+            "action": "WikiPageAction",
+            "event": "synchronize",
+            "moduleName": "Empty",
+            **self._lock_params(),
+            "since_last_input": since_last_input,
+        }
+        response = self.site.amc_request([body])[0]
+        data = response.json()
+
+        if data.get("noLockError"):
+            raise exceptions.TargetErrorException(f"Edit lock lost for page {self.fullname}")
+
+        # Wikidot may recreate the lock transparently (e.g. after a brief
+        # server-side expiry); the response then carries fresh
+        # camelCase lockId/lockSecret that must replace the ones used to
+        # acquire the lock, or subsequent save()/synchronize() calls fail.
+        if data.get("lockRecreated"):
+            self.lock_id = data["lockId"]
+            self.lock_secret = data["lockSecret"]
+
+        self.time_left = data.get("timeLeft")
+        return data
+
+    def check_draft_exists(self, title: str = "", source: str = "", comment: str = "") -> bool:
+        """
+        Check whether a draft already exists for this lock (WikiPageAction/checkDraftExists)
+
+        Parameters
+        ----------
+        title : str, default ""
+            Current in-progress title
+        source : str, default ""
+            Current in-progress source
+        comment : str, default ""
+            Current in-progress comment
+
+        Returns
+        -------
+        bool
+            Whether a draft exists
+
+        Notes
+        -----
+        The wire format echoes `form(edit-page-form)` back to the server
+        alongside the lock identifiers (per 30_action-catalog.md); this
+        implementation sends title/source/comments for that form, but the
+        exact reason the server wants the in-progress content for this
+        check (as opposed to just the lock id) is not documented upstream,
+        so this is an implementation judgment call rather than a confirmed
+        wire contract.
+        """
+        body = {
+            "action": "WikiPageAction",
+            "event": "checkDraftExists",
+            "moduleName": "Empty",
+            "wiki_page": self.fullname,
+            "lock_id": self.lock_id,
+            "title": title,
+            "source": source,
+            "comments": comment,
+            **omit_falsy(page_id=self.page_id),
+        }
+        response = self.site.amc_request([body])[0]
+        return bool(response.json().get("draftExists"))
+
+    def force_lock_intercept(self) -> dict[str, Any]:
+        """
+        Forcibly take over another user's lock (WikiPageAction/forceLockIntercept)
+
+        Unlike `force_lock=True` on the session (used when first acquiring
+        the lock), this is for a session that already holds a lock and
+        wants to intercept a newer lock taken by someone else in the
+        meantime.
+
+        Returns
+        -------
+        dict[str, Any]
+            Raw response data (`timeLeft`, `nonrecoverable`, `body`,
+            `error`, ...). On success this session's lock_id/lock_secret
+            are updated in place
+        """
+        body = {
+            "action": "WikiPageAction",
+            "event": "forceLockIntercept",
+            "moduleName": "Empty",
+            **self._lock_params(),
+        }
+        response = self.site.amc_request([body])[0]
+        data = response.json()
+
+        if "lock_id" in data:
+            self.lock_id = data["lock_id"]
+        if "lock_secret" in data:
+            self.lock_secret = data["lock_secret"]
+        self.time_left = data.get("timeLeft")
+        return data
+
+    def recreate_expired_lock(self) -> dict[str, Any]:
+        """
+        Recreate an expired lock (WikiPageAction/recreateExpiredLock)
+
+        Returns
+        -------
+        dict[str, Any]
+            Raw response data (`lockRecreated`, `lockId`, `lockSecret`,
+            `timeLeft`). On success this session's lock_id/lock_secret are
+            updated in place
+        """
+        body = {
+            "action": "WikiPageAction",
+            "event": "recreateExpiredLock",
+            "moduleName": "Empty",
+            **self._lock_params(),
+            "since_last_input": 0,
+        }
+        response = self.site.amc_request([body])[0]
+        data = response.json()
+
+        if data.get("lockRecreated"):
+            self.lock_id = data["lockId"]
+            self.lock_secret = data["lockSecret"]
+        self.time_left = data.get("timeLeft")
+        return data
+
+    def release(self, leave_draft: bool = False) -> None:
+        """
+        Release the edit lock (WikiPageAction/removePageEditLock)
+
+        Safe to call multiple times or on a session that was never opened
+        (no-op in that case). Failures are logged, not raised, so calling
+        this from `__exit__` never masks whatever error triggered the exit.
+
+        Parameters
+        ----------
+        leave_draft : bool, default False
+            Whether to keep the in-progress content as a draft instead of
+            discarding it
+        """
+        if not self._locked:
+            return
+        body: dict[str, Any] = {
+            "action": "WikiPageAction",
+            "event": "removePageEditLock",
+            "moduleName": "Empty",
+            "lock_id": self.lock_id,
+            "lock_secret": self.lock_secret,
+            "wiki_page": self.fullname,
+            **omit_falsy(leave_draft=leave_draft, page_id=self.page_id),
+        }
+        try:
+            self.site.amc_request([body])
+        except Exception:
+            wd_logger.exception(f"Failed to release page edit lock for {self.fullname} (lock_id={self.lock_id})")
+        finally:
+            self._locked = False
+
+    def preview(
+        self,
+        title: str = "",
+        source: str = "",
+        page_unix_name: str | None = None,
+        range_start: int | None = None,
+        range_end: int | None = None,
+    ) -> dict[str, str]:
+        """
+        Render a preview of in-progress content (edit/PagePreviewModule)
+
+        Parameters
+        ----------
+        title : str, default ""
+            In-progress title
+        source : str, default ""
+            In-progress source
+        page_unix_name : str | None, default None
+            Page unix name to preview under. Defaults to this session's
+            fullname
+        range_start : int | None, default None
+            Start of the edited range (mode="section" only)
+        range_end : int | None, default None
+            End of the edited range (mode="section" only)
+
+        Returns
+        -------
+        dict[str, str]
+            `{"body": <rendered HTML>, "title": <rendered title>}`
+        """
+        self._require_open()
+        body = {
+            "moduleName": "edit/PagePreviewModule",
+            "mode": self.mode,
+            "revision_id": self.revision_id,
+            "title": title,
+            "source": source,
+            "page_unix_name": page_unix_name or self.fullname,
+            **omit_falsy(pageId=self.page_id, range_start=range_start, range_end=range_end),
+        }
+        response = self.site.amc_request([body])[0]
+        data = response.json()
+        return {"body": require_body(response, "edit/PagePreviewModule"), "title": data.get("title", "")}
+
+    def diff(
+        self,
+        title: str = "",
+        source: str = "",
+        range_start: int | None = None,
+        range_end: int | None = None,
+    ) -> str:
+        """
+        Render a diff of in-progress content against the base revision (edit/PageEditDiffModule)
+
+        Parameters
+        ----------
+        title : str, default ""
+            In-progress title
+        source : str, default ""
+            In-progress source
+        range_start : int | None, default None
+            Start of the edited range (mode="section" only)
+        range_end : int | None, default None
+            End of the edited range (mode="section" only)
+
+        Returns
+        -------
+        str
+            Rendered diff HTML
+        """
+        self._require_open()
+        body = {
+            "moduleName": "edit/PageEditDiffModule",
+            "mode": self.mode,
+            "revision_id": self.revision_id,
+            "title": title,
+            "source": source,
+            **omit_falsy(range_start=range_start, range_end=range_end),
+        }
+        response = self.site.amc_request([body])[0]
+        return require_body(response, "edit/PageEditDiffModule")

--- a/src/wikidot/module/page_file.py
+++ b/src/wikidot/module/page_file.py
@@ -5,6 +5,7 @@ This module provides classes and functions related to files attached
 to Wikidot site pages. It enables operations such as retrieving file information.
 """
 
+import json
 from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
@@ -12,6 +13,7 @@ from typing import TYPE_CHECKING, Optional
 from bs4 import BeautifulSoup
 
 from ..connector.ajax import require_body
+from ..util.amc_body import flag, omit_falsy
 
 if TYPE_CHECKING:
     from .page import Page
@@ -215,6 +217,160 @@ class PageFileCollection(list["PageFile"]):
 
         return PageFileCollection(page=page, files=files)
 
+    @staticmethod
+    def check_exists(page: "Page", filename: str) -> bool:
+        """
+        Check whether a file with the given name exists on the page (FileAction/checkFileExists)
+
+        Parameters
+        ----------
+        page : Page
+            Page to check
+        filename : str
+            File name to check for
+
+        Returns
+        -------
+        bool
+            Whether the file exists
+        """
+        response = page.site.amc_request(
+            [
+                {
+                    "action": "FileAction",
+                    "event": "checkFileExists",
+                    "moduleName": "Empty",
+                    "filename": filename,
+                    "pageId": page.id,
+                }
+            ]
+        )[0]
+        return bool(response.json().get("exists"))
+
+    @staticmethod
+    def get_upload_form(page: "Page") -> str:
+        """
+        Get the rendered file upload form for a page (files/FileUploadModule)
+
+        Returns the HTML form only; the actual upload goes through the
+        separate multipart endpoint (see page_file_upload.py / D8 Task 3-5b),
+        not this module.
+
+        Parameters
+        ----------
+        page : Page
+            Page to render the upload form for
+
+        Returns
+        -------
+        str
+            Rendered HTML body
+        """
+        response = page.site.amc_request([{"moduleName": "files/FileUploadModule", "pageId": page.id}])[0]
+        return require_body(response, "files/FileUploadModule")
+
+    @staticmethod
+    def get_manager(page: "Page") -> str:
+        """
+        Get the rendered site-wide file manager view (files/manager/FileManagerModule)
+
+        The exact parameter set for a manager view scoped beyond a single
+        page was not captured during wire-format research (only that this
+        module exists, per 32_tasks.md Task 3-5); this sends `pageId` as
+        the one documented per-page parameter shape and returns the raw
+        body, which callers can parse or otherwise use as-is.
+
+        Parameters
+        ----------
+        page : Page
+            Page to scope the file manager view to
+
+        Returns
+        -------
+        str
+            Rendered HTML body
+        """
+        response = page.site.amc_request([{"moduleName": "files/manager/FileManagerModule", "pageId": page.id}])[0]
+        return require_body(response, "files/manager/FileManagerModule")
+
+    @staticmethod
+    def upload(
+        page: "Page",
+        filename: str,
+        content: bytes,
+        *,
+        multikey: str | None = None,
+    ) -> dict[str, str]:
+        """
+        Upload a file to a page (multipart, /default--flow/files__UploadTarget)
+
+        UNVERIFIED AGAINST A LIVE WIKIDOT INSTANCE -- see
+        AjaxModuleConnectorClient.upload_file's docstring for what is and
+        isn't confirmed. Does not go through site.amc_request(): this
+        endpoint returns an HTML fragment rather than the AMC JSON
+        envelope, so it uses a dedicated client method instead.
+
+        Parameters
+        ----------
+        page : Page
+            Page to attach the file to
+        filename : str
+            File name as it will appear on the page
+        content : bytes
+            File content
+        multikey : str | None, default None
+            Multi-file upload session key, required when uploading more
+            than one file so Wikidot can group them for
+            multi_upload_complete()
+
+        Returns
+        -------
+        dict[str, str]
+            Parsed response fields among "status" / "message" / "filename"
+        """
+        page.site.client.login_check()
+        return page.site.client.amc_client.upload_file(
+            page_id=page.id,
+            filename=filename,
+            content=content,
+            site_name=page.site.unix_name,
+            site_ssl_supported=page.site.ssl_supported,
+            multikey=multikey,
+        )
+
+    @staticmethod
+    def multi_upload_complete(page: "Page", multikey: str, filenames: list[str]) -> None:
+        """
+        Notify Wikidot that a batch of multipart uploads has finished (FileAction/multiUploadComplete)
+
+        Parameters
+        ----------
+        page : Page
+            Page the files were uploaded to
+        multikey : str
+            Multi-file upload session key shared by the uploads in this batch
+        filenames : list[str]
+            File names uploaded in this batch
+
+        Raises
+        ------
+        LoginRequiredException
+            When not logged in
+        """
+        page.site.client.login_check()
+        page.site.amc_request(
+            [
+                {
+                    "action": "FileAction",
+                    "event": "multiUploadComplete",
+                    "moduleName": "Empty",
+                    "multikey": multikey,
+                    "fnames": json.dumps(filenames),
+                    "page_id": page.id,
+                }
+            ]
+        )
+
 
 @dataclass
 class PageFile:
@@ -256,3 +412,151 @@ class PageFile:
             String representation of the file
         """
         return f"PageFile(id={self.id}, name={self.name}, url={self.url}, mime_type={self.mime_type}, size={self.size})"
+
+    def get_rename_form(self) -> str:
+        """
+        Get the rendered rename form for this file (files/FileRenameWinModule)
+
+        Returns
+        -------
+        str
+            Rendered HTML body
+        """
+        response = self.page.site.amc_request([{"moduleName": "files/FileRenameWinModule", "file_id": self.id}])[0]
+        return require_body(response, "files/FileRenameWinModule")
+
+    def get_move_form(self) -> str:
+        """
+        Get the rendered move form for this file (files/FileMoveWinModule)
+
+        Returns
+        -------
+        str
+            Rendered HTML body
+        """
+        response = self.page.site.amc_request([{"moduleName": "files/FileMoveWinModule", "file_id": self.id}])[0]
+        return require_body(response, "files/FileMoveWinModule")
+
+    def get_info(self) -> str:
+        """
+        Get the rendered detail view for this file (files/FileInformationWinModule)
+
+        Returns
+        -------
+        str
+            Rendered HTML body
+        """
+        response = self.page.site.amc_request([{"moduleName": "files/FileInformationWinModule", "file_id": self.id}])[0]
+        return require_body(response, "files/FileInformationWinModule")
+
+    def rename(self, new_name: str, force: bool = False) -> "PageFile":
+        """
+        Rename this file (FileAction/renameFile)
+
+        Parameters
+        ----------
+        new_name : str
+            New file name
+        force : bool, default False
+            Whether to overwrite if a file with the new name already exists
+
+        Returns
+        -------
+        PageFile
+            Self (for method chaining)
+
+        Raises
+        ------
+        LoginRequiredException
+            When not logged in
+        WikidotStatusCodeException
+            When the rename fails. `status_code` is "file_exists" (a file
+            with that name already exists; response carries `body`) or
+            "name_error" (invalid name; response carries `message`)
+        """
+        self.page.site.client.login_check()
+        self.page.site.amc_request(
+            [
+                {
+                    "action": "FileAction",
+                    "event": "renameFile",
+                    "moduleName": "Empty",
+                    "file_id": self.id,
+                    "new_name": new_name,
+                    **omit_falsy(force=flag(force)),
+                }
+            ]
+        )
+        self.name = new_name
+        return self
+
+    def move(self, destination_page_name: str, force: bool = False) -> None:
+        """
+        Move this file to another page (FileAction/moveFile)
+
+        Parameters
+        ----------
+        destination_page_name : str
+            Fullname of the destination page
+        force : bool, default False
+            Whether to overwrite if a file with the same name already
+            exists on the destination page
+
+        Raises
+        ------
+        LoginRequiredException
+            When not logged in
+        WikidotStatusCodeException
+            When the move fails. `status_code` is "file_exists" /
+            "no_destination" / "no_destination_permission"
+
+        Notes
+        -----
+        After a successful move this object's `page` reference still
+        points at the source page; re-fetch the file from the
+        destination page if you need an up-to-date PageFile
+        """
+        self.page.site.client.login_check()
+        self.page.site.amc_request(
+            [
+                {
+                    "action": "FileAction",
+                    "event": "moveFile",
+                    "moduleName": "Empty",
+                    "file_id": self.id,
+                    "destination_page_name": destination_page_name,
+                    **omit_falsy(force=flag(force)),
+                }
+            ]
+        )
+
+    def delete(self, confirm: bool = False) -> None:
+        """
+        Delete this file (FileAction/deleteFile)
+
+        Parameters
+        ----------
+        confirm : bool, default False
+            Must be explicitly set to True. This is a destructive,
+            irreversible operation
+
+        Raises
+        ------
+        ValueError
+            When confirm is not True
+        LoginRequiredException
+            When not logged in
+        """
+        if not confirm:
+            raise ValueError("delete() is destructive; pass confirm=True to proceed")
+        self.page.site.client.login_check()
+        self.page.site.amc_request(
+            [
+                {
+                    "action": "FileAction",
+                    "event": "deleteFile",
+                    "moduleName": "Empty",
+                    "file_id": self.id,
+                }
+            ]
+        )

--- a/src/wikidot/module/page_revision.py
+++ b/src/wikidot/module/page_revision.py
@@ -5,21 +5,88 @@ This module provides classes and functions related to Wikidot page edit history 
 It enables operations such as retrieving revisions, getting source code, and displaying HTML.
 """
 
+import json
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from datetime import datetime
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Literal, Optional
 
 import httpx
 from bs4 import BeautifulSoup
 
 from ..common.exceptions import NoElementException
 from ..connector.ajax import require_body
+from ..util.amc_body import omit_falsy
+from ..util.parser import odate as odate_parser
+from ..util.parser import user as user_parser
 from .page_source import PageSource
 
 if TYPE_CHECKING:
     from .page import Page
     from .user import AbstractUser
+
+
+#: The 7 change-type flags accepted by history/PageRevisionListModule's
+#: `options` JSON. Distinct from UserChangesListModule's Dashboard-side
+#: options, which lack "tags" (see 32_tasks.md Task 3-3).
+HistoryOptionKey = Literal["all", "source", "title", "move", "tags", "files", "meta"]
+
+
+def parse_revision_list_html(page: "Page", body_html: BeautifulSoup) -> list["PageRevision"]:
+    """
+    Parse a history/PageRevisionListModule response body into PageRevision objects
+
+    Shared by PageCollection._acquire_page_revisions (page.py, the eager
+    full-history fetch behind Page.revisions) and
+    PageRevisionCollection.acquire (filtered/paginated fetch), so the
+    table-row parsing logic lives in one place.
+
+    Parameters
+    ----------
+    page : Page
+        Page the revisions belong to
+    body_html : BeautifulSoup
+        Parsed response body
+
+    Returns
+    -------
+    list[PageRevision]
+        Parsed revisions, in the order they appear in the table
+
+    Raises
+    ------
+    NoElementException
+        When a required element is not found in a revision row
+    """
+    revs: list[PageRevision] = []
+    for rev_element in body_html.select("table.page-history > tr[id^=revision-row-]"):
+        rev_id = int(str(rev_element["id"]).removeprefix("revision-row-"))
+
+        tds = rev_element.select("td")
+        rev_no = int(tds[0].text.strip().removesuffix("."))
+        created_by_elem = tds[4].select_one("span.printuser")
+        if created_by_elem is None:
+            raise NoElementException(f"Cannot find created by element for page: {page.fullname}, revision: {rev_id}")
+        created_by = user_parser(page.site.client, created_by_elem)
+
+        created_at_elem = tds[5].select_one("span.odate")
+        if created_at_elem is None:
+            raise NoElementException(f"Cannot find created at element for page: {page.fullname}, revision: {rev_id}")
+        created_at = odate_parser(created_at_elem)
+
+        comment = tds[6].text.strip()
+
+        revs.append(
+            PageRevision(
+                page=page,
+                id=rev_id,
+                rev_no=rev_no,
+                created_by=created_by,
+                created_at=created_at,
+                comment=comment,
+            )
+        )
+    return revs
 
 
 class PageRevisionCollection(list["PageRevision"]):
@@ -237,6 +304,90 @@ class PageRevisionCollection(list["PageRevision"]):
         self._acquire_htmls(self.page, self)
         return self
 
+    @staticmethod
+    def get_diff(page: "Page", from_revision_id: int, to_revision_id: int, show_type: str = "inline") -> str:
+        """
+        Get an HTML diff between two revisions (history/PageDiffModule)
+
+        Parameters
+        ----------
+        page : Page
+            Page the revisions belong to
+        from_revision_id : int
+            Revision ID to diff from
+        to_revision_id : int
+            Revision ID to diff to
+        show_type : str, default "inline"
+            Diff display type
+
+        Returns
+        -------
+        str
+            Rendered diff HTML
+        """
+        response = page.site.amc_request(
+            [
+                {
+                    "moduleName": "history/PageDiffModule",
+                    "from_revision_id": from_revision_id,
+                    "to_revision_id": to_revision_id,
+                    "show_type": show_type,
+                }
+            ]
+        )[0]
+        return require_body(response, "history/PageDiffModule")
+
+    @staticmethod
+    def acquire(
+        page: "Page",
+        options: "dict[HistoryOptionKey, bool] | None" = None,
+        perpage: Literal[20, 50, 100, 200] = 20,
+        page_no: int = 1,
+    ) -> "PageRevisionCollection":
+        """
+        Get a page's revision history with server-side filtering (history/PageRevisionListModule)
+
+        Unlike the eager full-history fetch behind `Page.revisions`
+        (`PageCollection._acquire_page_revisions`, which always requests
+        `{"all": True}` with a huge perpage to populate the whole
+        collection), this exposes the change-type filter and pagination
+        Wikidot's own history view uses.
+
+        Parameters
+        ----------
+        page : Page
+            Page to fetch history for
+        options : dict[HistoryOptionKey, bool] | None, default None
+            Change-type filter flags. Defaults to `{"all": True}` when
+            omitted. Valid keys are the page history view's 7 kinds --
+            "all"/"source"/"title"/"move"/"tags"/"files"/"meta" -- which
+            differ from the Dashboard-side UserChangesListModule's options
+            (no "tags" there); do not mix the two up
+        perpage : Literal[20, 50, 100, 200], default 20
+            Items per page (matches Wikidot's own #h-perpage choices)
+        page_no : int, default 1
+            Page number (1-indexed)
+
+        Returns
+        -------
+        PageRevisionCollection
+            Revisions on the requested page of history
+        """
+        response = page.site.amc_request(
+            [
+                {
+                    "moduleName": "history/PageRevisionListModule",
+                    "page_id": page.id,
+                    "page": page_no,
+                    "perpage": perpage,
+                    "options": json.dumps(options or {"all": True}),
+                }
+            ]
+        )[0]
+        body = require_body(response, "history/PageRevisionListModule")
+        body_html = BeautifulSoup(body, "lxml")
+        return PageRevisionCollection(page, parse_revision_list_html(page, body_html))
+
 
 @dataclass
 class PageRevision:
@@ -353,3 +504,40 @@ class PageRevision:
             The HTML display to set
         """
         self._html = value
+
+    def revert(self, force: bool = False) -> dict[str, Any]:
+        """
+        Revert the page to this revision (WikiPageAction/revert)
+
+        Parameters
+        ----------
+        force : bool, default False
+            Whether to force the revert despite an active edit lock held
+            by someone else
+
+        Returns
+        -------
+        dict[str, Any]
+            Raw response data. On a lock conflict (force not set, or set
+            but still refused), the response carries `locks` + `body`
+            describing the conflicting lock instead of completing the
+            revert; the caller is responsible for inspecting this rather
+            than the exception being raised here, since a lock conflict is
+            reported as `status: "ok"` with these extra keys
+
+        Raises
+        ------
+        LoginRequiredException
+            When not logged in
+        """
+        self.page.site.client.login_check()
+        body = {
+            "action": "WikiPageAction",
+            "event": "revert",
+            "moduleName": "Empty",
+            "pageId": self.page.id,
+            "revisionId": self.id,
+            **omit_falsy(force="yes" if force else False),
+        }
+        response = self.page.site.amc_request([body])[0]
+        return response.json()

--- a/src/wikidot/module/site.py
+++ b/src/wikidot/module/site.py
@@ -34,6 +34,7 @@ from .site_application import SiteApplication
 from .site_member import SiteMember
 from .site_member_admin import MemberAccessor
 from .site_settings import SiteSettingsAccessor
+from .site_tools import SiteToolsAccessor
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -373,6 +374,7 @@ class Site:
     forum: "SiteForumAccessor" = field(init=False, repr=False)
     settings: "SiteSettingsAccessor" = field(init=False, repr=False)
     member: "MemberAccessor" = field(init=False, repr=False)
+    tools: "SiteToolsAccessor" = field(init=False, repr=False)
 
     # キャッシュ属性
     _members: list["SiteMember"] | None = field(init=False, default=None, repr=False)
@@ -390,6 +392,7 @@ class Site:
         self.forum = SiteForumAccessor(self)
         self.settings = SiteSettingsAccessor(self)
         self.member = MemberAccessor(self)
+        self.tools = SiteToolsAccessor(self)
 
     def __str__(self) -> str:
         """

--- a/src/wikidot/module/site_tools.py
+++ b/src/wikidot/module/site_tools.py
@@ -1,0 +1,261 @@
+"""
+Module for site-wide tooling views: Site Tools, Wanted Pages, Orphaned
+Pages, Drafts, the category-driven page list (manage:listpages), and a
+filtered recent-changes feed.
+
+Access through `Site.tools`.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import TYPE_CHECKING, Any, Literal
+
+from bs4 import BeautifulSoup
+
+from ..common.exceptions import NoElementException
+from ..connector.ajax import require_body
+from ..util.amc_body import flag, omit_falsy
+from ..util.parser import odate as odate_parser
+from ..util.parser import user as user_parser
+
+if TYPE_CHECKING:
+    from .site import Site, SiteChange
+
+#: The 8 change-type flags accepted by changes/SiteChangesListModule's
+#: `options` JSON (distinct from history/PageRevisionListModule's 7 -- this
+#: one adds "new" and lacks nothing page history has).
+RecentChangesOptionKey = Literal["all", "source", "title", "tags", "move", "files", "new", "meta"]
+
+
+class SiteToolsAccessor:
+    """
+    Accessor for site-wide tooling views (Site Tools, Wanted/Orphaned
+    Pages, Drafts, category page lists, filtered recent changes)
+
+    Access through `Site.tools`.
+    """
+
+    def __init__(self, site: Site) -> None:
+        """
+        Initialize method
+
+        Parameters
+        ----------
+        site : Site
+            Parent site instance
+        """
+        self.site = site
+
+    def get_overview(self) -> str:
+        """
+        Get the rendered Site Tools overview page (sitetools/SiteToolsModule)
+
+        Returns
+        -------
+        str
+            Rendered HTML body
+        """
+        response = self.site.amc_request([{"moduleName": "sitetools/SiteToolsModule"}])[0]
+        return require_body(response, "sitetools/SiteToolsModule")
+
+    def get_wanted_pages(self, page: int | None = None, embed: bool = False) -> str:
+        """
+        Get the Wanted Pages list (sitetools/WantedPagesModule)
+
+        Parameters
+        ----------
+        page : int | None, default None
+            Page number for pagination
+        embed : bool, default False
+            Whether to render in embedded (no-chrome) mode
+
+        Returns
+        -------
+        str
+            Rendered HTML body
+        """
+        body: dict[str, Any] = {
+            "moduleName": "sitetools/WantedPagesModule",
+            **omit_falsy(p=page, embed=flag(embed)),
+        }
+        response = self.site.amc_request([body])[0]
+        return require_body(response, "sitetools/WantedPagesModule")
+
+    def get_orphaned_pages(self) -> str:
+        """
+        Get the Orphaned Pages list (sitetools/OrphanedPagesModule)
+
+        Returns
+        -------
+        str
+            Rendered HTML body
+        """
+        response = self.site.amc_request([{"moduleName": "sitetools/OrphanedPagesModule"}])[0]
+        return require_body(response, "sitetools/OrphanedPagesModule")
+
+    def get_drafts(self) -> str:
+        """
+        Get the drafts list, scoped to Site Tools (list/ListDraftsModule)
+
+        Returns
+        -------
+        str
+            Rendered HTML body
+        """
+        response = self.site.amc_request([{"moduleName": "list/ListDraftsModule", "location": "sitetools"}])[0]
+        return require_body(response, "list/ListDraftsModule")
+
+    def get_categories(self) -> str:
+        """
+        Get the category list for manage:listpages (list/WikiCategoriesModule)
+
+        Notes
+        -----
+        Per 50_page.md, the outer page-list body on manage:listpages is
+        static HTML shipped with the page itself, not fetched via this
+        module; this wraps the same module for programmatic access. Use
+        `expand_category()` to get an individual category's page list.
+
+        Returns
+        -------
+        str
+            Rendered HTML body
+        """
+        response = self.site.amc_request([{"moduleName": "list/WikiCategoriesModule"}])[0]
+        return require_body(response, "list/WikiCategoriesModule")
+
+    def expand_category(self, category_id: int, include_hidden: bool = False) -> str:
+        """
+        Get the page list for a single category (list/WikiCategoriesPageListModule)
+
+        Parameters
+        ----------
+        category_id : int
+            Category ID to expand
+        include_hidden : bool, default False
+            Whether to include hidden pages
+
+        Returns
+        -------
+        str
+            Rendered HTML body
+        """
+        body = {
+            "moduleName": "list/WikiCategoriesPageListModule",
+            "category_id": category_id,
+            **omit_falsy(includeHidden=flag(include_hidden)),
+        }
+        response = self.site.amc_request([body])[0]
+        return require_body(response, "list/WikiCategoriesPageListModule")
+
+    def get_recent_changes(
+        self,
+        category_id: int | None = None,
+        page_id: int | None = None,
+        options: dict[RecentChangesOptionKey, bool] | None = None,
+        perpage: Literal[10, 20, 50, 100, 200] = 20,
+        page_no: int = 1,
+    ) -> list[SiteChange]:
+        """
+        Get recent changes with server-side filtering (changes/SiteChangesListModule)
+
+        Unlike `Site.get_recent_changes()` (which always requests the
+        unfiltered "all" feed and paginates internally up to a `limit`),
+        this exposes the categoryId/pageId filtering and change-type
+        options flags Wikidot's own system:recent-changes view uses. Kept
+        as a separate method on this accessor, rather than as a change to
+        the existing one, to avoid modifying site.py (shared with other
+        in-flight work) beyond registering this accessor.
+
+        Parameters
+        ----------
+        category_id : int | None, default None
+            Restrict to a single category. Omitted (all categories) when None
+        page_id : int | None, default None
+            Restrict to a single page
+        options : dict[RecentChangesOptionKey, bool] | None, default None
+            Change-type filter flags. Defaults to `{"all": True}` when
+            omitted. Valid keys are this module's 8 kinds --
+            "all"/"source"/"title"/"tags"/"move"/"files"/"new"/"meta" --
+            which differ from history/PageRevisionListModule's 7 (no "new"
+            there); do not mix the two up
+        perpage : Literal[10, 20, 50, 100, 200], default 20
+            Items per page
+        page_no : int, default 1
+            Page number (1-indexed)
+
+        Returns
+        -------
+        list[SiteChange]
+            Changes on the requested page
+
+        Raises
+        ------
+        NoElementException
+            When HTML element parsing fails
+        """
+        from .site import SiteChange
+
+        body: dict[str, Any] = {
+            "moduleName": "changes/SiteChangesListModule",
+            "perpage": str(perpage),
+            "page": page_no,
+            "options": json.dumps(options or {"all": True}),
+            **omit_falsy(categoryId=category_id, pageId=page_id),
+        }
+        response = self.site.amc_request([body])[0]
+        html = BeautifulSoup(require_body(response, "changes/SiteChangesListModule"), "lxml")
+
+        changes: list[SiteChange] = []
+        for item in html.select("div.changes-list-item"):
+            comment_elem = item.select_one("td.comments")
+            comment = comment_elem.get_text().strip() if comment_elem else None
+            if comment == "":
+                comment = None
+
+            title_elem = item.select_one("td.title a")
+            if title_elem is None:
+                raise NoElementException("Title element is not found.")
+
+            page_title = title_elem.get_text().strip()
+            href = title_elem.get("href", "")
+            page_fullname = str(href).strip("/")
+
+            odate_elem = item.select_one("td.mod-date span.odate")
+            if odate_elem is None:
+                raise NoElementException("Odate element is not found.")
+            changed_at = odate_parser(odate_elem)
+
+            rev_elem = item.select_one("td.revision-no")
+            if rev_elem is None:
+                raise NoElementException("Revision number element is not found.")
+            rev_text = rev_elem.get_text()
+            rev_match = re.search(r"(\d+)", rev_text)
+            if rev_match is None:
+                raise NoElementException("Revision number is not found.")
+            revision_no = int(rev_match.group(1))
+
+            user_elem = item.select_one("td.mod-by span.printuser")
+            if user_elem is None:
+                raise NoElementException("User element is not found.")
+            changed_by = user_parser(self.site.client, user_elem)
+
+            flags_elem = item.select("td.flags span")
+            change_flags = [span.get_text().strip() for span in flags_elem]
+
+            changes.append(
+                SiteChange(
+                    site=self.site,
+                    page_fullname=page_fullname,
+                    page_title=page_title,
+                    revision_no=revision_no,
+                    changed_by=changed_by,
+                    changed_at=changed_at,
+                    flags=change_flags,
+                    comment=comment,
+                )
+            )
+
+        return changes

--- a/tests/unit/test_amc_client.py
+++ b/tests/unit/test_amc_client.py
@@ -561,3 +561,79 @@ class TestAjaxModuleConnectorClientFormErrors:
 
         with pytest.raises(WikidotStatusCodeException):
             client.request([{"moduleName": "Test"}])
+
+
+class TestAjaxModuleConnectorClientUploadFile:
+    """AjaxModuleConnectorClient.upload_file のテスト
+
+    Task 3-5b: /default--flow/files__UploadTarget は実機未検証（wire形式は
+    Wikidotのクライアント側JSの読解による）。ここではモックしたHTTPレスポンス
+    に対してリクエスト構築とレスポンスパースが正しく行われることのみ検証する。
+    """
+
+    def test_upload_file_success(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url="https://test-site.wikidot.com/default--flow/files__UploadTarget",
+            text='<div id="status">ok</div><div id="message">File uploaded.</div><div id="filename">a.txt</div>',
+        )
+
+        client = AjaxModuleConnectorClient(site_name="www")
+        result = client.upload_file(
+            page_id=1,
+            filename="a.txt",
+            content=b"hello",
+            site_name="test-site",
+            site_ssl_supported=True,
+        )
+
+        assert result == {"status": "ok", "message": "File uploaded.", "filename": "a.txt"}
+
+    def test_upload_file_sends_multipart_fields(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url="https://test-site.wikidot.com/default--flow/files__UploadTarget",
+            text='<div id="status">ok</div>',
+        )
+
+        client = AjaxModuleConnectorClient(site_name="www")
+        client.upload_file(
+            page_id=42,
+            filename="a.txt",
+            content=b"hello",
+            site_name="test-site",
+            site_ssl_supported=True,
+            multikey="mk-1",
+        )
+
+        request = httpx_mock.get_requests()[0]
+        body_text = request.content.decode()
+        assert 'name="action"' in body_text
+        assert "FileAction" in body_text
+        assert 'name="event"' in body_text
+        assert "uploadFile" in body_text
+        assert 'name="page_id"' in body_text
+        assert "42" in body_text
+        assert 'name="source"' in body_text
+        assert "multiflash" in body_text
+        assert 'name="multikey"' in body_text
+        assert "mk-1" in body_text
+        assert 'name="userfile"; filename="a.txt"' in body_text
+
+    def test_upload_file_missing_optional_fields(self, httpx_mock: HTTPXMock) -> None:
+        """statusのみのレスポンスでもエラーにならない"""
+        httpx_mock.add_response(
+            url="https://test-site.wikidot.com/default--flow/files__UploadTarget",
+            text='<div id="status">fail</div>',
+        )
+
+        client = AjaxModuleConnectorClient(site_name="www")
+        result = client.upload_file(
+            page_id=1,
+            filename="a.txt",
+            content=b"hello",
+            site_name="test-site",
+            site_ssl_supported=True,
+        )
+
+        assert result == {"status": "fail"}
+        assert "message" not in result
+        assert "filename" not in result

--- a/tests/unit/test_page.py
+++ b/tests/unit/test_page.py
@@ -808,3 +808,225 @@ class TestPageEdit:
         call_args_list = mock_page_with_id.site.amc_request.call_args_list
         lock_call = call_args_list[0]  # 1回目がロック取得
         assert lock_call[0][0][0].get("force_lock") == "yes"
+
+
+class TestPageOpenEditor:
+    """Page.open_editorのテスト"""
+
+    def test_open_editor_returns_unopened_session(self, mock_page_with_id: Page) -> None:
+        """未オープンのPageEditSessionを返す"""
+        from wikidot.module.page_edit_session import PageEditSession
+
+        session = mock_page_with_id.open_editor()
+        assert isinstance(session, PageEditSession)
+        assert session._locked is False
+        assert session.fullname == mock_page_with_id.fullname
+        assert session.page_id == mock_page_with_id._id
+
+
+class TestPageTemplateSource:
+    """Page.get_template_sourceのテスト"""
+
+    def test_get_template_source(self, mock_page_with_id: Page) -> None:
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "ok", "body": "template source"}
+        mock_page_with_id.site.amc_request = MagicMock(return_value=[mock_response])
+
+        result = mock_page_with_id.get_template_source()
+        assert result == "template source"
+
+
+class TestPageMetaMethods:
+    """Page.set_meta / delete_metaのテスト"""
+
+    def test_set_meta(self, mock_page_with_id: Page) -> None:
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "ok"}
+        mock_page_with_id.site.amc_request = MagicMock(return_value=[mock_response])
+        mock_page_with_id.site.client.is_logged_in = True
+        mock_page_with_id.site.client.login_check = MagicMock()
+
+        mock_page_with_id.set_meta("og:title", "Title")
+
+        body = mock_page_with_id.site.amc_request.call_args[0][0][0]
+        assert body["metaName"] == "og:title"
+        assert body["metaContent"] == "Title"
+        assert body["event"] == "saveMetaTag"
+        assert "allPages" not in body
+
+    def test_set_meta_all_pages(self, mock_page_with_id: Page) -> None:
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "ok"}
+        mock_page_with_id.site.amc_request = MagicMock(return_value=[mock_response])
+        mock_page_with_id.site.client.is_logged_in = True
+        mock_page_with_id.site.client.login_check = MagicMock()
+
+        mock_page_with_id.set_meta("og:title", "Title", all_pages=True)
+
+        body = mock_page_with_id.site.amc_request.call_args[0][0][0]
+        assert body["allPages"] == "true"
+
+    def test_delete_meta(self, mock_page_with_id: Page) -> None:
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "ok"}
+        mock_page_with_id.site.amc_request = MagicMock(return_value=[mock_response])
+        mock_page_with_id.site.client.is_logged_in = True
+        mock_page_with_id.site.client.login_check = MagicMock()
+
+        mock_page_with_id.delete_meta("og:title")
+
+        body = mock_page_with_id.site.amc_request.call_args[0][0][0]
+        assert body["event"] == "deleteMetaTag"
+        assert "allPages" not in body
+
+
+class TestPageBlock:
+    """Page.get_block_form / set_blockのテスト"""
+
+    def test_get_block_form(self, mock_page_with_id: Page) -> None:
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "ok", "body": "<form></form>"}
+        mock_page_with_id.site.amc_request = MagicMock(return_value=[mock_response])
+
+        assert mock_page_with_id.get_block_form() == "<form></form>"
+
+    def test_set_block_true(self, mock_page_with_id: Page) -> None:
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "ok"}
+        mock_page_with_id.site.amc_request = MagicMock(return_value=[mock_response])
+        mock_page_with_id.site.client.is_logged_in = True
+        mock_page_with_id.site.client.login_check = MagicMock()
+
+        mock_page_with_id.set_block(True)
+        body = mock_page_with_id.site.amc_request.call_args[0][0][0]
+        assert body["block"] == "true"
+
+    def test_set_block_false_omits_key(self, mock_page_with_id: Page) -> None:
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "ok"}
+        mock_page_with_id.site.amc_request = MagicMock(return_value=[mock_response])
+        mock_page_with_id.site.client.is_logged_in = True
+        mock_page_with_id.site.client.login_check = MagicMock()
+
+        mock_page_with_id.set_block(False)
+        body = mock_page_with_id.site.amc_request.call_args[0][0][0]
+        assert "block" not in body
+
+
+class TestPageBacklinksAndWatch:
+    """Page.get_backlinks / watch / get_watchersのテスト"""
+
+    def test_get_backlinks(self, mock_page_with_id: Page) -> None:
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "ok", "body": "<div>backlinks</div>"}
+        mock_page_with_id.site.amc_request = MagicMock(return_value=[mock_response])
+
+        assert mock_page_with_id.get_backlinks() == "<div>backlinks</div>"
+
+    def test_watch(self, mock_page_with_id: Page) -> None:
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "ok"}
+        mock_page_with_id.site.amc_request = MagicMock(return_value=[mock_response])
+        mock_page_with_id.site.client.is_logged_in = True
+        mock_page_with_id.site.client.login_check = MagicMock()
+
+        mock_page_with_id.watch()
+        body = mock_page_with_id.site.amc_request.call_args[0][0][0]
+        assert body["action"] == "WatchAction"
+        assert body["event"] == "watchPage"
+
+    def test_get_watchers(self, mock_page_with_id: Page) -> None:
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "ok", "body": "<div>watchers</div>"}
+        mock_page_with_id.site.amc_request = MagicMock(return_value=[mock_response])
+
+        assert mock_page_with_id.get_watchers() == "<div>watchers</div>"
+
+
+class TestPageTagsAndParentForms:
+    """Page.get_tags_form / update_tags_by_button / get_parent_formのテスト"""
+
+    def test_get_tags_form(self, mock_page_with_id: Page) -> None:
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "ok", "body": "<form></form>"}
+        mock_page_with_id.site.amc_request = MagicMock(return_value=[mock_response])
+
+        assert mock_page_with_id.get_tags_form() == "<form></form>"
+
+    def test_update_tags_by_button(self, mock_page_with_id: Page) -> None:
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "ok"}
+        mock_page_with_id.site.amc_request = MagicMock(return_value=[mock_response])
+        mock_page_with_id.site.client.is_logged_in = True
+        mock_page_with_id.site.client.login_check = MagicMock()
+
+        mock_page_with_id.update_tags_by_button("scp euclid")
+        body = mock_page_with_id.site.amc_request.call_args[0][0][0]
+        assert body["event"] == "updateTagsByButton"
+        assert body["tags"] == "scp euclid"
+
+    def test_get_parent_form(self, mock_page_with_id: Page) -> None:
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "ok", "body": "<form></form>"}
+        mock_page_with_id.site.amc_request = MagicMock(return_value=[mock_response])
+
+        assert mock_page_with_id.get_parent_form() == "<form></form>"
+
+
+class TestPageRenameExtended:
+    """Page.rename (fixdeps/force/locks/leftDeps) と get_rename_backlinksのテスト"""
+
+    def test_get_rename_backlinks(self, mock_page_with_id: Page) -> None:
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "ok", "body": "<div>backlinks</div>"}
+        mock_page_with_id.site.amc_request = MagicMock(return_value=[mock_response])
+
+        assert mock_page_with_id.get_rename_backlinks() == "<div>backlinks</div>"
+
+    def test_rename_with_fixdeps(self, mock_page_with_id: Page, page_rename_success: dict[str, Any]) -> None:
+        mock_response = MagicMock()
+        mock_response.json.return_value = page_rename_success
+        mock_page_with_id.site.amc_request = MagicMock(return_value=[mock_response])
+        mock_page_with_id.site.client.is_logged_in = True
+        mock_page_with_id.site.client.login_check = MagicMock()
+
+        mock_page_with_id.rename("new-name", fixdeps=[1, 2, 3])
+        body = mock_page_with_id.site.amc_request.call_args[0][0][0]
+        assert body["fixdeps"] == "1,2,3"
+
+    def test_rename_with_force(self, mock_page_with_id: Page, page_rename_success: dict[str, Any]) -> None:
+        mock_response = MagicMock()
+        mock_response.json.return_value = page_rename_success
+        mock_page_with_id.site.amc_request = MagicMock(return_value=[mock_response])
+        mock_page_with_id.site.client.is_logged_in = True
+        mock_page_with_id.site.client.login_check = MagicMock()
+
+        mock_page_with_id.rename("new-name", force=True)
+        body = mock_page_with_id.site.amc_request.call_args[0][0][0]
+        assert body["force"] == "yes"
+
+    def test_rename_locks_raises(self, mock_page_with_id: Page) -> None:
+        """locksが含まれる場合、握りつぶさずTargetErrorExceptionを送出"""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "ok", "locks": True, "body": "<div>locked</div>"}
+        mock_page_with_id.site.amc_request = MagicMock(return_value=[mock_response])
+        mock_page_with_id.site.client.is_logged_in = True
+        mock_page_with_id.site.client.login_check = MagicMock()
+
+        with pytest.raises(exceptions.TargetErrorException):
+            mock_page_with_id.rename("new-name")
+
+    def test_rename_left_deps_raises(self, mock_page_with_id: Page) -> None:
+        """leftDepsが含まれる場合、握りつぶさずTargetErrorExceptionを送出"""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "status": "ok",
+            "leftDeps": True,
+            "newName": "new-name",
+        }
+        mock_page_with_id.site.amc_request = MagicMock(return_value=[mock_response])
+        mock_page_with_id.site.client.is_logged_in = True
+        mock_page_with_id.site.client.login_check = MagicMock()
+
+        with pytest.raises(exceptions.TargetErrorException):
+            mock_page_with_id.rename("new-name")

--- a/tests/unit/test_page_edit_session.py
+++ b/tests/unit/test_page_edit_session.py
@@ -1,0 +1,390 @@
+"""PageEditSessionモジュールのユニットテスト"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+from wikidot.common import exceptions
+from wikidot.module.page_edit_session import PageEditSession
+
+if TYPE_CHECKING:
+    from wikidot.module.site import Site
+
+
+def _mock_response(data: dict) -> MagicMock:
+    response = MagicMock()
+    response.json.return_value = data
+    return response
+
+
+class TestPageEditSessionOpen:
+    """open() / __enter__ のテスト"""
+
+    def test_open_success_new_page(self, mock_site_no_http: Site) -> None:
+        """新規ページのロックを取得できる（page_revision_idなし）"""
+        mock_site_no_http.client.is_logged_in = True
+        mock_site_no_http.client.login_check = MagicMock()
+        mock_site_no_http.amc_request = MagicMock(
+            return_value=[_mock_response({"status": "ok", "lock_id": "L1", "lock_secret": "S1", "timeLeft": 900})]
+        )
+
+        session = PageEditSession(site=mock_site_no_http, fullname="new-page")
+        session.open()
+
+        assert session.lock_id == "L1"
+        assert session.lock_secret == "S1"
+        assert session.is_existing_page is False
+        assert session.revision_id == ""
+        assert session.time_left == 900
+
+    def test_open_success_existing_page(self, mock_site_no_http: Site) -> None:
+        """既存ページのロックを取得できる（page_revision_idあり）"""
+        mock_site_no_http.client.is_logged_in = True
+        mock_site_no_http.client.login_check = MagicMock()
+        mock_site_no_http.amc_request = MagicMock(
+            return_value=[
+                _mock_response(
+                    {
+                        "status": "ok",
+                        "lock_id": "L1",
+                        "lock_secret": "S1",
+                        "page_revision_id": 100,
+                        "timeLeft": 900,
+                    }
+                )
+            ]
+        )
+
+        session = PageEditSession(site=mock_site_no_http, fullname="existing-page", page_id=1)
+        session.open()
+
+        assert session.is_existing_page is True
+        assert session.revision_id == "100"
+
+    def test_open_locked_raises(self, mock_site_no_http: Site) -> None:
+        """ロック中の場合TargetErrorExceptionを送出"""
+        mock_site_no_http.client.is_logged_in = True
+        mock_site_no_http.client.login_check = MagicMock()
+        mock_site_no_http.amc_request = MagicMock(return_value=[_mock_response({"status": "ok", "locked": True})])
+
+        session = PageEditSession(site=mock_site_no_http, fullname="locked-page")
+        with pytest.raises(exceptions.TargetErrorException):
+            session.open()
+
+    def test_open_sends_force_lock(self, mock_site_no_http: Site) -> None:
+        """force_lock=Trueでforce_lock=yesが送られる"""
+        mock_site_no_http.client.is_logged_in = True
+        mock_site_no_http.client.login_check = MagicMock()
+        mock_site_no_http.amc_request = MagicMock(
+            return_value=[_mock_response({"status": "ok", "lock_id": "L1", "lock_secret": "S1"})]
+        )
+
+        session = PageEditSession(site=mock_site_no_http, fullname="p", force_lock=True)
+        session.open()
+
+        body = mock_site_no_http.amc_request.call_args[0][0][0]
+        assert body["force_lock"] == "yes"
+
+    def test_open_omits_page_id_when_none(self, mock_site_no_http: Site) -> None:
+        """page_id未指定時はキー自体を送らない"""
+        mock_site_no_http.client.is_logged_in = True
+        mock_site_no_http.client.login_check = MagicMock()
+        mock_site_no_http.amc_request = MagicMock(
+            return_value=[_mock_response({"status": "ok", "lock_id": "L1", "lock_secret": "S1"})]
+        )
+
+        session = PageEditSession(site=mock_site_no_http, fullname="new-page")
+        session.open()
+
+        body = mock_site_no_http.amc_request.call_args[0][0][0]
+        assert "page_id" not in body
+
+    def test_section_mode_requires_section(self, mock_site_no_http: Site) -> None:
+        """mode="section"でsection未指定はValueError"""
+        with pytest.raises(ValueError, match="section"):
+            PageEditSession(site=mock_site_no_http, fullname="p", mode="section")
+
+    def test_section_mode_sends_section_param(self, mock_site_no_http: Site) -> None:
+        """mode="section"でsectionパラメータが送られる"""
+        mock_site_no_http.client.is_logged_in = True
+        mock_site_no_http.client.login_check = MagicMock()
+        mock_site_no_http.amc_request = MagicMock(
+            return_value=[_mock_response({"status": "ok", "lock_id": "L1", "lock_secret": "S1"})]
+        )
+
+        session = PageEditSession(site=mock_site_no_http, fullname="p", mode="section", section=2)
+        session.open()
+
+        body = mock_site_no_http.amc_request.call_args[0][0][0]
+        assert body["section"] == 2
+        assert body["mode"] == "section"
+
+
+class TestPageEditSessionContextManager:
+    """__enter__ / __exit__ のテスト"""
+
+    def test_exit_releases_lock_when_not_saved(self, mock_site_no_http: Site) -> None:
+        """save()が呼ばれずにwithブロックを抜けるとロックを解放する"""
+        mock_site_no_http.client.is_logged_in = True
+        mock_site_no_http.client.login_check = MagicMock()
+        lock_response = _mock_response({"status": "ok", "lock_id": "L1", "lock_secret": "S1"})
+        release_response = _mock_response({"status": "ok"})
+        mock_site_no_http.amc_request = MagicMock(side_effect=[[lock_response], [release_response]])
+
+        with PageEditSession(site=mock_site_no_http, fullname="p") as session:
+            assert session.lock_id == "L1"
+
+        assert mock_site_no_http.amc_request.call_count == 2
+        release_body = mock_site_no_http.amc_request.call_args_list[1][0][0][0]
+        assert release_body["event"] == "removePageEditLock"
+
+    def test_exit_does_not_release_after_successful_save(self, mock_site_no_http: Site) -> None:
+        """save()成功後はロックを解放しない"""
+        mock_site_no_http.client.is_logged_in = True
+        mock_site_no_http.client.login_check = MagicMock()
+        lock_response = _mock_response({"status": "ok", "lock_id": "L1", "lock_secret": "S1"})
+        save_response = _mock_response({"status": "ok"})
+        mock_site_no_http.amc_request = MagicMock(side_effect=[[lock_response], [save_response]])
+
+        with PageEditSession(site=mock_site_no_http, fullname="p") as session:
+            session.save(title="t", source="s")
+
+        assert mock_site_no_http.amc_request.call_count == 2
+
+    def test_exit_releases_lock_on_exception(self, mock_site_no_http: Site) -> None:
+        """withブロック内で例外が発生した場合もロックを解放する"""
+        mock_site_no_http.client.is_logged_in = True
+        mock_site_no_http.client.login_check = MagicMock()
+        lock_response = _mock_response({"status": "ok", "lock_id": "L1", "lock_secret": "S1"})
+        release_response = _mock_response({"status": "ok"})
+        mock_site_no_http.amc_request = MagicMock(side_effect=[[lock_response], [release_response]])
+
+        with pytest.raises(ValueError), PageEditSession(site=mock_site_no_http, fullname="p") as session:
+            assert session.lock_id == "L1"
+            raise ValueError("boom")
+
+        assert mock_site_no_http.amc_request.call_count == 2
+
+    def test_enter_failure_does_not_call_exit_release(self, mock_site_no_http: Site) -> None:
+        """__enter__自体が失敗した場合は解放リクエストを送らない（ロック未取得のため）"""
+        mock_site_no_http.client.is_logged_in = True
+        mock_site_no_http.client.login_check = MagicMock()
+        mock_site_no_http.amc_request = MagicMock(return_value=[_mock_response({"status": "ok", "locked": True})])
+
+        with pytest.raises(exceptions.TargetErrorException), PageEditSession(site=mock_site_no_http, fullname="p"):
+            pass
+
+        assert mock_site_no_http.amc_request.call_count == 1
+
+
+class TestPageEditSessionSave:
+    """save() のテスト"""
+
+    def test_save_success(self, mock_site_no_http: Site) -> None:
+        """保存が成功する"""
+        mock_site_no_http.client.is_logged_in = True
+        mock_site_no_http.client.login_check = MagicMock()
+        lock_response = _mock_response({"status": "ok", "lock_id": "L1", "lock_secret": "S1"})
+        save_response = _mock_response({"status": "ok", "revisionId": 999})
+        mock_site_no_http.amc_request = MagicMock(side_effect=[[lock_response], [save_response]])
+
+        session = PageEditSession(site=mock_site_no_http, fullname="p").open()
+        data = session.save(title="t", source="s", comment="c")
+
+        assert data["revisionId"] == 999
+        assert session._saved is True
+
+    def test_save_status_not_ok_raises(self, mock_site_no_http: Site) -> None:
+        """statusが"ok"以外の場合WikidotStatusCodeException"""
+        mock_site_no_http.client.is_logged_in = True
+        mock_site_no_http.client.login_check = MagicMock()
+        lock_response = _mock_response({"status": "ok", "lock_id": "L1", "lock_secret": "S1"})
+        save_response = _mock_response({"status": "no_permission"})
+        mock_site_no_http.amc_request = MagicMock(side_effect=[[lock_response], [save_response]])
+
+        session = PageEditSession(site=mock_site_no_http, fullname="p").open()
+        with pytest.raises(exceptions.WikidotStatusCodeException):
+            session.save()
+
+    def test_save_no_lock_error_raises(self, mock_site_no_http: Site) -> None:
+        """noLockErrorが立っている場合TargetErrorException"""
+        mock_site_no_http.client.is_logged_in = True
+        mock_site_no_http.client.login_check = MagicMock()
+        lock_response = _mock_response({"status": "ok", "lock_id": "L1", "lock_secret": "S1"})
+        save_response = _mock_response({"status": "ok", "noLockError": True, "body": "lost", "nonrecoverable": True})
+        mock_site_no_http.amc_request = MagicMock(side_effect=[[lock_response], [save_response]])
+
+        session = PageEditSession(site=mock_site_no_http, fullname="p").open()
+        with pytest.raises(exceptions.TargetErrorException):
+            session.save()
+
+    def test_save_before_open_raises(self, mock_site_no_http: Site) -> None:
+        """openせずにsave()を呼ぶとUnexpectedException"""
+        session = PageEditSession(site=mock_site_no_http, fullname="p")
+        with pytest.raises(exceptions.UnexpectedException):
+            session.save()
+
+    def test_save_and_continue_sends_yes(self, mock_site_no_http: Site) -> None:
+        """and_continue=Trueでand_continue=yesが送られる"""
+        mock_site_no_http.client.is_logged_in = True
+        mock_site_no_http.client.login_check = MagicMock()
+        lock_response = _mock_response({"status": "ok", "lock_id": "L1", "lock_secret": "S1"})
+        save_response = _mock_response({"status": "ok"})
+        mock_site_no_http.amc_request = MagicMock(side_effect=[[lock_response], [save_response]])
+
+        session = PageEditSession(site=mock_site_no_http, fullname="p").open()
+        session.save(and_continue=True)
+
+        body = mock_site_no_http.amc_request.call_args[0][0][0]
+        assert body["and_continue"] == "yes"
+
+    def test_save_omits_optional_falsy_params(self, mock_site_no_http: Site) -> None:
+        """range_start/range_end/tags/parentPage/dont_notify_watchers未指定時はキーを送らない"""
+        mock_site_no_http.client.is_logged_in = True
+        mock_site_no_http.client.login_check = MagicMock()
+        lock_response = _mock_response({"status": "ok", "lock_id": "L1", "lock_secret": "S1"})
+        save_response = _mock_response({"status": "ok"})
+        mock_site_no_http.amc_request = MagicMock(side_effect=[[lock_response], [save_response]])
+
+        session = PageEditSession(site=mock_site_no_http, fullname="p").open()
+        session.save()
+
+        body = mock_site_no_http.amc_request.call_args[0][0][0]
+        for key in ("range_start", "range_end", "tags", "parentPage", "dont_notify_watchers", "and_continue"):
+            assert key not in body
+
+
+class TestPageEditSessionSynchronize:
+    """synchronize() のテスト"""
+
+    def test_synchronize_updates_time_left(self, mock_site_no_http: Site) -> None:
+        mock_site_no_http.client.is_logged_in = True
+        mock_site_no_http.client.login_check = MagicMock()
+        lock_response = _mock_response({"status": "ok", "lock_id": "L1", "lock_secret": "S1"})
+        sync_response = _mock_response({"status": "ok", "timeLeft": 850})
+        mock_site_no_http.amc_request = MagicMock(side_effect=[[lock_response], [sync_response]])
+
+        session = PageEditSession(site=mock_site_no_http, fullname="p").open()
+        session.synchronize(since_last_input=10)
+
+        assert session.time_left == 850
+
+    def test_synchronize_lock_recreated_updates_lock(self, mock_site_no_http: Site) -> None:
+        """lockRecreated時にlock_id/lock_secretが差し替わる"""
+        mock_site_no_http.client.is_logged_in = True
+        mock_site_no_http.client.login_check = MagicMock()
+        lock_response = _mock_response({"status": "ok", "lock_id": "L1", "lock_secret": "S1"})
+        sync_response = _mock_response(
+            {"status": "ok", "lockRecreated": True, "lockId": "L2", "lockSecret": "S2", "timeLeft": 900}
+        )
+        mock_site_no_http.amc_request = MagicMock(side_effect=[[lock_response], [sync_response]])
+
+        session = PageEditSession(site=mock_site_no_http, fullname="p").open()
+        session.synchronize()
+
+        assert session.lock_id == "L2"
+        assert session.lock_secret == "S2"
+
+    def test_synchronize_no_lock_error_raises(self, mock_site_no_http: Site) -> None:
+        mock_site_no_http.client.is_logged_in = True
+        mock_site_no_http.client.login_check = MagicMock()
+        lock_response = _mock_response({"status": "ok", "lock_id": "L1", "lock_secret": "S1"})
+        sync_response = _mock_response({"status": "ok", "noLockError": True})
+        mock_site_no_http.amc_request = MagicMock(side_effect=[[lock_response], [sync_response]])
+
+        session = PageEditSession(site=mock_site_no_http, fullname="p").open()
+        with pytest.raises(exceptions.TargetErrorException):
+            session.synchronize()
+
+
+class TestPageEditSessionRelease:
+    """release() のテスト"""
+
+    def test_release_noop_when_not_open(self, mock_site_no_http: Site) -> None:
+        """openしていないセッションのrelease()は何もしない"""
+        mock_site_no_http.amc_request = MagicMock()
+        session = PageEditSession(site=mock_site_no_http, fullname="p")
+        session.release()
+        mock_site_no_http.amc_request.assert_not_called()
+
+    def test_release_failure_does_not_raise(self, mock_site_no_http: Site) -> None:
+        """解放リクエスト自体が失敗しても例外を送出しない"""
+        mock_site_no_http.client.is_logged_in = True
+        mock_site_no_http.client.login_check = MagicMock()
+        lock_response = _mock_response({"status": "ok", "lock_id": "L1", "lock_secret": "S1"})
+        mock_site_no_http.amc_request = MagicMock(
+            side_effect=[[lock_response], exceptions.ForbiddenException("no permission")]
+        )
+
+        session = PageEditSession(site=mock_site_no_http, fullname="p").open()
+        session.release()  # 例外を送出しない
+
+
+class TestPageEditSessionMisc:
+    """check_draft_exists / force_lock_intercept / recreate_expired_lock / preview / diff"""
+
+    def test_check_draft_exists_true(self, mock_site_no_http: Site) -> None:
+        mock_site_no_http.client.is_logged_in = True
+        mock_site_no_http.client.login_check = MagicMock()
+        lock_response = _mock_response({"status": "ok", "lock_id": "L1", "lock_secret": "S1"})
+        check_response = _mock_response({"status": "ok", "draftExists": True})
+        mock_site_no_http.amc_request = MagicMock(side_effect=[[lock_response], [check_response]])
+
+        session = PageEditSession(site=mock_site_no_http, fullname="p").open()
+        assert session.check_draft_exists() is True
+
+    def test_force_lock_intercept_updates_lock(self, mock_site_no_http: Site) -> None:
+        mock_site_no_http.client.is_logged_in = True
+        mock_site_no_http.client.login_check = MagicMock()
+        lock_response = _mock_response({"status": "ok", "lock_id": "L1", "lock_secret": "S1"})
+        intercept_response = _mock_response({"lock_id": "L3", "lock_secret": "S3", "timeLeft": 900})
+        mock_site_no_http.amc_request = MagicMock(side_effect=[[lock_response], [intercept_response]])
+
+        session = PageEditSession(site=mock_site_no_http, fullname="p").open()
+        session.force_lock_intercept()
+
+        assert session.lock_id == "L3"
+        assert session.lock_secret == "S3"
+
+    def test_recreate_expired_lock_updates_lock(self, mock_site_no_http: Site) -> None:
+        mock_site_no_http.client.is_logged_in = True
+        mock_site_no_http.client.login_check = MagicMock()
+        lock_response = _mock_response({"status": "ok", "lock_id": "L1", "lock_secret": "S1"})
+        recreate_response = _mock_response(
+            {"status": "ok", "lockRecreated": True, "lockId": "L4", "lockSecret": "S4", "timeLeft": 900}
+        )
+        mock_site_no_http.amc_request = MagicMock(side_effect=[[lock_response], [recreate_response]])
+
+        session = PageEditSession(site=mock_site_no_http, fullname="p").open()
+        session.recreate_expired_lock()
+
+        assert session.lock_id == "L4"
+        assert session.lock_secret == "S4"
+
+    def test_preview_returns_body_and_title(self, mock_site_no_http: Site) -> None:
+        mock_site_no_http.client.is_logged_in = True
+        mock_site_no_http.client.login_check = MagicMock()
+        lock_response = _mock_response({"status": "ok", "lock_id": "L1", "lock_secret": "S1"})
+        preview_response = _mock_response({"status": "ok", "body": "<p>preview</p>", "title": "T"})
+        mock_site_no_http.amc_request = MagicMock(side_effect=[[lock_response], [preview_response]])
+
+        session = PageEditSession(site=mock_site_no_http, fullname="p").open()
+        result = session.preview(title="T", source="s")
+
+        assert result["body"] == "<p>preview</p>"
+        assert result["title"] == "T"
+
+    def test_diff_returns_body(self, mock_site_no_http: Site) -> None:
+        mock_site_no_http.client.is_logged_in = True
+        mock_site_no_http.client.login_check = MagicMock()
+        lock_response = _mock_response({"status": "ok", "lock_id": "L1", "lock_secret": "S1"})
+        diff_response = _mock_response({"status": "ok", "body": "<div>diff</div>"})
+        mock_site_no_http.amc_request = MagicMock(side_effect=[[lock_response], [diff_response]])
+
+        session = PageEditSession(site=mock_site_no_http, fullname="p").open()
+        result = session.diff(source="s")
+
+        assert result == "<div>diff</div>"

--- a/tests/unit/test_page_file.py
+++ b/tests/unit/test_page_file.py
@@ -298,4 +298,176 @@ class TestPageFile:
         assert "PageFile" in result
         assert "id=123" in result
         assert "name=test.txt" in result
-        assert "size=1024" in result
+
+
+class TestPageFileCollectionActions:
+    """PageFileCollectionの静的アクション系メソッドのテスト"""
+
+    def test_check_exists_true(self):
+        page = MagicMock()
+        page.id = 1
+        response = MagicMock()
+        response.json.return_value = {"status": "ok", "exists": True}
+        page.site.amc_request.return_value = [response]
+
+        assert PageFileCollection.check_exists(page, "test.txt") is True
+        body = page.site.amc_request.call_args[0][0][0]
+        assert body["action"] == "FileAction"
+        assert body["event"] == "checkFileExists"
+        assert body["filename"] == "test.txt"
+
+    def test_get_upload_form(self):
+        page = MagicMock()
+        page.id = 1
+        response = MagicMock()
+        response.json.return_value = {"status": "ok", "body": "<form></form>"}
+        page.site.amc_request.return_value = [response]
+
+        assert PageFileCollection.get_upload_form(page) == "<form></form>"
+
+    def test_get_manager(self):
+        page = MagicMock()
+        page.id = 1
+        response = MagicMock()
+        response.json.return_value = {"status": "ok", "body": "<div>manager</div>"}
+        page.site.amc_request.return_value = [response]
+
+        assert PageFileCollection.get_manager(page) == "<div>manager</div>"
+
+    def test_multi_upload_complete(self):
+        page = MagicMock()
+        page.id = 1
+        response = MagicMock()
+        response.json.return_value = {"status": "ok"}
+        page.site.amc_request.return_value = [response]
+
+        PageFileCollection.multi_upload_complete(page, "multikey-1", ["a.txt", "b.txt"])
+
+        body = page.site.amc_request.call_args[0][0][0]
+        assert body["action"] == "FileAction"
+        assert body["event"] == "multiUploadComplete"
+        assert body["multikey"] == "multikey-1"
+        import json as json_module
+
+        assert json_module.loads(body["fnames"]) == ["a.txt", "b.txt"]
+
+    def test_upload_delegates_to_amc_client(self):
+        page = MagicMock()
+        page.id = 1
+        page.site.unix_name = "test-site"
+        page.site.ssl_supported = True
+        page.site.client.amc_client.upload_file.return_value = {"status": "ok", "filename": "a.txt"}
+
+        result = PageFileCollection.upload(page, "a.txt", b"content", multikey="mk1")
+
+        assert result == {"status": "ok", "filename": "a.txt"}
+        page.site.client.amc_client.upload_file.assert_called_once_with(
+            page_id=1,
+            filename="a.txt",
+            content=b"content",
+            site_name="test-site",
+            site_ssl_supported=True,
+            multikey="mk1",
+        )
+
+
+class TestPageFileForms:
+    """PageFileのフォーム取得系メソッドのテスト"""
+
+    def test_get_rename_form(self):
+        page = MagicMock()
+        response = MagicMock()
+        response.json.return_value = {"status": "ok", "body": "<form>rename</form>"}
+        page.site.amc_request.return_value = [response]
+        file = PageFile(page=page, id=1, name="a.txt", url="", mime_type="", size=0)
+
+        assert file.get_rename_form() == "<form>rename</form>"
+
+    def test_get_move_form(self):
+        page = MagicMock()
+        response = MagicMock()
+        response.json.return_value = {"status": "ok", "body": "<form>move</form>"}
+        page.site.amc_request.return_value = [response]
+        file = PageFile(page=page, id=1, name="a.txt", url="", mime_type="", size=0)
+
+        assert file.get_move_form() == "<form>move</form>"
+
+    def test_get_info(self):
+        page = MagicMock()
+        response = MagicMock()
+        response.json.return_value = {"status": "ok", "body": "<div>info</div>"}
+        page.site.amc_request.return_value = [response]
+        file = PageFile(page=page, id=1, name="a.txt", url="", mime_type="", size=0)
+
+        assert file.get_info() == "<div>info</div>"
+
+
+class TestPageFileRenameMoveDelete:
+    """PageFile.rename / move / deleteのテスト"""
+
+    def test_rename_success(self):
+        page = MagicMock()
+        response = MagicMock()
+        response.json.return_value = {"status": "ok"}
+        page.site.amc_request.return_value = [response]
+        file = PageFile(page=page, id=1, name="old.txt", url="", mime_type="", size=0)
+
+        result = file.rename("new.txt")
+
+        assert result is file
+        assert file.name == "new.txt"
+        body = page.site.amc_request.call_args[0][0][0]
+        assert body["event"] == "renameFile"
+        assert body["new_name"] == "new.txt"
+        assert "force" not in body
+
+    def test_rename_force(self):
+        page = MagicMock()
+        response = MagicMock()
+        response.json.return_value = {"status": "ok"}
+        page.site.amc_request.return_value = [response]
+        file = PageFile(page=page, id=1, name="old.txt", url="", mime_type="", size=0)
+
+        file.rename("new.txt", force=True)
+
+        body = page.site.amc_request.call_args[0][0][0]
+        assert body["force"] == "true"
+
+    def test_move_success(self):
+        page = MagicMock()
+        response = MagicMock()
+        response.json.return_value = {"status": "ok"}
+        page.site.amc_request.return_value = [response]
+        file = PageFile(page=page, id=1, name="a.txt", url="", mime_type="", size=0)
+
+        file.move("other-page")
+
+        body = page.site.amc_request.call_args[0][0][0]
+        assert body["event"] == "moveFile"
+        assert body["destination_page_name"] == "other-page"
+
+    def test_delete_requires_confirm(self):
+        page = MagicMock()
+        file = PageFile(page=page, id=1, name="a.txt", url="", mime_type="", size=0)
+
+        try:
+            file.delete()
+            raised = False
+        except ValueError:
+            raised = True
+        assert raised is True
+        page.site.amc_request.assert_not_called()
+
+    def test_delete_with_confirm(self):
+        page = MagicMock()
+        response = MagicMock()
+        response.json.return_value = {"status": "ok"}
+        page.site.amc_request.return_value = [response]
+        file = PageFile(page=page, id=1, name="a.txt", url="", mime_type="", size=0)
+
+        file.delete(confirm=True)
+
+        body = page.site.amc_request.call_args[0][0][0]
+        assert body["action"] == "FileAction"
+        assert body["event"] == "deleteFile"
+        assert body["file_id"] == 1

--- a/tests/unit/test_page_revision.py
+++ b/tests/unit/test_page_revision.py
@@ -217,3 +217,122 @@ class TestPageRevision:
         """htmlセッター"""
         sample_revision.html = "<p>New HTML</p>"
         assert sample_revision._html == "<p>New HTML</p>"
+
+
+class TestPageRevisionCollectionGetDiff:
+    """PageRevisionCollection.get_diffのテスト"""
+
+    def test_get_diff_returns_body(self, mock_page):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "ok", "body": "<div>diff</div>"}
+        mock_page.site.amc_request.return_value = [mock_response]
+
+        result = PageRevisionCollection.get_diff(mock_page, from_revision_id=1, to_revision_id=2)
+
+        assert result == "<div>diff</div>"
+        body = mock_page.site.amc_request.call_args[0][0][0]
+        assert body["moduleName"] == "history/PageDiffModule"
+        assert body["from_revision_id"] == 1
+        assert body["to_revision_id"] == 2
+        assert body["show_type"] == "inline"
+
+
+class TestPageRevisionCollectionAcquire:
+    """PageRevisionCollection.acquire（履歴の絞り込み）のテスト"""
+
+    def test_acquire_defaults_to_all(self, mock_page):
+        import json as json_module
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "ok", "body": "<table class='page-history'></table>"}
+        mock_page.site.amc_request.return_value = [mock_response]
+
+        result = PageRevisionCollection.acquire(mock_page)
+
+        assert len(result) == 0
+        body = mock_page.site.amc_request.call_args[0][0][0]
+        assert json_module.loads(body["options"]) == {"all": True}
+        assert body["perpage"] == 20
+        assert body["page"] == 1
+
+    def test_acquire_with_options_filter(self, mock_page):
+        import json as json_module
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "ok", "body": "<table class='page-history'></table>"}
+        mock_page.site.amc_request.return_value = [mock_response]
+
+        PageRevisionCollection.acquire(mock_page, options={"tags": True, "move": True}, perpage=50, page_no=2)
+
+        body = mock_page.site.amc_request.call_args[0][0][0]
+        assert json_module.loads(body["options"]) == {"tags": True, "move": True}
+        assert body["perpage"] == 50
+        assert body["page"] == 2
+
+    def test_acquire_parses_revisions(self, mock_page, mock_user):
+        printuser_html = (
+            '<span class="printuser avatarhover">'
+            '<a href="http://www.wikidot.com/user:info/test-user" '
+            'onclick="WIKIDOT.page.listeners.userInfo(12345); return false;">test-user</a>'
+            "</span>"
+        )
+        html = (
+            '<table class="page-history">'
+            '<tr id="revision-row-100">'
+            "<td>3.</td><td></td><td></td><td></td>"
+            f"<td>{printuser_html}</td>"
+            '<td><span class="odate time_1700000000">14 Nov 2023</span></td>'
+            "<td>edit comment</td>"
+            "</tr>"
+            "</table>"
+        )
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "ok", "body": html}
+        mock_page.site.amc_request.return_value = [mock_response]
+
+        result = PageRevisionCollection.acquire(mock_page)
+
+        assert len(result) == 1
+        assert result[0].id == 100
+        assert result[0].rev_no == 3
+        assert result[0].comment == "edit comment"
+
+
+class TestPageRevisionRevert:
+    """PageRevision.revertのテスト"""
+
+    def test_revert_success(self, mock_page, sample_revision):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "ok"}
+        mock_page.site.amc_request.return_value = [mock_response]
+
+        result = sample_revision.revert()
+
+        assert result == {"status": "ok"}
+        body = mock_page.site.amc_request.call_args[0][0][0]
+        assert body["action"] == "WikiPageAction"
+        assert body["event"] == "revert"
+        assert body["pageId"] == mock_page.id
+        assert body["revisionId"] == sample_revision.id
+        assert "force" not in body
+
+    def test_revert_force(self, mock_page, sample_revision):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "ok"}
+        mock_page.site.amc_request.return_value = [mock_response]
+
+        sample_revision.revert(force=True)
+
+        body = mock_page.site.amc_request.call_args[0][0][0]
+        assert body["force"] == "yes"
+
+    def test_revert_locked_response_not_swallowed(self, mock_page, sample_revision):
+        """locks応答を握りつぶさず、呼び出し側にそのまま返す"""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "ok", "locks": True, "body": "<div>locked</div>"}
+        mock_page.site.amc_request.return_value = [mock_response]
+
+        result = sample_revision.revert()
+
+        assert result["locks"] is True
+        assert result["body"] == "<div>locked</div>"

--- a/tests/unit/test_site_tools.py
+++ b/tests/unit/test_site_tools.py
@@ -1,0 +1,153 @@
+"""SiteToolsAccessorモジュールのユニットテスト"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+from wikidot.module.site_tools import SiteToolsAccessor
+
+if TYPE_CHECKING:
+    from wikidot.module.site import Site
+
+
+def _mock_response(data: dict) -> MagicMock:
+    response = MagicMock()
+    response.json.return_value = data
+    return response
+
+
+class TestSiteToolsAccessorInit:
+    """Site.toolsアクセサ経由での取得テスト"""
+
+    def test_site_has_tools_accessor(self, mock_site_no_http: Site) -> None:
+        assert isinstance(mock_site_no_http.tools, SiteToolsAccessor)
+        assert mock_site_no_http.tools.site is mock_site_no_http
+
+
+class TestSiteToolsSimpleViews:
+    """パラメータなしのビュー取得系メソッドのテスト"""
+
+    def test_get_overview(self, mock_site_no_http: Site) -> None:
+        mock_site_no_http.amc_request = MagicMock(
+            return_value=[_mock_response({"status": "ok", "body": "<div>overview</div>"})]
+        )
+        assert mock_site_no_http.tools.get_overview() == "<div>overview</div>"
+        body = mock_site_no_http.amc_request.call_args[0][0][0]
+        assert body["moduleName"] == "sitetools/SiteToolsModule"
+
+    def test_get_orphaned_pages(self, mock_site_no_http: Site) -> None:
+        mock_site_no_http.amc_request = MagicMock(
+            return_value=[_mock_response({"status": "ok", "body": "<div>orphaned</div>"})]
+        )
+        assert mock_site_no_http.tools.get_orphaned_pages() == "<div>orphaned</div>"
+
+    def test_get_drafts(self, mock_site_no_http: Site) -> None:
+        mock_site_no_http.amc_request = MagicMock(
+            return_value=[_mock_response({"status": "ok", "body": "<div>drafts</div>"})]
+        )
+        assert mock_site_no_http.tools.get_drafts() == "<div>drafts</div>"
+        body = mock_site_no_http.amc_request.call_args[0][0][0]
+        assert body["location"] == "sitetools"
+
+    def test_get_categories(self, mock_site_no_http: Site) -> None:
+        mock_site_no_http.amc_request = MagicMock(
+            return_value=[_mock_response({"status": "ok", "body": "<div>categories</div>"})]
+        )
+        assert mock_site_no_http.tools.get_categories() == "<div>categories</div>"
+
+
+class TestSiteToolsWantedPages:
+    """get_wanted_pagesのテスト"""
+
+    def test_get_wanted_pages_default(self, mock_site_no_http: Site) -> None:
+        mock_site_no_http.amc_request = MagicMock(
+            return_value=[_mock_response({"status": "ok", "body": "<div>wanted</div>"})]
+        )
+        mock_site_no_http.tools.get_wanted_pages()
+        body = mock_site_no_http.amc_request.call_args[0][0][0]
+        assert "p" not in body
+        assert "embed" not in body
+
+    def test_get_wanted_pages_with_params(self, mock_site_no_http: Site) -> None:
+        mock_site_no_http.amc_request = MagicMock(
+            return_value=[_mock_response({"status": "ok", "body": "<div>wanted</div>"})]
+        )
+        mock_site_no_http.tools.get_wanted_pages(page=2, embed=True)
+        body = mock_site_no_http.amc_request.call_args[0][0][0]
+        assert body["p"] == 2
+        assert body["embed"] == "true"
+
+
+class TestSiteToolsExpandCategory:
+    """expand_categoryのテスト"""
+
+    def test_expand_category(self, mock_site_no_http: Site) -> None:
+        mock_site_no_http.amc_request = MagicMock(
+            return_value=[_mock_response({"status": "ok", "body": "<div>pages</div>", "categoryId": 5})]
+        )
+        result = mock_site_no_http.tools.expand_category(5)
+        assert result == "<div>pages</div>"
+        body = mock_site_no_http.amc_request.call_args[0][0][0]
+        assert body["category_id"] == 5
+        assert "includeHidden" not in body
+
+    def test_expand_category_include_hidden(self, mock_site_no_http: Site) -> None:
+        mock_site_no_http.amc_request = MagicMock(
+            return_value=[_mock_response({"status": "ok", "body": "<div>pages</div>"})]
+        )
+        mock_site_no_http.tools.expand_category(5, include_hidden=True)
+        body = mock_site_no_http.amc_request.call_args[0][0][0]
+        assert body["includeHidden"] == "true"
+
+
+class TestSiteToolsRecentChanges:
+    """get_recent_changesのテスト"""
+
+    def test_default_options_is_all(self, mock_site_no_http: Site) -> None:
+        mock_site_no_http.amc_request = MagicMock(
+            return_value=[_mock_response({"status": "ok", "body": "<div></div>"})]
+        )
+        mock_site_no_http.tools.get_recent_changes()
+        body = mock_site_no_http.amc_request.call_args[0][0][0]
+        assert json.loads(body["options"]) == {"all": True}
+        assert "categoryId" not in body
+        assert "pageId" not in body
+
+    def test_category_and_page_filter(self, mock_site_no_http: Site) -> None:
+        mock_site_no_http.amc_request = MagicMock(
+            return_value=[_mock_response({"status": "ok", "body": "<div></div>"})]
+        )
+        mock_site_no_http.tools.get_recent_changes(category_id=3, page_id=99)
+        body = mock_site_no_http.amc_request.call_args[0][0][0]
+        assert body["categoryId"] == 3
+        assert body["pageId"] == 99
+
+    def test_parses_changes(self, mock_site_no_http: Site) -> None:
+        printuser_html = (
+            '<span class="printuser avatarhover">'
+            '<a href="http://www.wikidot.com/user:info/test-user" '
+            'onclick="WIKIDOT.page.listeners.userInfo(12345); return false;">test-user</a>'
+            "</span>"
+        )
+        html = (
+            '<div class="changes-list-item">'
+            '<td class="title"><a href="/component:scp-173">SCP-173</a></td>'
+            '<td class="revision-no">3</td>'
+            f'<td class="mod-by">{printuser_html}</td>'
+            '<td class="mod-date"><span class="odate time_1700000000">14 Nov 2023</span></td>'
+            '<td class="comments">edit note</td>'
+            '<td class="flags"><span>S</span></td>'
+            "</div>"
+        )
+        mock_site_no_http.amc_request = MagicMock(return_value=[_mock_response({"status": "ok", "body": html})])
+
+        changes = mock_site_no_http.tools.get_recent_changes()
+
+        assert len(changes) == 1
+        assert changes[0].page_fullname == "component:scp-173"
+        assert changes[0].page_title == "SCP-173"
+        assert changes[0].revision_no == 3
+        assert changes[0].comment == "edit note"
+        assert changes[0].flags == ["S"]


### PR DESCRIPTION
## Summary

ページの編集セッション・履歴・ファイル操作などを追加する。

> スタック PR。base は `feature/forum-admin`。

## Related Issue

なし

## Changes

- 編集ロックの取得から解放までを保証する編集セッションを新設
- プレビュー / 編集中の差分 / テンプレート本文の取得
- 履歴の絞り込み取得、リビジョン間差分、巻き戻し
- リネームの依存解決（`fixdeps` / `force`）
- ファイルのリネーム / 移動 / 削除 / 存在確認 / アップロード
- ページのロック、バックリンク、監視、メタタグの全ページ適用
- サイト横断ビュー（Wanted / Orphaned / Drafts / カテゴリ一覧 / 絞り込み付き最近の変更）を新設

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring
- [x] Test addition/modification
- [ ] CI/CD or build related

## Testing

- [x] `make format` passes
- [x] `make lint` passes
- [x] `make test` passes

## Checklist

- [x] Code follows the project's style guidelines
- [ ] Documentation has been updated as needed
- [x] Tests have been added for the changes (if applicable)

## Additional Information

- リネーム時の `locks` / `leftDeps` を従来は無視していたため、例外として伝播するよう変更した（**既存挙動の変更**）
- 新規ページ作成時に `page_id` を空文字で送っていたのを、キーごと省略する形に統一した
- 既存の `create` / `edit` は内部を編集セッション経由に置き換えたが、外部シグネチャは変えていない
- ファイルアップロードは応答が JSON ではなく HTML 断片のため専用経路を通す。**実機未検証**

README と `llms.txt` は追加した API を反映していない。リリース前にまとめて追随させる。
