### PR TITLE
アカウント/Dashboard 操作の追加

### DIFF
--- a/src/wikidot/module/account.py
+++ b/src/wikidot/module/account.py
@@ -9,12 +9,18 @@ All requests in this module are sent to `www.wikidot.com` (Client.amc_client's
 default host), never to a site's own host.
 """
 
+import re
+from dataclasses import dataclass
+from datetime import datetime
 from typing import TYPE_CHECKING, Any, Literal
+
+from bs4 import BeautifulSoup
 
 from ..common import exceptions
 from ..common.decorators import login_required
 from ..connector.ajax import require_body
 from ..util.amc_body import checkbox, flag, json_param, omit_falsy
+from ..util.parser import odate as odate_parser
 
 if TYPE_CHECKING:
     from .client import Client
@@ -697,6 +703,103 @@ class AccountProfile:
         return dict(data)
 
 
+@dataclass
+class UserChange:
+    """
+    A row of the account's own recent page edits (userinfo/UserChangesListModule)
+
+    Nearly identical in structure to SiteChange (site.py's
+    changes/SiteChangesListModule row), with a site column added since this
+    view spans every site the account belongs to (measured 2026-07-29, see
+    `70_account.md` "一覧モジュールの行マークアップ").
+
+    Attributes
+    ----------
+    client : Client
+        Client instance
+    site_title : str
+        Title of the site the change occurred on (td.site > a)
+    site_url : str
+        URL of the site the change occurred on (td.site > a href)
+    page_fullname : str
+        Fullname of the changed page
+    page_title : str
+        Title of the changed page
+    revision_no : int
+        Revision number
+    changed_at : datetime
+        Date and time of change
+    flags : list[str]
+        Change flags ("N"=new, "S"=source change, "T"=title change,
+        "R"=rename, "M"=move, "F"=file, "A"=delete)
+    """
+
+    client: "Client"
+    site_title: str
+    site_url: str
+    page_fullname: str
+    page_title: str
+    revision_no: int
+    changed_at: datetime
+    flags: list[str]
+
+    def __str__(self) -> str:
+        """
+        String representation of the object
+
+        Returns
+        -------
+        str
+            String representation of the change history entry
+        """
+        return (
+            f"UserChange(site_title={self.site_title}, page_fullname={self.page_fullname}, "
+            f"revision_no={self.revision_no}, changed_at={self.changed_at}, flags={self.flags})"
+        )
+
+
+@dataclass
+class RecentPost:
+    """
+    A row of the account's own recent forum posts (userinfo/UserRecentPostsListModule)
+
+    Row markup was measured 2026-07-29 (see `70_account.md` "一覧モジュールの
+    行マークアップ"): each row is `div.post`, with
+    `div.long > div.head > div.title > a` (title/link), `div.info > span.odate`
+    (date), and `div.content` (post text).
+
+    Attributes
+    ----------
+    client : Client
+        Client instance
+    title : str
+        Post/thread title (div.title > a)
+    url : str
+        Link to the post (div.title > a href)
+    created_at : datetime
+        Date and time of the post
+    content : str
+        Post text (div.content)
+    """
+
+    client: "Client"
+    title: str
+    url: str
+    created_at: datetime
+    content: str
+
+    def __str__(self) -> str:
+        """
+        String representation of the object
+
+        Returns
+        -------
+        str
+            String representation of the post
+        """
+        return f"RecentPost(title={self.title}, created_at={self.created_at})"
+
+
 class AccountRecentActivity:
     """
     A class that provides operations on the `/account/recent` dashboard tab
@@ -715,52 +818,105 @@ class AccountRecentActivity:
             Parent client instance
         """
         self.client = client
+        self._changes_user_id_cache: int | None = None
+        self._posts_user_id_cache: int | None = None
 
-    def _own_user_id(self) -> int:
+    def _fetch_hidden_user_id(self, module_name: str, element_id: str) -> int:
         """
-        Internal helper to get the logged-in account's own user ID
+        Internal helper to fetch a hidden `userId` field from a shell module
+
+        `www.wikidot.com` pages do not expose `WIKIREQUEST.info.userId`
+        (unlike a site's own pages), and userinfo/UserChangesListModule /
+        userinfo/UserRecentPostsListModule respond with status "not_ok" and
+        an empty body if `userId` is omitted. The real UI reads it from a
+        hidden input on the shell module that renders the tab
+        (userinfo/UserChangesModule / userinfo/UserRecentPostsModule) before
+        requesting the list module.
+
+        Parameters
+        ----------
+        module_name : str
+            Shell module to fetch ("userinfo/UserChangesModule" or
+            "userinfo/UserRecentPostsModule")
+        element_id : str
+            id of the hidden input holding the user ID
+            ("changes-user-id" or "recent-posts-user-id")
 
         Returns
         -------
         int
-            User ID of Client.me
+            The account's own user ID
 
         Raises
         ------
         UnexpectedException
-            If Client.me is unset despite being logged in (should not happen)
+            If the hidden field is missing or non-numeric
         """
-        me = self.client.me
-        if me is None or me.id is None:
-            raise exceptions.UnexpectedException("Client.me is not set despite being logged in")
-        return me.id
+        response = self.client.amc_client.request([{"moduleName": module_name}])[0]
+        html = BeautifulSoup(require_body(response, module_name), "lxml")
+        hidden = html.select_one(f"#{element_id}")
+        if hidden is None:
+            raise exceptions.UnexpectedException(f"Cannot find #{element_id} in {module_name}")
+        value = hidden.get("value")
+        if value is None or not str(value).isdigit():
+            raise exceptions.UnexpectedException(f"#{element_id} in {module_name} is not numeric: {value!r}")
+        return int(str(value))
+
+    def _changes_user_id(self) -> int:
+        """
+        Internal helper to get (and cache) the userId for UserChangesListModule
+
+        Returns
+        -------
+        int
+            User ID, as read from userinfo/UserChangesModule's
+            #changes-user-id hidden field
+        """
+        if self._changes_user_id_cache is None:
+            self._changes_user_id_cache = self._fetch_hidden_user_id("userinfo/UserChangesModule", "changes-user-id")
+        return self._changes_user_id_cache
+
+    def _posts_user_id(self) -> int:
+        """
+        Internal helper to get (and cache) the userId for UserRecentPostsListModule
+
+        Returns
+        -------
+        int
+            User ID, as read from userinfo/UserRecentPostsModule's
+            #recent-posts-user-id hidden field
+        """
+        if self._posts_user_id_cache is None:
+            self._posts_user_id_cache = self._fetch_hidden_user_id(
+                "userinfo/UserRecentPostsModule", "recent-posts-user-id"
+            )
+        return self._posts_user_id_cache
 
     @login_required
-    def get_changes_html(
+    def get_changes(
         self,
-        page: int = 1,
-        perpage: int = 20,
         options: dict[str, bool] | None = None,
-    ) -> str:
+        limit: int | None = None,
+    ) -> list["UserChange"]:
         """
-        Fetch a page of the account's own recent page edits (raw HTML)
+        Get the account's own recent page edits, across all sites
+
+        Wraps `userinfo/UserChangesListModule`, fetching pages until
+        exhausted or `limit` is reached.
 
         Parameters
         ----------
-        page : int, default 1
-            Page number
-        perpage : int, default 20
-            Entries per page
         options : dict[str, bool] | None, default None
             Filter flags. Keys must be a subset of RECENT_CHANGES_OPTION_KEYS
             ("all", "source", "title", "move", "files", "new", "meta"); unlike
             history/PageHistoryModule's options, there is no "tags" key here
+        limit : int | None, default None
+            Maximum number of entries to retrieve. If None, retrieves all
 
         Returns
         -------
-        str
-            Raw rendered HTML body (row markup was not captured during the
-            investigation, so this is not parsed into a structured list)
+        list[UserChange]
+            List of change history (in descending order by date)
 
         Raises
         ------
@@ -768,6 +924,8 @@ class AccountRecentActivity:
             If not logged in
         ValueError
             If options contains a key outside RECENT_CHANGES_OPTION_KEYS
+        NoElementException
+            If HTML element parsing fails
         """
         if options is not None:
             unknown = set(options) - RECENT_CHANGES_OPTION_KEYS
@@ -777,49 +935,170 @@ class AccountRecentActivity:
                     f"(no 'tags' key here, unlike page-history options): {sorted(unknown)}"
                 )
 
-        response = self.client.amc_client.request(
-            [
-                {
-                    "moduleName": "userinfo/UserChangesListModule",
-                    "page": page,
-                    "perpage": perpage,
-                    "userId": self._own_user_id(),
-                    **omit_falsy(options=json_param(options) if options else False),
-                }
-            ]
-        )[0]
-        return require_body(response, "userinfo/UserChangesListModule")
+        user_id = self._changes_user_id()
+
+        changes: list[UserChange] = []
+        per_page = min(limit, 1000) if limit is not None else 1000
+        page_no = 1
+
+        while True:
+            response = self.client.amc_client.request(
+                [
+                    {
+                        "moduleName": "userinfo/UserChangesListModule",
+                        "page": page_no,
+                        "perpage": per_page,
+                        "userId": user_id,
+                        **omit_falsy(options=json_param(options) if options else False),
+                    }
+                ]
+            )[0]
+            html = BeautifulSoup(require_body(response, "userinfo/UserChangesListModule"), "lxml")
+            items = html.select("div.changes-list-item")
+
+            if not items:
+                break
+
+            for item in items:
+                site_elem = item.select_one("td.site a")
+
+                title_elem = item.select_one("td.title a")
+                if title_elem is None:
+                    raise exceptions.NoElementException("Title element is not found.")
+                page_title = title_elem.get_text().strip()
+                href = title_elem.get("href", "")
+                page_fullname = str(href).strip("/")
+
+                odate_elem = item.select_one("td.mod-date span.odate")
+                if odate_elem is None:
+                    raise exceptions.NoElementException("Odate element is not found.")
+                changed_at = odate_parser(odate_elem)
+
+                rev_elem = item.select_one("td.revision-no")
+                if rev_elem is None:
+                    raise exceptions.NoElementException("Revision number element is not found.")
+                rev_match = re.search(r"(\d+)", rev_elem.get_text())
+                if rev_match is None:
+                    raise exceptions.NoElementException("Revision number is not found.")
+                revision_no = int(rev_match.group(1))
+
+                flags_elem = item.select("td.flags span.spantip")
+                flags = [span.get_text().strip() for span in flags_elem]
+
+                changes.append(
+                    UserChange(
+                        client=self.client,
+                        site_title=site_elem.get_text().strip() if site_elem else "",
+                        site_url=str(site_elem.get("href", "")) if site_elem else "",
+                        page_fullname=page_fullname,
+                        page_title=page_title,
+                        revision_no=revision_no,
+                        changed_at=changed_at,
+                        flags=flags,
+                    )
+                )
+
+                if limit is not None and len(changes) >= limit:
+                    return changes
+
+            pager = html.select_one("div.pager")
+            if pager is None:
+                break
+
+            pager_links = pager.select("a")
+            if len(pager_links) < 2:
+                break
+
+            last_page = int(pager_links[-2].get_text().strip())
+            if page_no >= last_page:
+                break
+
+            page_no += 1
+
+        return changes
 
     @login_required
-    def get_posts_html(self, page: int = 1) -> str:
+    def get_posts(self, limit: int | None = None) -> list["RecentPost"]:
         """
-        Fetch a page of the account's own recent forum posts (raw HTML)
+        Get the account's own recent forum posts, across all sites
+
+        Wraps `userinfo/UserRecentPostsListModule`, fetching pages until
+        exhausted or `limit` is reached.
 
         Parameters
         ----------
-        page : int, default 1
-            Page number
+        limit : int | None, default None
+            Maximum number of entries to retrieve. If None, retrieves all
 
         Returns
         -------
-        str
-            Raw rendered HTML body
+        list[RecentPost]
+            List of recent posts (in descending order by date)
 
         Raises
         ------
         LoginRequiredException
             If not logged in
+        NoElementException
+            If HTML element parsing fails
         """
-        response = self.client.amc_client.request(
-            [
-                {
-                    "moduleName": "userinfo/UserRecentPostsListModule",
-                    "page": page,
-                    "userId": self._own_user_id(),
-                }
-            ]
-        )[0]
-        return require_body(response, "userinfo/UserRecentPostsListModule")
+        user_id = self._posts_user_id()
+
+        posts: list[RecentPost] = []
+        page_no = 1
+
+        while True:
+            response = self.client.amc_client.request(
+                [
+                    {
+                        "moduleName": "userinfo/UserRecentPostsListModule",
+                        "page": page_no,
+                        "userId": user_id,
+                    }
+                ]
+            )[0]
+            html = BeautifulSoup(require_body(response, "userinfo/UserRecentPostsListModule"), "lxml")
+            items = html.select("div.post")
+
+            if not items:
+                break
+
+            for item in items:
+                title_elem = item.select_one("div.long div.head div.title a")
+                if title_elem is None:
+                    raise exceptions.NoElementException("Title element is not found.")
+
+                odate_elem = item.select_one("div.info span.odate")
+                content_elem = item.select_one("div.content")
+
+                posts.append(
+                    RecentPost(
+                        client=self.client,
+                        title=title_elem.get_text().strip(),
+                        url=str(title_elem.get("href", "")),
+                        created_at=(odate_parser(odate_elem) if odate_elem else datetime.fromtimestamp(0)),
+                        content=content_elem.get_text().strip() if content_elem else "",
+                    )
+                )
+
+                if limit is not None and len(posts) >= limit:
+                    return posts
+
+            pager = html.select_one("div.pager")
+            if pager is None:
+                break
+
+            pager_links = pager.select("a")
+            if len(pager_links) < 2:
+                break
+
+            last_page = int(pager_links[-2].get_text().strip())
+            if page_no >= last_page:
+                break
+
+            page_no += 1
+
+        return posts
 
 
 class ClientAccountAccessor:

--- a/src/wikidot/module/account.py
+++ b/src/wikidot/module/account.py
@@ -1,0 +1,846 @@
+"""
+Module for handling the logged-in user's Wikidot account (`www.wikidot.com/account/settings`)
+
+This module provides classes for account-level settings and profile operations
+that are distinct from any single site: password/email/language, private message
+receive preferences, forum signature, avatar, and API key management.
+
+All requests in this module are sent to `www.wikidot.com` (Client.amc_client's
+default host), never to a site's own host.
+"""
+
+from typing import TYPE_CHECKING, Any, Literal
+
+from ..common import exceptions
+from ..common.decorators import login_required
+from ..connector.ajax import require_body
+from ..util.amc_body import checkbox, flag, json_param, omit_falsy
+
+if TYPE_CHECKING:
+    from .client import Client
+    from .user import AbstractUser
+
+#: `from` values accepted by DashboardSettingsAction/saveReceiveMessages
+PrivateMessageReceiveFrom = Literal["a", "mf", "f", "n"]
+
+#: option keys accepted by userinfo/UserChangesListModule's `options` JSON.
+#: Unlike the page-history version (history/PageHistoryModule), there is no
+#: "tags" key here.
+RECENT_CHANGES_OPTION_KEYS = frozenset({"all", "source", "title", "move", "files", "new", "meta"})
+
+
+class AccountSettings:
+    """
+    A class that provides operations on `DashboardSettingsAction` and `dashboard/settings/*`
+
+    Covers account-wide settings: password, email, language, private message
+    receive preferences and block list, toolbars, digest/newsletter/invitation
+    subscriptions, API key, and Facebook link. Access through Client.account.settings.
+
+    Note that `saveReceiveMessages` / `blockUser` / `deleteBlock` live under this
+    action namespace even though they are about private messages: Wikidot groups
+    all of DashboardSettingsAction here regardless of topic, so this class owns them
+    instead of ClientPrivateMessageAccessor.
+    """
+
+    def __init__(self, client: "Client"):
+        """
+        Initialize method
+
+        Parameters
+        ----------
+        client : Client
+            Parent client instance
+        """
+        self.client = client
+
+    def _request(self, event: str, **params: Any) -> Any:
+        """
+        Internal helper to send a DashboardSettingsAction request
+
+        Parameters
+        ----------
+        event : str
+            Event name
+        **params : Any
+            Additional request parameters
+
+        Returns
+        -------
+        Any
+            Parsed JSON response
+        """
+        response = self.client.amc_client.request(
+            [
+                {
+                    "action": "DashboardSettingsAction",
+                    "event": event,
+                    "moduleName": "Empty",
+                    **params,
+                }
+            ]
+        )[0]
+        return response.json()
+
+    @login_required
+    def set_receive_messages(self, from_: PrivateMessageReceiveFrom) -> None:
+        """
+        Set who is allowed to send you private messages
+
+        Parameters
+        ----------
+        from_ : Literal["a", "mf", "f", "n"]
+            "a" = all registered users, "mf" = co-members + contacts,
+            "f" = contacts only, "n" = nobody
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        FormErrorsException
+            If validation fails
+        """
+        self._request("saveReceiveMessages", **{"from": from_})
+
+    @login_required
+    def block_user(self, user: "AbstractUser") -> None:
+        """
+        Add a user to the private message block list
+
+        Parameters
+        ----------
+        user : AbstractUser
+            User to block
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        self._request("blockUser", userId=user.id)
+
+    @login_required
+    def unblock_user(self, user: "AbstractUser") -> None:
+        """
+        Remove a user from the private message block list
+
+        Parameters
+        ----------
+        user : AbstractUser
+            User to unblock
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        self._request("deleteBlock", userId=user.id)
+
+    @login_required
+    def start_email_change(self, email: str) -> None:
+        """
+        Start the two-step email change flow (step 1)
+
+        Wikidot sends a confirmation code to the new address; complete the
+        change with confirm_email_change(evercode).
+
+        Parameters
+        ----------
+        email : str
+            New email address
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        FormErrorsException
+            status "form_error" with a message (single string, not per-field)
+        """
+        self._request("changeEmail1", email=email)
+
+    @login_required
+    def confirm_email_change(self, evercode: str) -> None:
+        """
+        Complete the two-step email change flow (step 2)
+
+        Parameters
+        ----------
+        evercode : str
+            Confirmation code received by email
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        FormErrorsException
+            status "form_error" with a message (single string, not per-field)
+        """
+        self._request("changeEmail2", evercode=evercode)
+
+    @login_required
+    def change_password(self, old_password: str, new_password: str) -> None:
+        """
+        Change the account password
+
+        Parameters
+        ----------
+        old_password : str
+            Current password
+        new_password : str
+            New password (sent twice as new_password1/new_password2, matching
+            form(change-password-form))
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        FormErrorsException
+            status "form_error" with a message
+        """
+        self._request(
+            "changePassword",
+            old_password=old_password,
+            new_password1=new_password,
+            new_password2=new_password,
+        )
+
+    @login_required
+    def set_language(self, language: str) -> None:
+        """
+        Set the account UI language
+
+        Parameters
+        ----------
+        language : str
+            Language code (e.g. "en", "ja")
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        self._request("saveLanguage", language=language)
+
+    @login_required
+    def set_receive_digest(self, receive: bool) -> None:
+        """
+        Set whether to receive the site activity digest email
+
+        Parameters
+        ----------
+        receive : bool
+            True to subscribe, False to unsubscribe
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        self._request("saveReceiveDigest", **omit_falsy(receive="yes" if receive else False))
+
+    @login_required
+    def set_receive_newsletter(self, receive: bool) -> None:
+        """
+        Set whether to receive the Wikidot newsletter
+
+        Parameters
+        ----------
+        receive : bool
+            True to subscribe, False to unsubscribe
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        self._request("saveReceiveNewsletter", **omit_falsy(receive="yes" if receive else False))
+
+    @login_required
+    def set_receive_invitations(self, receive: bool) -> None:
+        """
+        Set whether to receive site invitations
+
+        Parameters
+        ----------
+        receive : bool
+            True to allow invitations, False to block them
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        self._request("saveReceiveInvitations", **omit_falsy(receive=flag(receive)))
+
+    @login_required
+    def set_toolbars(self, top: bool = False, bottom: bool = False) -> None:
+        """
+        Set which editor toolbars are shown
+
+        Parameters
+        ----------
+        top : bool, default False
+            Show the top toolbar
+        bottom : bool, default False
+            Show the bottom toolbar
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+
+        Notes
+        -----
+        This is `DashboardSettingsAction/saveToolbarsPref` (account-wide editor
+        preference). Do not confuse it with `ManageSiteAction/saveToolbarsPref`,
+        a same-named event on a per-site settings action.
+        """
+        self._request(
+            "saveToolbarsPref",
+            **omit_falsy(toolbarTop=checkbox(top), toolbarBottom=checkbox(bottom)),
+        )
+
+    @login_required
+    def generate_api_key(self, read_only: bool = False) -> str:
+        """
+        Regenerate the account's API key
+
+        Parameters
+        ----------
+        read_only : bool, default False
+            True to generate a read-only key. Any other value (including
+            omission) generates a read-write key; only the literal "r" means
+            read-only on the wire
+
+        Returns
+        -------
+        str
+            The newly generated API key
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        data = self._request("generateApiKey", type="r" if read_only else "w")
+        return str(data["newKey"])
+
+    @login_required
+    def connect_facebook(self, fb_user: dict[str, Any]) -> dict[str, Any]:
+        """
+        Link the account with a Facebook account
+
+        Parameters
+        ----------
+        fb_user : dict[str, Any]
+            Facebook user object, sent using bracket notation
+            (e.g. fbUser[id]=..., fbUser[name]=...)
+
+        Returns
+        -------
+        dict[str, Any]
+            The "fbaccount" field of the response
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        data = self._request("connectWithFacebook", fbUser=fb_user)
+        return dict(data["fbaccount"])
+
+    @login_required
+    def disconnect_facebook(self) -> None:
+        """
+        Unlink the account from Facebook
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        self._request("disconnectWithFacebook")
+
+    # ------------------------------------------------------------------
+    # Raw module fetches (dashboard/settings/*)
+    #
+    # These mirror the tabs of the /account/settings dashboard and exist for
+    # completeness with the module catalog; most of their state is more
+    # conveniently read/written through the action methods above. They
+    # return the raw rendered HTML body rather than a parsed structure,
+    # since only the request/response envelope (not per-tab markup) was
+    # measured during the investigation.
+    # ------------------------------------------------------------------
+
+    def _fetch(self, module_name: str) -> str:
+        """
+        Internal helper to fetch a dashboard/settings/* module's rendered HTML
+
+        Parameters
+        ----------
+        module_name : str
+            Module name to fetch
+
+        Returns
+        -------
+        str
+            Raw rendered HTML body
+        """
+        response = self.client.amc_client.request([{"moduleName": module_name}])[0]
+        return require_body(response, module_name)
+
+    @login_required
+    def get_account_html(self) -> str:
+        """Fetch the raw HTML of dashboard/settings/DSAccountModule (`#/account`)."""
+        return self._fetch("dashboard/settings/DSAccountModule")
+
+    @login_required
+    def get_about_html(self) -> str:
+        """Fetch the raw HTML of dashboard/settings/DSAboutModule (`#/about`)."""
+        return self._fetch("dashboard/settings/DSAboutModule")
+
+    @login_required
+    def get_forum_signature_html(self) -> str:
+        """Fetch the raw HTML of dashboard/settings/DSForumSignatureModule (`#/forumsignature`)."""
+        return self._fetch("dashboard/settings/DSForumSignatureModule")
+
+    @login_required
+    def get_toolbars_html(self) -> str:
+        """Fetch the raw HTML of dashboard/settings/DSToolbarsModule (`#/toolbars`)."""
+        return self._fetch("dashboard/settings/DSToolbarsModule")
+
+    @login_required
+    def get_newsletter_html(self) -> str:
+        """Fetch the raw HTML of dashboard/settings/DSNewsletterModule (`#/newsletter`)."""
+        return self._fetch("dashboard/settings/DSNewsletterModule")
+
+    @login_required
+    def get_messages_html(self) -> str:
+        """
+        Fetch the raw HTML of dashboard/settings/DSMessagesModule (`#/messages`)
+
+        This is also the module used to re-render the PM settings tab after
+        set_receive_messages()/block_user()/unblock_user(). Do not confuse
+        with dashboard/messages/DMSettingsModule (the `/account/messages#/settings`
+        tab), which is a different module that renders the same UI from the
+        messages hub and returned an empty body when measured.
+        """
+        return self._fetch("dashboard/settings/DSMessagesModule")
+
+    @login_required
+    def get_invitations_html(self) -> str:
+        """Fetch the raw HTML of dashboard/settings/DSInvitationsModule (`#/invitations`)."""
+        return self._fetch("dashboard/settings/DSInvitationsModule")
+
+    @login_required
+    def get_facebook_html(self) -> str:
+        """Fetch the raw HTML of dashboard/settings/DSFacebookModule (`#/facebook`)."""
+        return self._fetch("dashboard/settings/DSFacebookModule")
+
+    @login_required
+    def get_visibility_html(self) -> str:
+        """
+        Fetch the raw HTML of dashboard/settings/DSVisibilityModule (`#/visibility`)
+
+        Unmeasured: in the investigation this module returned status
+        "no_permission" for a non-Pro account, so its availability on
+        free accounts is unconfirmed.
+        """
+        return self._fetch("dashboard/settings/DSVisibilityModule")
+
+    @login_required
+    def get_api_html(self) -> str:
+        """Fetch the raw HTML of dashboard/settings/DSApiModule (`#/api`)."""
+        return self._fetch("dashboard/settings/DSApiModule")
+
+
+class AccountProfile:
+    """
+    A class that provides operations on `DashboardProfileAction`
+
+    Covers the public profile: display name, "about" bio, forum signature,
+    profile visibility, and avatar. Access through Client.account.profile.
+    """
+
+    def __init__(self, client: "Client"):
+        """
+        Initialize method
+
+        Parameters
+        ----------
+        client : Client
+            Parent client instance
+        """
+        self.client = client
+
+    def _request(self, event: str, **params: Any) -> Any:
+        """
+        Internal helper to send a DashboardProfileAction request
+
+        Parameters
+        ----------
+        event : str
+            Event name
+        **params : Any
+            Additional request parameters
+
+        Returns
+        -------
+        Any
+            Parsed JSON response
+        """
+        response = self.client.amc_client.request(
+            [
+                {
+                    "action": "DashboardProfileAction",
+                    "event": event,
+                    "moduleName": "Empty",
+                    **params,
+                }
+            ]
+        )[0]
+        return response.json()
+
+    @login_required
+    def change_screen_name(self, screen_name: str) -> None:
+        """
+        Change the account's display (screen) name
+
+        Parameters
+        ----------
+        screen_name : str
+            New display name
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        FormErrorsException
+            If validation fails
+        """
+        self._request("changeScreenName", screenName=screen_name)
+
+    @login_required
+    def save_about(
+        self,
+        real_name: str = "",
+        gender: Literal["m", "f"] | None = None,
+        birthday_day: str = "",
+        birthday_month: str = "",
+        birthday_year: str = "",
+        about: str = "",
+        website: str = "",
+        im_aim: str = "",
+        im_gadu_gadu: str = "",
+        im_google_talk: str = "",
+        im_icq: str = "",
+        im_jabber: str = "",
+        im_msn: str = "",
+        im_yahoo: str = "",
+        location: str = "",
+    ) -> None:
+        """
+        Save the "about" section of the profile (form(dp-about-form))
+
+        Parameters
+        ----------
+        real_name : str, default ""
+            Real name
+        gender : Literal["m", "f"] | None, default None
+            Gender. None omits the field (matches the empty radio state)
+        birthday_day, birthday_month, birthday_year : str, default ""
+            Birthday, sent as separate select/text fields as on the form
+        about : str, default ""
+            Free-text bio. The web form caps this at 200 characters; this
+            method does not enforce that client-side, so an over-length
+            value surfaces as FormErrorsException from the server
+        website : str, default ""
+            Personal website URL
+        im_aim, im_gadu_gadu, im_google_talk, im_icq, im_jabber, im_msn, im_yahoo : str, default ""
+            Instant messenger handles
+        location : str, default ""
+            Location text
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        FormErrorsException
+            If validation fails (e.g. `about` over 200 characters)
+        """
+        self._request(
+            "saveAbout",
+            **omit_falsy(
+                real_name=real_name,
+                gender=gender,
+                birthday_day=birthday_day,
+                birthday_month=birthday_month,
+                birthday_year=birthday_year,
+                about=about,
+                website=website,
+                im_aim=im_aim,
+                im_gadu_gadu=im_gadu_gadu,
+                im_google_talk=im_google_talk,
+                im_icq=im_icq,
+                im_jabber=im_jabber,
+                im_msn=im_msn,
+                im_yahoo=im_yahoo,
+                location=location,
+            ),
+        )
+
+    @login_required
+    def save_forum_signature(self, source: str) -> None:
+        """
+        Save the forum post signature
+
+        Parameters
+        ----------
+        source : str
+            Signature source (Wikidot markup). The web form caps this at 400
+            characters; this method does not enforce that client-side, so an
+            over-length value surfaces as FormErrorsException from the server
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        FormErrorsException
+            If validation fails (e.g. over 400 characters)
+        """
+        self._request("saveForumSignature", source=source)
+
+    @login_required
+    def preview_forum_signature(self, source: str) -> str:
+        """
+        Render a preview of a forum signature without saving it
+
+        Parameters
+        ----------
+        source : str
+            Signature source to preview
+
+        Returns
+        -------
+        str
+            Rendered HTML preview
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        response = self.client.amc_client.request(
+            [{"moduleName": "dashboard/settings/DSForumSignaturePreviewModule", "source": source}]
+        )[0]
+        return require_body(response, "dashboard/settings/DSForumSignaturePreviewModule")
+
+    @login_required
+    def save_profile_visibility(self, raw_fields: dict[str, Any]) -> None:
+        """
+        Save profile visibility settings (form(ap-provilev-form))
+
+        Unmeasured: `dashboard/settings/DSVisibilityModule` returned
+        status "no_permission" for a non-Pro account during the
+        investigation, so the field names of ap-provilev-form (note: "provilev"
+        is the site's own typo, not corrected here) could not be captured.
+        Pass the exact field names/values as sent by the real form.
+
+        Parameters
+        ----------
+        raw_fields : dict[str, Any]
+            Raw form fields to send as-is
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        ForbiddenException
+            If the account has no permission (observed on non-Pro accounts)
+        """
+        self._request("saveProfileVisibility", **raw_fields)
+
+    @login_required
+    def delete_avatar(self) -> None:
+        """
+        Delete the account's avatar image
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        self._request("deleteAvatar")
+
+    @login_required
+    def upload_avatar_from_uri(self, uri: str) -> dict[str, Any]:
+        """
+        Set the account's avatar from an image URL
+
+        Parameters
+        ----------
+        uri : str
+            URL of the image to use as the new avatar
+
+        Returns
+        -------
+        dict[str, Any]
+            Response containing "status", "im48", "im16" (avatar URLs at
+            each size)
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        data = self._request("uploadAvatarUri", uri=uri)
+        return dict(data)
+
+
+class AccountRecentActivity:
+    """
+    A class that provides operations on the `/account/recent` dashboard tab
+
+    Covers the logged-in account's own recent page edits and forum posts,
+    across all sites it belongs to. Access through Client.account.recent.
+    """
+
+    def __init__(self, client: "Client"):
+        """
+        Initialize method
+
+        Parameters
+        ----------
+        client : Client
+            Parent client instance
+        """
+        self.client = client
+
+    def _own_user_id(self) -> int:
+        """
+        Internal helper to get the logged-in account's own user ID
+
+        Returns
+        -------
+        int
+            User ID of Client.me
+
+        Raises
+        ------
+        UnexpectedException
+            If Client.me is unset despite being logged in (should not happen)
+        """
+        me = self.client.me
+        if me is None or me.id is None:
+            raise exceptions.UnexpectedException("Client.me is not set despite being logged in")
+        return me.id
+
+    @login_required
+    def get_changes_html(
+        self,
+        page: int = 1,
+        perpage: int = 20,
+        options: dict[str, bool] | None = None,
+    ) -> str:
+        """
+        Fetch a page of the account's own recent page edits (raw HTML)
+
+        Parameters
+        ----------
+        page : int, default 1
+            Page number
+        perpage : int, default 20
+            Entries per page
+        options : dict[str, bool] | None, default None
+            Filter flags. Keys must be a subset of RECENT_CHANGES_OPTION_KEYS
+            ("all", "source", "title", "move", "files", "new", "meta"); unlike
+            history/PageHistoryModule's options, there is no "tags" key here
+
+        Returns
+        -------
+        str
+            Raw rendered HTML body (row markup was not captured during the
+            investigation, so this is not parsed into a structured list)
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        ValueError
+            If options contains a key outside RECENT_CHANGES_OPTION_KEYS
+        """
+        if options is not None:
+            unknown = set(options) - RECENT_CHANGES_OPTION_KEYS
+            if unknown:
+                raise ValueError(
+                    f"Unknown options for userinfo/UserChangesListModule "
+                    f"(no 'tags' key here, unlike page-history options): {sorted(unknown)}"
+                )
+
+        response = self.client.amc_client.request(
+            [
+                {
+                    "moduleName": "userinfo/UserChangesListModule",
+                    "page": page,
+                    "perpage": perpage,
+                    "userId": self._own_user_id(),
+                    **omit_falsy(options=json_param(options) if options else False),
+                }
+            ]
+        )[0]
+        return require_body(response, "userinfo/UserChangesListModule")
+
+    @login_required
+    def get_posts_html(self, page: int = 1) -> str:
+        """
+        Fetch a page of the account's own recent forum posts (raw HTML)
+
+        Parameters
+        ----------
+        page : int, default 1
+            Page number
+
+        Returns
+        -------
+        str
+            Raw rendered HTML body
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        response = self.client.amc_client.request(
+            [
+                {
+                    "moduleName": "userinfo/UserRecentPostsListModule",
+                    "page": page,
+                    "userId": self._own_user_id(),
+                }
+            ]
+        )[0]
+        return require_body(response, "userinfo/UserRecentPostsListModule")
+
+
+class ClientAccountAccessor:
+    """
+    A class that provides account-level (Dashboard) settings/profile operations
+
+    Associated with a client instance, provides access to the sub-accessors
+    covering the /account/settings and /account/recent dashboards. Access
+    through the Client.account property.
+    """
+
+    def __init__(self, client: "Client"):
+        """
+        Initialize method
+
+        Parameters
+        ----------
+        client : Client
+            Parent client instance
+        """
+        self.client = client
+        self.settings = AccountSettings(client)
+        self.profile = AccountProfile(client)
+        self.recent = AccountRecentActivity(client)

--- a/src/wikidot/module/client.py
+++ b/src/wikidot/module/client.py
@@ -1,10 +1,13 @@
 from types import TracebackType
-from typing import Optional
+from typing import Any, Optional
 
 from ..common import wd_logger
 from ..common.exceptions import LoginRequiredException
 from ..connector.ajax import AjaxModuleConnectorClient, AjaxModuleConnectorConfig
+from . import private_message as pm
+from .account import ClientAccountAccessor
 from .auth import HTTPAuthentication
+from .dashboard_site import DashboardSites, NewSitePrivacy, NewSiteTemplate
 from .private_message import (
     PrivateMessage,
     PrivateMessageCollection,
@@ -163,6 +166,230 @@ class ClientPrivateMessageAccessor:
         """
         return PrivateMessage.from_id(self.client, message_id)
 
+    def mark_as_read(self, message_ids: list[int]) -> None:
+        """
+        Mark messages as read
+
+        Parameters
+        ----------
+        message_ids : list[int]
+            IDs of the messages to mark as read
+        """
+        PrivateMessageCollection.mark_as_read(self.client, message_ids)
+
+    def mark_as_unread(self, message_ids: list[int]) -> None:
+        """
+        Mark messages as unread
+
+        Parameters
+        ----------
+        message_ids : list[int]
+            IDs of the messages to mark as unread
+        """
+        PrivateMessageCollection.mark_as_unread(self.client, message_ids)
+
+    def remove(self, message_ids: list[int]) -> None:
+        """
+        Delete messages
+
+        Parameters
+        ----------
+        message_ids : list[int]
+            IDs of the messages to delete
+        """
+        PrivateMessageCollection.remove_messages(self.client, message_ids)
+
+    def save_draft(self, subject: str, body: str, recipient: Optional["User"] = None) -> None:
+        """
+        Save a private message draft
+
+        Parameters
+        ----------
+        subject : str
+            Draft subject
+        body : str
+            Draft body
+        recipient : User | None, default None
+            Intended recipient
+        """
+        PrivateMessage.save_draft(self.client, subject, body, recipient)
+
+    def check_can_send(self, user: AbstractUser) -> None:
+        """
+        Check whether the account is allowed to message a user
+
+        Parameters
+        ----------
+        user : AbstractUser
+            Prospective recipient
+
+        Raises
+        ------
+        ForbiddenException
+            If sending is not allowed
+        """
+        PrivateMessage.check_can_send(self.client, user)
+
+    def preview(self, subject: str, body: str, recipient: Optional["User"] = None) -> str:
+        """
+        Render a preview of a private message without sending it
+
+        Parameters
+        ----------
+        subject : str
+            Message subject
+        body : str
+            Message body
+        recipient : User | None, default None
+            Intended recipient
+
+        Returns
+        -------
+        str
+            Rendered HTML preview
+        """
+        return PrivateMessage.preview(self.client, subject, body, recipient)
+
+    def fetch_reply_form_html(self, reply_message_id: int) -> str:
+        """
+        Fetch the pre-filled "new message" form HTML for replying to a message
+
+        Parameters
+        ----------
+        reply_message_id : int
+            ID of the message being replied to
+
+        Returns
+        -------
+        str
+            Raw rendered HTML body
+        """
+        return PrivateMessage.fetch_reply_form_html(self.client, reply_message_id)
+
+    def get_invitations_html(self, page: int = 1) -> str:
+        """
+        Fetch a page of the account's pending site invitations (raw HTML)
+
+        Parameters
+        ----------
+        page : int, default 1
+            Page number
+
+        Returns
+        -------
+        str
+            Raw rendered HTML body
+        """
+        return pm.get_invitations_html(self.client, page)
+
+    def get_invitation_detail_html(self, item: int) -> str:
+        """
+        Fetch the detail HTML of a single site invitation
+
+        Parameters
+        ----------
+        item : int
+            Invitation ID
+
+        Returns
+        -------
+        str
+            Raw rendered HTML body
+        """
+        return pm.get_invitation_detail_html(self.client, item)
+
+    def get_applications_html(self, page: int = 1) -> str:
+        """
+        Fetch a page of the account's pending site join applications (raw HTML)
+
+        Parameters
+        ----------
+        page : int, default 1
+            Page number
+
+        Returns
+        -------
+        str
+            Raw rendered HTML body
+        """
+        return pm.get_applications_html(self.client, page)
+
+    def get_application_detail_html(self, item: int) -> str:
+        """
+        Fetch the detail HTML of a single site join application
+
+        Parameters
+        ----------
+        item : int
+            Application ID
+
+        Returns
+        -------
+        str
+            Raw rendered HTML body
+        """
+        return pm.get_application_detail_html(self.client, item)
+
+    def get_contacts_html(self) -> str:
+        """
+        Fetch the account's contact list (raw HTML)
+
+        Returns
+        -------
+        str
+            Raw rendered HTML body
+        """
+        return pm.get_contacts_html(self.client)
+
+    def get_contacts_list_html(self) -> str:
+        """
+        Fetch the contact picker used when composing a new message (raw HTML)
+
+        Returns
+        -------
+        str
+            Raw rendered HTML body
+        """
+        return pm.get_contacts_list_html(self.client)
+
+    def add_contact(self, user: AbstractUser) -> None:
+        """
+        Add a user to the account's contact list
+
+        Parameters
+        ----------
+        user : AbstractUser
+            User to add
+        """
+        pm.add_contact(self.client, user)
+
+    def remove_contact(self, user: AbstractUser) -> None:
+        """
+        Remove a user from the account's contact list
+
+        Parameters
+        ----------
+        user : AbstractUser
+            User to remove
+        """
+        pm.remove_contact(self.client, user)
+
+    def add_contact_via_profile(self, user: AbstractUser) -> str:
+        """
+        Add a user to the account's contact list from their profile page
+
+        Parameters
+        ----------
+        user : AbstractUser
+            User to add
+
+        Returns
+        -------
+        str
+            Raw rendered HTML body
+        """
+        return pm.add_contact_via_profile(self.client, user)
+
 
 class ClientSiteAccessor:
     """
@@ -199,6 +426,165 @@ class ClientSiteAccessor:
         """
         return Site.from_unix_name(self.client, unix_name)
 
+    def create(
+        self,
+        name: str,
+        unixname: str,
+        subtitle: str = "",
+        language: str = "en",
+        template: NewSiteTemplate = "standard-template",
+        privacy: NewSitePrivacy = "open",
+        tos: bool = True,
+    ) -> str:
+        """
+        Create a new site
+
+        Parameters
+        ----------
+        name : str
+            Site title
+        unixname : str
+            Site UNIX name (e.g. "foo" -> foo.wikidot.com)
+        subtitle : str, default ""
+            Site subtitle
+        language : str, default "en"
+            Site language code
+        template : NewSiteTemplate, default "standard-template"
+            Starting content template
+        privacy : NewSitePrivacy, default "open"
+            Site visibility
+        tos : bool, default True
+            Whether to accept the Terms of Service
+
+        Returns
+        -------
+        str
+            UNIX name of the created site
+
+        Raises
+        ------
+        FormErrorsException
+            If validation fails (e.g. unixname already taken)
+        """
+        return DashboardSites.create(
+            self.client,
+            name=name,
+            unixname=unixname,
+            subtitle=subtitle,
+            language=language,
+            template=template,
+            privacy=privacy,
+            tos=tos,
+        )
+
+    @property
+    def my_sites_html(self) -> str:
+        """
+        Fetch the raw HTML of the account's site dashboard (all roles + deleted)
+
+        Returns
+        -------
+        str
+            Raw rendered HTML body
+        """
+        return DashboardSites.list_html(self.client)
+
+    def accept_invitation(self, invitation_id: int) -> None:
+        """
+        Accept a pending site invitation
+
+        Parameters
+        ----------
+        invitation_id : int
+            Invitation ID
+        """
+        DashboardSites.accept_invitation(self.client, invitation_id)
+
+    def throw_away_invitation(self, invitation_id: int) -> None:
+        """
+        Discard a pending site invitation without accepting it
+
+        Parameters
+        ----------
+        invitation_id : int
+            Invitation ID
+        """
+        DashboardSites.throw_away_invitation(self.client, invitation_id)
+
+    def remove_application(self, site_id: int) -> None:
+        """
+        Withdraw a pending membership application the account submitted to a site
+
+        Parameters
+        ----------
+        site_id : int
+            ID of the site the application was submitted to
+        """
+        DashboardSites.remove_application(self.client, site_id)
+
+    def restore_site(self, site_id: int, confirm_site_name: str) -> None:
+        """
+        Restore a deleted site the account administers
+
+        Parameters
+        ----------
+        site_id : int
+            ID of the deleted site
+        confirm_site_name : str
+            Site name, required as a typed confirmation
+        """
+        DashboardSites.restore_site(self.client, site_id, confirm_site_name)
+
+    def resign_as_admin(self, site_id: int) -> None:
+        """
+        Resign the account's admin role on a site
+
+        Parameters
+        ----------
+        site_id : int
+            Site ID
+        """
+        DashboardSites.resign_as_admin(self.client, site_id)
+
+    def resign_as_moderator(self, site_id: int) -> None:
+        """
+        Resign the account's moderator role on a site
+
+        Parameters
+        ----------
+        site_id : int
+            Site ID
+        """
+        DashboardSites.resign_as_moderator(self.client, site_id)
+
+    def sign_off_as_member(self, site_id: int) -> None:
+        """
+        Leave a site the account is a plain member of
+
+        Parameters
+        ----------
+        site_id : int
+            Site ID
+        """
+        DashboardSites.sign_off_as_member(self.client, site_id)
+
+    def set_site_storage_limit(self, site_id: int, raw_fields: dict[str, Any]) -> None:
+        """
+        Set a site's file storage limit
+
+        Unmeasured: the form fields of limit-site-<siteId> could not be
+        captured during the investigation (no Pro site available). Pass the
+        exact field names/values as sent by the real form.
+
+        Parameters
+        ----------
+        site_id : int
+            Site ID
+        raw_fields : dict[str, Any]
+            Raw form fields to send as-is
+        """
+        DashboardSites.set_storage_limit(self.client, site_id, raw_fields)
+
 
 class Client:
     """
@@ -212,6 +598,7 @@ class Client:
     user: "ClientUserAccessor"
     private_message: "ClientPrivateMessageAccessor"
     site: "ClientSiteAccessor"
+    account: "ClientAccountAccessor"
 
     # セッション関連属性
     amc_client: AjaxModuleConnectorClient
@@ -267,6 +654,7 @@ class Client:
         self.user = ClientUserAccessor(self)
         self.private_message = ClientPrivateMessageAccessor(self)
         self.site = ClientSiteAccessor(self)
+        self.account = ClientAccountAccessor(self)
 
         # ------------
         # メソッド終わり

--- a/src/wikidot/module/client.py
+++ b/src/wikidot/module/client.py
@@ -7,7 +7,7 @@ from ..connector.ajax import AjaxModuleConnectorClient, AjaxModuleConnectorConfi
 from . import private_message as pm
 from .account import ClientAccountAccessor
 from .auth import HTTPAuthentication
-from .dashboard_site import DashboardSites, NewSitePrivacy, NewSiteTemplate
+from .dashboard_site import DashboardSite, DashboardSites, NewSitePrivacy, NewSiteTemplate
 from .private_message import (
     PrivateMessage,
     PrivateMessageCollection,
@@ -298,21 +298,16 @@ class ClientPrivateMessageAccessor:
         """
         return pm.get_invitation_detail_html(self.client, item)
 
-    def get_applications_html(self, page: int = 1) -> str:
+    def get_applications(self) -> list["pm.SiteJoinApplication"]:
         """
-        Fetch a page of the account's pending site join applications (raw HTML)
-
-        Parameters
-        ----------
-        page : int, default 1
-            Page number
+        Get all of the account's pending outgoing site join applications
 
         Returns
         -------
-        str
-            Raw rendered HTML body
+        list[SiteJoinApplication]
+            All pending applications
         """
-        return pm.get_applications_html(self.client, page)
+        return pm.get_applications(self.client)
 
     def get_application_detail_html(self, item: int) -> str:
         """
@@ -330,16 +325,16 @@ class ClientPrivateMessageAccessor:
         """
         return pm.get_application_detail_html(self.client, item)
 
-    def get_contacts_html(self) -> str:
+    def get_contacts(self) -> list["pm.Contact"]:
         """
-        Fetch the account's contact list (raw HTML)
+        Get the account's contact list
 
         Returns
         -------
-        str
-            Raw rendered HTML body
+        list[Contact]
+            All contacts
         """
-        return pm.get_contacts_html(self.client)
+        return pm.get_contacts(self.client)
 
     def get_contacts_list_html(self) -> str:
         """
@@ -478,16 +473,16 @@ class ClientSiteAccessor:
         )
 
     @property
-    def my_sites_html(self) -> str:
+    def my_sites(self) -> list[DashboardSite]:
         """
-        Fetch the raw HTML of the account's site dashboard (all roles + deleted)
+        Get every site the account belongs to (all roles) plus deleted sites
 
         Returns
         -------
-        str
-            Raw rendered HTML body
+        list[DashboardSite]
+            All rows of the account's site dashboard
         """
-        return DashboardSites.list_html(self.client)
+        return DashboardSites.list_sites(self.client)
 
     def accept_invitation(self, invitation_id: int) -> None:
         """

--- a/src/wikidot/module/dashboard_site.py
+++ b/src/wikidot/module/dashboard_site.py
@@ -14,7 +14,10 @@ All requests are sent to `www.wikidot.com` (Client.amc_client's default
 host), never to a site's own host.
 """
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
+
+from bs4 import BeautifulSoup
 
 from ..common.decorators import login_required
 from ..connector.ajax import require_body
@@ -34,6 +37,218 @@ NewSiteTemplate = Literal[
 
 #: `privacy` values accepted by NewSiteAction/createSite (form(new-site-form))
 NewSitePrivacy = Literal["open", "closed", "private"]
+
+
+@dataclass
+class DashboardSite:
+    """
+    A row of the account's site dashboard listing (dashboard/sites/DSListModule)
+
+    Represents the current account's relationship to one site (any role, or a
+    site it once belonged to but is now deleted). Distinct from `Site`, which
+    represents a site's own state independent of any particular account.
+
+    Row markup was measured 2026-07-29 (see `70_account.md` "一覧モジュールの
+    行マークアップ"): each row is `div.site`, with `div.name > a` (title),
+    `div.url` (site URL), and a `div.data` block holding `span.activity`,
+    `span.site-id`, `span.unix-name`, `span.tagline`, `span.deleted`,
+    `span.occupation`. The measurement captured the DOM skeleton but not the
+    exact value encoding of every field, so `activity` and `role` are kept as
+    the raw observed text rather than a guessed enum/unit.
+
+    Attributes
+    ----------
+    client : Client
+        Client instance
+    site_id : int
+        Site ID (span.site-id)
+    title : str
+        Site title (text of div.name > a)
+    url : str
+        Site URL (text of div.url)
+    unix_name : str
+        Site UNIX name (span.unix-name)
+    tagline : str
+        Site tagline/subtitle (span.tagline)
+    activity : str
+        Raw text of span.activity. Exact meaning/unit was not confirmed during
+        the investigation
+    role : str
+        Raw text of span.occupation. Observed values are expected to align
+        with the hash-tab identifiers used elsewhere on this page
+        ("master_admin" / "admin" / "moderator" / "member"), but this
+        correspondence was not independently confirmed
+    deleted : bool
+        Whether span.deleted is present in this row's div.data block
+    """
+
+    client: "Client"
+    site_id: int
+    title: str
+    url: str
+    unix_name: str
+    tagline: str
+    activity: str
+    role: str
+    deleted: bool
+
+    def __str__(self) -> str:
+        """
+        String representation of the object
+
+        Returns
+        -------
+        str
+            String representation of the dashboard site row
+        """
+        return f"DashboardSite(site_id={self.site_id}, title={self.title}, role={self.role}, deleted={self.deleted})"
+
+    def restore(self, confirm_site_name: str) -> None:
+        """
+        Restore this site (must currently be deleted)
+
+        Parameters
+        ----------
+        confirm_site_name : str
+            Site name, required as a typed confirmation
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        DashboardSites.restore_site(self.client, self.site_id, confirm_site_name)
+
+    def resign_as_admin(self) -> None:
+        """
+        Resign the account's admin role on this site
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        DashboardSites.resign_as_admin(self.client, self.site_id)
+
+    def resign_as_moderator(self) -> None:
+        """
+        Resign the account's moderator role on this site
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        DashboardSites.resign_as_moderator(self.client, self.site_id)
+
+    def sign_off_as_member(self) -> None:
+        """
+        Leave this site (account must be a plain member)
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        DashboardSites.sign_off_as_member(self.client, self.site_id)
+
+    def set_storage_limit(self, raw_fields: dict[str, Any]) -> None:
+        """
+        Set this site's file storage limit
+
+        Unmeasured: see DashboardSites.set_storage_limit for details.
+
+        Parameters
+        ----------
+        raw_fields : dict[str, Any]
+            Raw form fields to send as-is
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        DashboardSites.set_storage_limit(self.client, self.site_id, raw_fields)
+
+    @staticmethod
+    def _parse_row(client: "Client", row: Any) -> "DashboardSite | None":
+        """
+        Internal method to parse a single dashboard/sites/DSListModule row
+
+        Parameters
+        ----------
+        client : Client
+            Client instance
+        row : bs4.Tag
+            `div.site` element to parse
+
+        Returns
+        -------
+        DashboardSite | None
+            Parsed row, or None if a required element is missing
+        """
+        name_link = row.select_one("div.name > a")
+        url_elem = row.select_one("div.url")
+        site_id_elem = row.select_one("span.site-id")
+        unix_name_elem = row.select_one("span.unix-name")
+        tagline_elem = row.select_one("span.tagline")
+        activity_elem = row.select_one("span.activity")
+        role_elem = row.select_one("span.occupation")
+        deleted_elem = row.select_one("span.deleted")
+
+        if name_link is None or site_id_elem is None or unix_name_elem is None:
+            return None
+
+        site_id_text = site_id_elem.get_text().strip()
+        if not site_id_text.isdigit():
+            return None
+
+        return DashboardSite(
+            client=client,
+            site_id=int(site_id_text),
+            title=name_link.get_text().strip(),
+            url=url_elem.get_text().strip() if url_elem else "",
+            unix_name=unix_name_elem.get_text().strip(),
+            tagline=tagline_elem.get_text().strip() if tagline_elem else "",
+            activity=activity_elem.get_text().strip() if activity_elem else "",
+            role=role_elem.get_text().strip() if role_elem else "",
+            deleted=deleted_elem is not None,
+        )
+
+    @staticmethod
+    @login_required
+    def acquire_all(client: "Client") -> list["DashboardSite"]:
+        """
+        Retrieve every site the account belongs to (all roles) plus deleted sites
+
+        Wraps dashboard/sites/DSListModule, which renders the full list in one
+        response (the real UI filters by role/deleted client-side via DOM
+        attributes rather than separate requests).
+
+        Parameters
+        ----------
+        client : Client
+            Client instance
+
+        Returns
+        -------
+        list[DashboardSite]
+            All rows of the account's site dashboard
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        response = client.amc_client.request([{"moduleName": "dashboard/sites/DSListModule"}])[0]
+        html = BeautifulSoup(require_body(response, "dashboard/sites/DSListModule"), "lxml")
+
+        sites = []
+        for row in html.select("div.site"):
+            site = DashboardSite._parse_row(client, row)
+            if site is not None:
+                sites.append(site)
+        return sites
 
 
 class DashboardSites:
@@ -113,16 +328,9 @@ class DashboardSites:
         return str(response.json()["siteUnixName"])
 
     @staticmethod
-    @login_required
-    def list_html(client: "Client") -> str:
+    def list_sites(client: "Client") -> list[DashboardSite]:
         """
-        Fetch the raw HTML of dashboard/sites/DSListModule
-
-        Renders every site the account belongs to (all roles) plus deleted
-        sites in one response; the real UI filters by role/deleted client-side
-        via DOM attributes rather than separate requests. Row markup detail
-        (site id/unix name/role attributes) was not captured during the
-        investigation, so this returns the raw body rather than a parsed list.
+        Retrieve every site the account belongs to (all roles) plus deleted sites
 
         Parameters
         ----------
@@ -131,16 +339,15 @@ class DashboardSites:
 
         Returns
         -------
-        str
-            Raw rendered HTML body
+        list[DashboardSite]
+            All rows of the account's site dashboard
 
         Raises
         ------
         LoginRequiredException
             If not logged in
         """
-        response = client.amc_client.request([{"moduleName": "dashboard/sites/DSListModule"}])[0]
-        return require_body(response, "dashboard/sites/DSListModule")
+        return DashboardSite.acquire_all(client)
 
     @staticmethod
     @login_required

--- a/src/wikidot/module/dashboard_site.py
+++ b/src/wikidot/module/dashboard_site.py
@@ -1,0 +1,387 @@
+"""
+Module for handling the logged-in user's own sites and site invitations
+(`www.wikidot.com/account/sites`)
+
+These operations act on the current account's relationship to sites --
+creating a new site, listing sites the account belongs to, accepting or
+discarding invitations, and resigning from a role -- as distinct from
+`Site`, which represents operations performed *within* a single already-
+identified site. Some targets here (a pending invitation, a deleted site)
+have no accessible `Site` object yet, so these are modeled as standalone
+functions taking raw IDs rather than methods on a resource dataclass.
+
+All requests are sent to `www.wikidot.com` (Client.amc_client's default
+host), never to a site's own host.
+"""
+
+from typing import TYPE_CHECKING, Any, Literal
+
+from ..common.decorators import login_required
+from ..connector.ajax import require_body
+from ..util.amc_body import checkbox, omit_falsy
+
+if TYPE_CHECKING:
+    from .client import Client
+
+#: `template` values accepted by NewSiteAction/createSite (form(new-site-form))
+NewSiteTemplate = Literal[
+    "standard-template",
+    "blog-template",
+    "blank-template",
+    "default-template",
+    "notebooks",
+]
+
+#: `privacy` values accepted by NewSiteAction/createSite (form(new-site-form))
+NewSitePrivacy = Literal["open", "closed", "private"]
+
+
+class DashboardSites:
+    """
+    A class that provides operations on `DashboardSitesAction` / `NewSiteAction` /
+    `dashboard/sites/*`
+
+    Static namespace grouping the account's site-dashboard operations. Access
+    through Client.site (create/list/accept_invitation/...) rather than
+    instantiating this class directly.
+    """
+
+    @staticmethod
+    @login_required
+    def create(
+        client: "Client",
+        name: str,
+        unixname: str,
+        subtitle: str = "",
+        language: str = "en",
+        template: NewSiteTemplate = "standard-template",
+        privacy: NewSitePrivacy = "open",
+        tos: bool = True,
+    ) -> str:
+        """
+        Create a new site (form(new-site-form) -> NewSiteAction/createSite)
+
+        Parameters
+        ----------
+        client : Client
+            Client instance
+        name : str
+            Site title
+        unixname : str
+            Site UNIX name (used in the domain, e.g. "foo" -> foo.wikidot.com)
+        subtitle : str, default ""
+            Site subtitle
+        language : str, default "en"
+            Site language code
+        template : NewSiteTemplate, default "standard-template"
+            Starting content template
+        privacy : NewSitePrivacy, default "open"
+            Site visibility ("open", "closed", or "private")
+        tos : bool, default True
+            Whether to accept the Terms of Service. The real form requires
+            this checked to submit; sending False reproduces the unchecked
+            (omitted) wire state
+
+        Returns
+        -------
+        str
+            UNIX name of the created site (the "siteUnixName" response field)
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        FormErrorsException
+            If validation fails (e.g. unixname already taken)
+        """
+        response = client.amc_client.request(
+            [
+                {
+                    "action": "NewSiteAction",
+                    "event": "createSite",
+                    "moduleName": "Empty",
+                    "name": name,
+                    "subtitle": subtitle,
+                    "unixname": unixname,
+                    "language": language,
+                    "template": template,
+                    "privacy": privacy,
+                    **omit_falsy(tos=checkbox(tos)),
+                }
+            ]
+        )[0]
+        return str(response.json()["siteUnixName"])
+
+    @staticmethod
+    @login_required
+    def list_html(client: "Client") -> str:
+        """
+        Fetch the raw HTML of dashboard/sites/DSListModule
+
+        Renders every site the account belongs to (all roles) plus deleted
+        sites in one response; the real UI filters by role/deleted client-side
+        via DOM attributes rather than separate requests. Row markup detail
+        (site id/unix name/role attributes) was not captured during the
+        investigation, so this returns the raw body rather than a parsed list.
+
+        Parameters
+        ----------
+        client : Client
+            Client instance
+
+        Returns
+        -------
+        str
+            Raw rendered HTML body
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        response = client.amc_client.request([{"moduleName": "dashboard/sites/DSListModule"}])[0]
+        return require_body(response, "dashboard/sites/DSListModule")
+
+    @staticmethod
+    @login_required
+    def accept_invitation(client: "Client", invitation_id: int) -> None:
+        """
+        Accept a pending site invitation
+
+        Parameters
+        ----------
+        client : Client
+            Client instance
+        invitation_id : int
+            Invitation ID (as listed by dashboard/messages/DMInvitationsModule)
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        client.amc_client.request(
+            [
+                {
+                    "action": "DashboardSitesAction",
+                    "event": "acceptInvitation",
+                    "invitation_id": invitation_id,
+                    "moduleName": "Empty",
+                }
+            ]
+        )
+
+    @staticmethod
+    @login_required
+    def throw_away_invitation(client: "Client", invitation_id: int) -> None:
+        """
+        Discard a pending site invitation without accepting it
+
+        Parameters
+        ----------
+        client : Client
+            Client instance
+        invitation_id : int
+            Invitation ID
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        client.amc_client.request(
+            [
+                {
+                    "action": "DashboardSitesAction",
+                    "event": "throwAwayInvitation",
+                    "invitation_id": invitation_id,
+                    "moduleName": "Empty",
+                }
+            ]
+        )
+
+    @staticmethod
+    @login_required
+    def remove_application(client: "Client", site_id: int) -> None:
+        """
+        Withdraw a pending membership application the account submitted to a site
+
+        Parameters
+        ----------
+        client : Client
+            Client instance
+        site_id : int
+            ID of the site the application was submitted to
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        client.amc_client.request(
+            [
+                {
+                    "action": "DashboardSitesAction",
+                    "event": "removeApplication",
+                    "site_id": site_id,
+                    "moduleName": "Empty",
+                }
+            ]
+        )
+
+    @staticmethod
+    @login_required
+    def restore_site(client: "Client", site_id: int, confirm_site_name: str) -> None:
+        """
+        Restore a deleted site the account administers
+
+        Parameters
+        ----------
+        client : Client
+            Client instance
+        site_id : int
+            ID of the deleted site
+        confirm_site_name : str
+            Site name, required by form(ds-restore-site-form) as a typed
+            confirmation (mirrors the real UI's "type the site name" guard)
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        client.amc_client.request(
+            [
+                {
+                    "action": "DashboardSitesAction",
+                    "event": "restoreSite",
+                    "site_id": site_id,
+                    "site_name": confirm_site_name,
+                    "moduleName": "Empty",
+                }
+            ]
+        )
+
+    @staticmethod
+    @login_required
+    def resign_as_admin(client: "Client", site_id: int) -> None:
+        """
+        Resign the account's admin role on a site (form(ds-admin-resign-form))
+
+        Parameters
+        ----------
+        client : Client
+            Client instance
+        site_id : int
+            Site ID
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        client.amc_client.request(
+            [
+                {
+                    "action": "DashboardSitesAction",
+                    "event": "adminResign",
+                    "site_id": site_id,
+                    "moduleName": "Empty",
+                }
+            ]
+        )
+
+    @staticmethod
+    @login_required
+    def resign_as_moderator(client: "Client", site_id: int) -> None:
+        """
+        Resign the account's moderator role on a site (form(ds-moderator-resign-form))
+
+        Parameters
+        ----------
+        client : Client
+            Client instance
+        site_id : int
+            Site ID
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        client.amc_client.request(
+            [
+                {
+                    "action": "DashboardSitesAction",
+                    "event": "moderatorResign",
+                    "site_id": site_id,
+                    "moduleName": "Empty",
+                }
+            ]
+        )
+
+    @staticmethod
+    @login_required
+    def sign_off_as_member(client: "Client", site_id: int) -> None:
+        """
+        Leave a site the account is a plain member of (form(ds-member-signoff-form))
+
+        Parameters
+        ----------
+        client : Client
+            Client instance
+        site_id : int
+            Site ID
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        client.amc_client.request(
+            [
+                {
+                    "action": "DashboardSitesAction",
+                    "event": "memberSignOff",
+                    "site_id": site_id,
+                    "moduleName": "Empty",
+                }
+            ]
+        )
+
+    @staticmethod
+    @login_required
+    def set_storage_limit(client: "Client", site_id: int, raw_fields: dict[str, Any]) -> None:
+        """
+        Set a site's file storage limit (form(limit-site-<siteId>))
+
+        Unmeasured: dashboard/sites/DSListModule did not render this form
+        for the investigation account (no Pro site available), so the field
+        names of limit-site-<siteId> could not be captured. Pass the exact
+        field names/values as sent by the real form.
+
+        Parameters
+        ----------
+        client : Client
+            Client instance
+        site_id : int
+            Site ID
+        raw_fields : dict[str, Any]
+            Raw form fields to send as-is
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        client.amc_client.request(
+            [
+                {
+                    "action": "DashboardSitesAction",
+                    "event": "setStorageLimit",
+                    "site_id": site_id,
+                    "moduleName": "Empty",
+                    **raw_fields,
+                }
+            ]
+        )

--- a/src/wikidot/module/private_message.py
+++ b/src/wikidot/module/private_message.py
@@ -735,9 +735,12 @@ class PrivateMessage:
 #
 # These represent the account's own outgoing/incoming relationships to
 # sites and other users, rendered by dashboard/messages/DM*Module. Row
-# markup for these list modules was not captured during the investigation
-# (unlike the inbox/sent tr.message structure above), so listing functions
-# return the raw rendered HTML rather than a parsed collection.
+# markup for DMApplicationsModule/DMContactsModule was measured 2026-07-29
+# and is parsed into SiteJoinApplication/Contact below (DMApplicationsModule
+# rows follow the same tr.message[data-href] pattern as inbox/sent). Row
+# markup for DMInvitationsModule was not captured (no invitations existed on
+# the investigation account), so its listing function still returns raw
+# rendered HTML.
 # ----------------------------------------------------------------------
 
 
@@ -807,18 +810,24 @@ class SiteJoinApplication:
     admin's view of incoming applications to their own site.
 
     Row markup was measured 2026-07-29 (see `70_account.md` "一覧モジュールの
-    行マークアップ"): each row is a `tr` with `span.from` / `span.subject` /
-    `span.preview` / `span.date > span.odate`. The measurement did not find a
-    site-id/application-id-bearing attribute on the row, so this object
-    cannot drive `DMViewApplicationModule` or
-    `DashboardSitesAction/removeApplication` directly; use
-    `ClientSiteAccessor.remove_application(site_id)` with a site_id obtained
-    elsewhere if you need to withdraw an application.
+    行マークアップ" / "行の属性"): each row is `tr.message` with
+    `data-href="#/applications/<item_id>"` (the same pattern as the inbox/sent
+    `tr.message[data-href]`), plus `span.from` / `span.subject` /
+    `span.preview` / `span.date > span.odate`. The row does not carry a
+    site_id, so this object cannot drive
+    `DashboardSitesAction/removeApplication` (which takes a site_id, not this
+    item_id) directly; use `ClientSiteAccessor.remove_application(site_id)`
+    with a site_id obtained elsewhere if you need to withdraw an application.
+    Extracting a site_id from `DMViewApplicationModule`'s response was not
+    attempted since that response's structure is unmeasured.
 
     Attributes
     ----------
     client : Client
         Client instance
+    item_id : int
+        Application ID (tail of `tr.message`'s data-href), usable as the
+        `item` parameter of `DMViewApplicationModule`
     from_site : str
         Text of span.from (the site the application was submitted to)
     subject : str
@@ -830,6 +839,7 @@ class SiteJoinApplication:
     """
 
     client: "Client"
+    item_id: int
     from_site: str
     subject: str
     preview: str
@@ -844,7 +854,23 @@ class SiteJoinApplication:
         str
             String representation of the application
         """
-        return f"SiteJoinApplication(from_site={self.from_site}, subject={self.subject})"
+        return f"SiteJoinApplication(item_id={self.item_id}, from_site={self.from_site}, subject={self.subject})"
+
+    def fetch_detail_html(self) -> str:
+        """
+        Fetch the detail HTML of this application (DMViewApplicationModule)
+
+        Returns
+        -------
+        str
+            Raw rendered HTML body
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        return get_application_detail_html(self.client, self.item_id)
 
     @staticmethod
     def _parse_row(client: "Client", row: Tag) -> "SiteJoinApplication | None":
@@ -856,15 +882,20 @@ class SiteJoinApplication:
         client : Client
             Client instance
         row : bs4.Tag
-            `tr` element to parse
+            `tr.message` element to parse
 
         Returns
         -------
         SiteJoinApplication | None
             Parsed row, or None if a required element is missing
         """
+        data_href = row.get("data-href")
         from_elem = row.select_one("span.from")
-        if from_elem is None:
+        if data_href is None or from_elem is None:
+            return None
+
+        item_id_text = str(data_href).split("/")[-1]
+        if not item_id_text.isdigit():
             return None
 
         subject_elem = row.select_one("span.subject")
@@ -873,6 +904,7 @@ class SiteJoinApplication:
 
         return SiteJoinApplication(
             client=client,
+            item_id=int(item_id_text),
             from_site=from_elem.get_text().strip(),
             subject=subject_elem.get_text().strip() if subject_elem else "",
             preview=preview_elem.get_text().strip() if preview_elem else "",
@@ -910,7 +942,7 @@ def get_applications(client: "Client") -> list["SiteJoinApplication"]:
     max_page: int = int(pager[-2].get_text()) if len(pager) > 2 else 1
 
     applications: list[SiteJoinApplication] = []
-    for row in first_html.select("tr"):
+    for row in first_html.select("tr.message"):
         application = SiteJoinApplication._parse_row(client, row)
         if application is not None:
             applications.append(application)
@@ -919,7 +951,7 @@ def get_applications(client: "Client") -> list["SiteJoinApplication"]:
         bodies = [{"page": page, "moduleName": module_name} for page in range(2, max_page + 1)]
         for response in client.amc_client.request(bodies):
             html = BeautifulSoup(require_body(response, module_name), "lxml")
-            for row in html.select("tr"):
+            for row in html.select("tr.message"):
                 application = SiteJoinApplication._parse_row(client, row)
                 if application is not None:
                     applications.append(application)

--- a/src/wikidot/module/private_message.py
+++ b/src/wikidot/module/private_message.py
@@ -16,6 +16,7 @@ from typing_extensions import Self
 from ..common import exceptions
 from ..common.decorators import login_required
 from ..connector.ajax import require_body
+from ..util.amc_body import omit_falsy
 from ..util.parser import odate as odate_parser
 from ..util.parser import user as user_parser
 
@@ -239,6 +240,101 @@ class PrivateMessageCollection(list["PrivateMessage"]):
         """
         return cls(PrivateMessageCollection._acquire(client, module_name))
 
+    @staticmethod
+    @login_required
+    def mark_as_read(client: "Client", message_ids: list[int]) -> None:
+        """
+        Mark messages as read
+
+        Wraps `DashboardMessageAction/setAsReaded` (the misspelling is
+        Wikidot's own event name on the wire and is intentionally kept
+        as-is here; only this Python method name uses correct spelling).
+
+        Parameters
+        ----------
+        client : Client
+            Client instance
+        message_ids : list[int]
+            IDs of the messages to mark as read
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        client.amc_client.request(
+            [
+                {
+                    "action": "DashboardMessageAction",
+                    "event": "setAsReaded",
+                    "selected": message_ids,
+                    "moduleName": "Empty",
+                }
+            ]
+        )
+
+    @staticmethod
+    @login_required
+    def mark_as_unread(client: "Client", message_ids: list[int]) -> None:
+        """
+        Mark messages as unread
+
+        Wraps `DashboardMessageAction/setAsUnreaded`.
+
+        Parameters
+        ----------
+        client : Client
+            Client instance
+        message_ids : list[int]
+            IDs of the messages to mark as unread
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        client.amc_client.request(
+            [
+                {
+                    "action": "DashboardMessageAction",
+                    "event": "setAsUnreaded",
+                    "selected": message_ids,
+                    "moduleName": "Empty",
+                }
+            ]
+        )
+
+    @staticmethod
+    @login_required
+    def remove_messages(client: "Client", message_ids: list[int]) -> None:
+        """
+        Delete messages
+
+        Wraps `DashboardMessageAction/removeMessages`.
+
+        Parameters
+        ----------
+        client : Client
+            Client instance
+        message_ids : list[int]
+            IDs of the messages to delete
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        client.amc_client.request(
+            [
+                {
+                    "action": "DashboardMessageAction",
+                    "event": "removeMessages",
+                    "messages": message_ids,
+                    "moduleName": "Empty",
+                }
+            ]
+        )
+
 
 class PrivateMessageInbox(PrivateMessageCollection):
     """
@@ -447,3 +543,447 @@ class PrivateMessage:
                 }
             ]
         )
+
+    @staticmethod
+    @login_required
+    def save_draft(client: "Client", subject: str, body: str, recipient: Optional["User"] = None) -> None:
+        """
+        Save a private message draft
+
+        Parameters
+        ----------
+        client : Client
+            Client instance
+        subject : str
+            Draft subject
+        body : str
+            Draft body
+        recipient : User | None, default None
+            Intended recipient. May be omitted (the real form allows a
+            draft with no recipient selected yet)
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        client.amc_client.request(
+            [
+                {
+                    "action": "DashboardMessageAction",
+                    "event": "saveDraft",
+                    "source": body,
+                    "subject": subject,
+                    "moduleName": "Empty",
+                    **omit_falsy(to_user_id=recipient.id if recipient is not None else False),
+                }
+            ]
+        )
+
+    @staticmethod
+    @login_required
+    def check_can_send(client: "Client", user: "AbstractUser") -> None:
+        """
+        Check whether the account is allowed to send a private message to a user
+
+        Wraps `DashboardMessageAction/checkCan`. Does not return a boolean:
+        only the generic no_permission rejection path was confirmed during
+        the investigation, so other rejection reasons (e.g. the recipient's
+        receive-messages setting) may surface as a plain
+        WikidotStatusCodeException instead of ForbiddenException. Treat "no
+        exception raised" as "allowed".
+
+        Parameters
+        ----------
+        client : Client
+            Client instance
+        user : AbstractUser
+            Prospective recipient
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        ForbiddenException
+            If sending is not allowed
+        WikidotStatusCodeException
+            If sending is not allowed for a reason other than no_permission
+        """
+        client.amc_client.request(
+            [
+                {
+                    "action": "DashboardMessageAction",
+                    "event": "checkCan",
+                    "userId": user.id,
+                    "moduleName": "Empty",
+                }
+            ]
+        )
+
+    @staticmethod
+    @login_required
+    def preview(client: "Client", subject: str, body: str, recipient: Optional["User"] = None) -> str:
+        """
+        Render a preview of a private message without sending it
+
+        Wraps the `dashboard/messages/DMPreviewModule` module.
+
+        Parameters
+        ----------
+        client : Client
+            Client instance
+        subject : str
+            Message subject
+        body : str
+            Message body
+        recipient : User | None, default None
+            Intended recipient
+
+        Returns
+        -------
+        str
+            Rendered HTML preview
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        response = client.amc_client.request(
+            [
+                {
+                    "moduleName": "dashboard/messages/DMPreviewModule",
+                    "source": body,
+                    "subject": subject,
+                    **omit_falsy(to_user_id=recipient.id if recipient is not None else False),
+                }
+            ]
+        )[0]
+        return require_body(response, "dashboard/messages/DMPreviewModule")
+
+    @staticmethod
+    @login_required
+    def fetch_reply_form_html(client: "Client", reply_message_id: int) -> str:
+        """
+        Fetch the pre-filled "new message" form HTML for replying to a message
+
+        Wraps the `dashboard/messages/DMNewMessageModule` module with
+        `replyMessageId` set, which renders the form with the original
+        sender pre-filled as recipient (`toUserId`/`toUserName` in the
+        rendered HTML). Returns the raw body since the investigation
+        captured the request/response shape but not the specific markup
+        used to extract those pre-filled values.
+
+        Parameters
+        ----------
+        client : Client
+            Client instance
+        reply_message_id : int
+            ID of the message being replied to
+
+        Returns
+        -------
+        str
+            Raw rendered HTML body
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        response = client.amc_client.request(
+            [{"moduleName": "dashboard/messages/DMNewMessageModule", "replyMessageId": reply_message_id}]
+        )[0]
+        return require_body(response, "dashboard/messages/DMNewMessageModule")
+
+    def mark_as_read(self) -> None:
+        """
+        Mark this message as read
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        PrivateMessageCollection.mark_as_read(self.client, [self.id])
+
+    def mark_as_unread(self) -> None:
+        """
+        Mark this message as unread
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        PrivateMessageCollection.mark_as_unread(self.client, [self.id])
+
+    def delete(self) -> None:
+        """
+        Delete this message
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        PrivateMessageCollection.remove_messages(self.client, [self.id])
+
+
+# ----------------------------------------------------------------------
+# Site invitations / applications / contacts (/account/messages tabs)
+#
+# These represent the account's own outgoing/incoming relationships to
+# sites and other users, rendered by dashboard/messages/DM*Module. Row
+# markup for these list modules was not captured during the investigation
+# (unlike the inbox/sent tr.message structure above), so listing functions
+# return the raw rendered HTML rather than a parsed collection.
+# ----------------------------------------------------------------------
+
+
+@login_required
+def get_invitations_html(client: "Client", page: int = 1) -> str:
+    """
+    Fetch a page of the account's pending site invitations (raw HTML)
+
+    Wraps `dashboard/messages/DMInvitationsModule`.
+
+    Parameters
+    ----------
+    client : Client
+        Client instance
+    page : int, default 1
+        Page number
+
+    Returns
+    -------
+    str
+        Raw rendered HTML body
+
+    Raises
+    ------
+    LoginRequiredException
+        If not logged in
+    """
+    response = client.amc_client.request([{"moduleName": "dashboard/messages/DMInvitationsModule", "page": page}])[0]
+    return require_body(response, "dashboard/messages/DMInvitationsModule")
+
+
+@login_required
+def get_invitation_detail_html(client: "Client", item: int) -> str:
+    """
+    Fetch the detail HTML of a single site invitation
+
+    Wraps `dashboard/messages/DMViewInvitationModule`.
+
+    Parameters
+    ----------
+    client : Client
+        Client instance
+    item : int
+        Invitation ID
+
+    Returns
+    -------
+    str
+        Raw rendered HTML body
+
+    Raises
+    ------
+    LoginRequiredException
+        If not logged in
+    """
+    response = client.amc_client.request([{"moduleName": "dashboard/messages/DMViewInvitationModule", "item": item}])[0]
+    return require_body(response, "dashboard/messages/DMViewInvitationModule")
+
+
+@login_required
+def get_applications_html(client: "Client", page: int = 1) -> str:
+    """
+    Fetch a page of the account's pending site join applications (raw HTML)
+
+    Wraps `dashboard/messages/DMApplicationsModule`. This is the account's
+    own outgoing applications to other sites; do not confuse it with
+    SiteApplication (site_application.py), which is a site admin's view of
+    incoming applications to their own site.
+
+    Parameters
+    ----------
+    client : Client
+        Client instance
+    page : int, default 1
+        Page number
+
+    Returns
+    -------
+    str
+        Raw rendered HTML body
+
+    Raises
+    ------
+    LoginRequiredException
+        If not logged in
+    """
+    response = client.amc_client.request([{"moduleName": "dashboard/messages/DMApplicationsModule", "page": page}])[0]
+    return require_body(response, "dashboard/messages/DMApplicationsModule")
+
+
+@login_required
+def get_application_detail_html(client: "Client", item: int) -> str:
+    """
+    Fetch the detail HTML of a single site join application
+
+    Wraps `dashboard/messages/DMViewApplicationModule`.
+
+    Parameters
+    ----------
+    client : Client
+        Client instance
+    item : int
+        Application ID
+
+    Returns
+    -------
+    str
+        Raw rendered HTML body
+
+    Raises
+    ------
+    LoginRequiredException
+        If not logged in
+    """
+    response = client.amc_client.request([{"moduleName": "dashboard/messages/DMViewApplicationModule", "item": item}])[
+        0
+    ]
+    return require_body(response, "dashboard/messages/DMViewApplicationModule")
+
+
+@login_required
+def get_contacts_html(client: "Client") -> str:
+    """
+    Fetch the account's contact list (raw HTML)
+
+    Wraps `dashboard/messages/DMContactsModule`.
+
+    Parameters
+    ----------
+    client : Client
+        Client instance
+
+    Returns
+    -------
+    str
+        Raw rendered HTML body
+
+    Raises
+    ------
+    LoginRequiredException
+        If not logged in
+    """
+    response = client.amc_client.request([{"moduleName": "dashboard/messages/DMContactsModule"}])[0]
+    return require_body(response, "dashboard/messages/DMContactsModule")
+
+
+@login_required
+def get_contacts_list_html(client: "Client") -> str:
+    """
+    Fetch the contact picker used when composing a new message (raw HTML)
+
+    Wraps `dashboard/messages/DMContactsListModule`.
+
+    Parameters
+    ----------
+    client : Client
+        Client instance
+
+    Returns
+    -------
+    str
+        Raw rendered HTML body
+
+    Raises
+    ------
+    LoginRequiredException
+        If not logged in
+    """
+    response = client.amc_client.request([{"moduleName": "dashboard/messages/DMContactsListModule"}])[0]
+    return require_body(response, "dashboard/messages/DMContactsListModule")
+
+
+@login_required
+def add_contact(client: "Client", user: "AbstractUser") -> None:
+    """
+    Add a user to the account's contact list
+
+    Wraps `ContactsAction/addContact`.
+
+    Parameters
+    ----------
+    client : Client
+        Client instance
+    user : AbstractUser
+        User to add
+
+    Raises
+    ------
+    LoginRequiredException
+        If not logged in
+    """
+    client.amc_client.request(
+        [{"action": "ContactsAction", "event": "addContact", "userId": user.id, "moduleName": "Empty"}]
+    )
+
+
+@login_required
+def remove_contact(client: "Client", user: "AbstractUser") -> None:
+    """
+    Remove a user from the account's contact list
+
+    Wraps `ContactsAction/removeContact`.
+
+    Parameters
+    ----------
+    client : Client
+        Client instance
+    user : AbstractUser
+        User to remove
+
+    Raises
+    ------
+    LoginRequiredException
+        If not logged in
+    """
+    client.amc_client.request(
+        [{"action": "ContactsAction", "event": "removeContact", "userId": user.id, "moduleName": "Empty"}]
+    )
+
+
+@login_required
+def add_contact_via_profile(client: "Client", user: "AbstractUser") -> str:
+    """
+    Add a user to the account's contact list from their profile page
+
+    Wraps `userinfo/UserAddToContactsModule`, a second (module-render-as-
+    action) path to add a contact distinct from ContactsAction/addContact,
+    used from a user's profile ("user:info") page rather than the messages
+    dashboard.
+
+    Parameters
+    ----------
+    client : Client
+        Client instance
+    user : AbstractUser
+        User to add
+
+    Returns
+    -------
+    str
+        Raw rendered HTML body
+
+    Raises
+    ------
+    LoginRequiredException
+        If not logged in
+    """
+    response = client.amc_client.request([{"moduleName": "userinfo/UserAddToContactsModule", "userId": user.id}])[0]
+    return require_body(response, "userinfo/UserAddToContactsModule")

--- a/src/wikidot/module/private_message.py
+++ b/src/wikidot/module/private_message.py
@@ -797,35 +797,134 @@ def get_invitation_detail_html(client: "Client", item: int) -> str:
     return require_body(response, "dashboard/messages/DMViewInvitationModule")
 
 
-@login_required
-def get_applications_html(client: "Client", page: int = 1) -> str:
+@dataclass
+class SiteJoinApplication:
     """
-    Fetch a page of the account's pending site join applications (raw HTML)
+    A row of the account's own outgoing site-join applications
+    (dashboard/messages/DMApplicationsModule)
 
-    Wraps `dashboard/messages/DMApplicationsModule`. This is the account's
-    own outgoing applications to other sites; do not confuse it with
-    SiteApplication (site_application.py), which is a site admin's view of
-    incoming applications to their own site.
+    Distinct from SiteApplication (site_application.py), which is a site
+    admin's view of incoming applications to their own site.
+
+    Row markup was measured 2026-07-29 (see `70_account.md` "一覧モジュールの
+    行マークアップ"): each row is a `tr` with `span.from` / `span.subject` /
+    `span.preview` / `span.date > span.odate`. The measurement did not find a
+    site-id/application-id-bearing attribute on the row, so this object
+    cannot drive `DMViewApplicationModule` or
+    `DashboardSitesAction/removeApplication` directly; use
+    `ClientSiteAccessor.remove_application(site_id)` with a site_id obtained
+    elsewhere if you need to withdraw an application.
+
+    Attributes
+    ----------
+    client : Client
+        Client instance
+    from_site : str
+        Text of span.from (the site the application was submitted to)
+    subject : str
+        Text of span.subject
+    preview : str
+        Text of span.preview
+    submitted_at : datetime
+        Submission date and time (span.date > span.odate)
+    """
+
+    client: "Client"
+    from_site: str
+    subject: str
+    preview: str
+    submitted_at: datetime
+
+    def __str__(self) -> str:
+        """
+        String representation of the object
+
+        Returns
+        -------
+        str
+            String representation of the application
+        """
+        return f"SiteJoinApplication(from_site={self.from_site}, subject={self.subject})"
+
+    @staticmethod
+    def _parse_row(client: "Client", row: Tag) -> "SiteJoinApplication | None":
+        """
+        Internal method to parse a single DMApplicationsModule row
+
+        Parameters
+        ----------
+        client : Client
+            Client instance
+        row : bs4.Tag
+            `tr` element to parse
+
+        Returns
+        -------
+        SiteJoinApplication | None
+            Parsed row, or None if a required element is missing
+        """
+        from_elem = row.select_one("span.from")
+        if from_elem is None:
+            return None
+
+        subject_elem = row.select_one("span.subject")
+        preview_elem = row.select_one("span.preview")
+        odate_elem = row.select_one("span.date span.odate")
+
+        return SiteJoinApplication(
+            client=client,
+            from_site=from_elem.get_text().strip(),
+            subject=subject_elem.get_text().strip() if subject_elem else "",
+            preview=preview_elem.get_text().strip() if preview_elem else "",
+            submitted_at=(odate_parser(odate_elem) if odate_elem else datetime.fromtimestamp(0)),
+        )
+
+
+@login_required
+def get_applications(client: "Client") -> list["SiteJoinApplication"]:
+    """
+    Get all of the account's pending outgoing site join applications
+
+    Wraps `dashboard/messages/DMApplicationsModule`, fetching all pages.
 
     Parameters
     ----------
     client : Client
         Client instance
-    page : int, default 1
-        Page number
 
     Returns
     -------
-    str
-        Raw rendered HTML body
+    list[SiteJoinApplication]
+        All pending applications
 
     Raises
     ------
     LoginRequiredException
         If not logged in
     """
-    response = client.amc_client.request([{"moduleName": "dashboard/messages/DMApplicationsModule", "page": page}])[0]
-    return require_body(response, "dashboard/messages/DMApplicationsModule")
+    module_name = "dashboard/messages/DMApplicationsModule"
+    first_response = client.amc_client.request([{"moduleName": module_name}])[0]
+    first_html = BeautifulSoup(require_body(first_response, module_name), "lxml")
+
+    pager: ResultSet[Tag] = first_html.select("div.pager span.target")
+    max_page: int = int(pager[-2].get_text()) if len(pager) > 2 else 1
+
+    applications: list[SiteJoinApplication] = []
+    for row in first_html.select("tr"):
+        application = SiteJoinApplication._parse_row(client, row)
+        if application is not None:
+            applications.append(application)
+
+    if max_page > 1:
+        bodies = [{"page": page, "moduleName": module_name} for page in range(2, max_page + 1)]
+        for response in client.amc_client.request(bodies):
+            html = BeautifulSoup(require_body(response, module_name), "lxml")
+            for row in html.select("tr"):
+                application = SiteJoinApplication._parse_row(client, row)
+                if application is not None:
+                    applications.append(application)
+
+    return applications
 
 
 @login_required
@@ -858,12 +957,60 @@ def get_application_detail_html(client: "Client", item: int) -> str:
     return require_body(response, "dashboard/messages/DMViewApplicationModule")
 
 
-@login_required
-def get_contacts_html(client: "Client") -> str:
+@dataclass
+class Contact:
     """
-    Fetch the account's contact list (raw HTML)
+    A row of the account's contact list (dashboard/messages/DMContactsModule)
 
-    Wraps `dashboard/messages/DMContactsModule`.
+    Row markup was measured 2026-07-29 (see `70_account.md` "一覧モジュールの
+    行マークアップ"): each row is a `tr` with
+    `td > span.printuser.avatarhover > a > img.small` and a delete button
+    (`td > a.awesome.red.small`). The user is parsed via the existing
+    printuser parser rather than the delete button, since removal only needs
+    the user ID (ContactsAction/removeContact), which the printuser element
+    already carries.
+
+    Attributes
+    ----------
+    client : Client
+        Client instance
+    user : AbstractUser
+        The contact
+    """
+
+    client: "Client"
+    user: "AbstractUser"
+
+    def __str__(self) -> str:
+        """
+        String representation of the object
+
+        Returns
+        -------
+        str
+            String representation of the contact
+        """
+        return f"Contact(user={self.user})"
+
+    def remove(self) -> None:
+        """
+        Remove this user from the account's contact list
+
+        Raises
+        ------
+        LoginRequiredException
+            If not logged in
+        """
+        remove_contact(self.client, self.user)
+
+
+@login_required
+def get_contacts(client: "Client") -> list["Contact"]:
+    """
+    Get the account's contact list
+
+    Wraps `dashboard/messages/DMContactsModule` (single request; this module
+    is not paginated).
 
     Parameters
     ----------
@@ -872,8 +1019,8 @@ def get_contacts_html(client: "Client") -> str:
 
     Returns
     -------
-    str
-        Raw rendered HTML body
+    list[Contact]
+        All contacts
 
     Raises
     ------
@@ -881,7 +1028,16 @@ def get_contacts_html(client: "Client") -> str:
         If not logged in
     """
     response = client.amc_client.request([{"moduleName": "dashboard/messages/DMContactsModule"}])[0]
-    return require_body(response, "dashboard/messages/DMContactsModule")
+    html = BeautifulSoup(require_body(response, "dashboard/messages/DMContactsModule"), "lxml")
+
+    contacts: list[Contact] = []
+    for row in html.select("tr"):
+        printuser_elem = row.select_one("span.printuser")
+        if printuser_elem is None:
+            continue
+        contacts.append(Contact(client=client, user=user_parser(client, printuser_elem)))
+
+    return contacts
 
 
 @login_required

--- a/tests/unit/test_account.py
+++ b/tests/unit/test_account.py
@@ -230,50 +230,153 @@ class TestAccountProfile:
         assert body["some_field"] == "value"
 
 
+#: userinfo/UserChangesListModule row fixture, based on the 2026-07-29 markup
+#: measurement recorded in 70_account.md ("一覧モジュールの行マークアップ")
+USER_CHANGES_LIST_BODY = """
+<div class="changes-list-item">
+  <table><tbody><tr>
+    <td class="site"><a href="http://foo.wikidot.com">Foo Site</a></td>
+    <td class="title"><a href="/component:scp-173">SCP-173</a></td>
+    <td class="flags"><span class="spantip">S</span></td>
+    <td class="mod-date"><span class="odate time_1700000000">01 Jan 2024</span></td>
+    <td class="revision-no">Rev. 5</td>
+  </tr></tbody></table>
+</div>
+"""
+
+#: userinfo/UserRecentPostsListModule row fixture, based on the 2026-07-29
+#: markup measurement
+USER_RECENT_POSTS_LIST_BODY = """
+<div class="post">
+  <div class="long">
+    <div class="head">
+      <div class="title"><a href="http://foo.wikidot.com/forum/t-123#post-456">Re: Something</a></div>
+    </div>
+  </div>
+  <div class="info">
+    <span class="printuser">
+        <a href="http://www.wikidot.com/user:info/me" onclick="WIKIDOT.page.listeners.userInfo(99999); return false;">me</a>
+    </span>
+    <span class="odate time_1700000000">01 Jan 2024</span>
+  </div>
+  <div class="content">Post content here</div>
+</div>
+"""
+
+
+def _mock_responses(*bodies: dict):
+    """複数回のamc_client.request呼び出しに対して、順番にレスポンスを返すside_effectを作る"""
+    responses = []
+    for body in bodies:
+        mock_response = MagicMock()
+        mock_response.json.return_value = body
+        responses.append([mock_response])
+    return responses
+
+
 class TestAccountRecentActivity:
     """AccountRecentActivityクラスのテスト"""
 
-    def test_get_changes_html_uses_own_user_id(self, mock_client):
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"body": "<div>changes</div>"}
-        mock_client.amc_client.request.return_value = [mock_response]
+    def test_get_changes_fetches_hidden_user_id_first(self, mock_client):
+        """userIdはuserinfo/UserChangesModuleの#changes-user-id hiddenから取る"""
+        mock_client.amc_client.request.side_effect = _mock_responses(
+            {"body": '<input type="hidden" id="changes-user-id" value="42">'},
+            {"body": USER_CHANGES_LIST_BODY},
+        )
 
         recent = AccountRecentActivity(mock_client)
-        html = recent.get_changes_html()
+        result = recent.get_changes()
 
-        body = _last_body(mock_client)
-        assert body["moduleName"] == "userinfo/UserChangesListModule"
-        assert body["userId"] == 99999
-        assert html == "<div>changes</div>"
+        first_call_body = mock_client.amc_client.request.call_args_list[0][0][0][0]
+        second_call_body = mock_client.amc_client.request.call_args_list[1][0][0][0]
+        assert first_call_body["moduleName"] == "userinfo/UserChangesModule"
+        assert second_call_body["moduleName"] == "userinfo/UserChangesListModule"
+        assert second_call_body["userId"] == 42
+        assert len(result) == 1
 
-    def test_get_changes_html_rejects_tags_option(self, mock_client):
+    def test_get_changes_parses_row_fields(self, mock_client):
+        mock_client.amc_client.request.side_effect = _mock_responses(
+            {"body": '<input type="hidden" id="changes-user-id" value="42">'},
+            {"body": USER_CHANGES_LIST_BODY},
+        )
+
+        recent = AccountRecentActivity(mock_client)
+        change = recent.get_changes()[0]
+
+        assert change.site_title == "Foo Site"
+        assert change.site_url == "http://foo.wikidot.com"
+        assert change.page_fullname == "component:scp-173"
+        assert change.page_title == "SCP-173"
+        assert change.revision_no == 5
+        assert change.flags == ["S"]
+
+    def test_get_changes_user_id_is_cached(self, mock_client):
+        """2回目以降の呼び出しでは#changes-user-idを再取得しない"""
+        mock_client.amc_client.request.side_effect = _mock_responses(
+            {"body": '<input type="hidden" id="changes-user-id" value="42">'},
+            {"body": USER_CHANGES_LIST_BODY},
+            {"body": USER_CHANGES_LIST_BODY},
+        )
+
+        recent = AccountRecentActivity(mock_client)
+        recent.get_changes()
+        recent.get_changes()
+
+        # shell moduleへのリクエストは1回だけ
+        shell_calls = [
+            call
+            for call in mock_client.amc_client.request.call_args_list
+            if call[0][0][0]["moduleName"] == "userinfo/UserChangesModule"
+        ]
+        assert len(shell_calls) == 1
+
+    def test_get_changes_rejects_tags_option(self, mock_client):
         """UserChangesListModuleのoptionsに"tags"は存在しない"""
         recent = AccountRecentActivity(mock_client)
         with pytest.raises(ValueError, match="tags"):
-            recent.get_changes_html(options={"tags": True})
+            recent.get_changes(options={"tags": True})
 
-    def test_get_changes_html_accepts_valid_options(self, mock_client):
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"body": ""}
-        mock_client.amc_client.request.return_value = [mock_response]
-
-        recent = AccountRecentActivity(mock_client)
-        recent.get_changes_html(options={"source": True, "title": True})
-
-        body = _last_body(mock_client)
-        assert "options" in body
-
-    def test_get_posts_html_uses_own_user_id(self, mock_client):
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"body": "<div>posts</div>"}
-        mock_client.amc_client.request.return_value = [mock_response]
+    def test_get_changes_accepts_valid_options(self, mock_client):
+        mock_client.amc_client.request.side_effect = _mock_responses(
+            {"body": '<input type="hidden" id="changes-user-id" value="42">'},
+            {"body": ""},
+        )
 
         recent = AccountRecentActivity(mock_client)
-        recent.get_posts_html()
+        recent.get_changes(options={"source": True, "title": True})
 
-        body = _last_body(mock_client)
-        assert body["moduleName"] == "userinfo/UserRecentPostsListModule"
-        assert body["userId"] == 99999
+        second_call_body = mock_client.amc_client.request.call_args_list[1][0][0][0]
+        assert "options" in second_call_body
+
+    def test_get_posts_fetches_hidden_user_id_first(self, mock_client):
+        """userIdはuserinfo/UserRecentPostsModuleの#recent-posts-user-id hiddenから取る"""
+        mock_client.amc_client.request.side_effect = _mock_responses(
+            {"body": '<input type="hidden" id="recent-posts-user-id" value="42">'},
+            {"body": USER_RECENT_POSTS_LIST_BODY},
+        )
+
+        recent = AccountRecentActivity(mock_client)
+        result = recent.get_posts()
+
+        first_call_body = mock_client.amc_client.request.call_args_list[0][0][0][0]
+        second_call_body = mock_client.amc_client.request.call_args_list[1][0][0][0]
+        assert first_call_body["moduleName"] == "userinfo/UserRecentPostsModule"
+        assert second_call_body["moduleName"] == "userinfo/UserRecentPostsListModule"
+        assert second_call_body["userId"] == 42
+        assert len(result) == 1
+
+    def test_get_posts_parses_row_fields(self, mock_client):
+        mock_client.amc_client.request.side_effect = _mock_responses(
+            {"body": '<input type="hidden" id="recent-posts-user-id" value="42">'},
+            {"body": USER_RECENT_POSTS_LIST_BODY},
+        )
+
+        recent = AccountRecentActivity(mock_client)
+        post = recent.get_posts()[0]
+
+        assert post.title == "Re: Something"
+        assert post.url == "http://foo.wikidot.com/forum/t-123#post-456"
+        assert post.content == "Post content here"
 
 
 class TestClientAccountAccessor:

--- a/tests/unit/test_account.py
+++ b/tests/unit/test_account.py
@@ -1,0 +1,287 @@
+"""
+アカウント/Dashboardモジュール（module.account）のユニットテスト
+
+AccountSettings, AccountProfile, AccountRecentActivity, ClientAccountAccessorをテストする。
+"""
+
+from unittest.mock import MagicMock, create_autospec
+
+import pytest
+
+from wikidot.common.exceptions import LoginRequiredException
+from wikidot.module.account import (
+    AccountProfile,
+    AccountRecentActivity,
+    AccountSettings,
+    ClientAccountAccessor,
+)
+from wikidot.module.client import Client
+
+
+@pytest.fixture
+def mock_client():
+    """モッククライアント（Clientのspec付き）"""
+    client = create_autospec(Client, instance=True)
+    client.is_logged_in = True
+    client.amc_client = MagicMock()
+    client.me = MagicMock(id=99999)
+    return client
+
+
+def _last_body(mock_client):
+    """直前のamc_client.request呼び出しの最初のリクエストボディを取得"""
+    return mock_client.amc_client.request.call_args[0][0][0]
+
+
+class TestAccountSettings:
+    """AccountSettingsクラスのテスト"""
+
+    def test_set_receive_messages(self, mock_client):
+        settings = AccountSettings(mock_client)
+        settings.set_receive_messages("mf")
+
+        body = _last_body(mock_client)
+        assert body["action"] == "DashboardSettingsAction"
+        assert body["event"] == "saveReceiveMessages"
+        assert body["from"] == "mf"
+
+    def test_block_user(self, mock_client):
+        settings = AccountSettings(mock_client)
+        user = MagicMock(id=123)
+        settings.block_user(user)
+
+        body = _last_body(mock_client)
+        assert body["event"] == "blockUser"
+        assert body["userId"] == 123
+
+    def test_unblock_user(self, mock_client):
+        settings = AccountSettings(mock_client)
+        user = MagicMock(id=123)
+        settings.unblock_user(user)
+
+        body = _last_body(mock_client)
+        assert body["event"] == "deleteBlock"
+        assert body["userId"] == 123
+
+    def test_change_password(self, mock_client):
+        settings = AccountSettings(mock_client)
+        settings.change_password("old-pw", "new-pw")
+
+        body = _last_body(mock_client)
+        assert body["event"] == "changePassword"
+        assert body["old_password"] == "old-pw"
+        assert body["new_password1"] == "new-pw"
+        assert body["new_password2"] == "new-pw"
+
+    def test_set_receive_digest_true_sends_yes(self, mock_client):
+        """receive=Trueは"yes"文字列で送られる"""
+        settings = AccountSettings(mock_client)
+        settings.set_receive_digest(True)
+
+        body = _last_body(mock_client)
+        assert body["receive"] == "yes"
+
+    def test_set_receive_digest_false_omits_key(self, mock_client):
+        """receive=Falseはキーごと省略される"""
+        settings = AccountSettings(mock_client)
+        settings.set_receive_digest(False)
+
+        body = _last_body(mock_client)
+        assert "receive" not in body
+
+    def test_set_receive_invitations_true_sends_true_string(self, mock_client):
+        """saveReceiveInvitationsはreceive="true"（flag形式、"yes"ではない）"""
+        settings = AccountSettings(mock_client)
+        settings.set_receive_invitations(True)
+
+        body = _last_body(mock_client)
+        assert body["receive"] == "true"
+
+    def test_set_toolbars_partial(self, mock_client):
+        """未指定側のキーは省略される（チェックボックス省略規則）"""
+        settings = AccountSettings(mock_client)
+        settings.set_toolbars(top=True, bottom=False)
+
+        body = _last_body(mock_client)
+        assert body["toolbarTop"] == "on"
+        assert "toolbarBottom" not in body
+
+    def test_generate_api_key_read_only(self, mock_client):
+        """read_only=Trueはtype="r"で送られる"""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"newKey": "abc123"}
+        mock_client.amc_client.request.return_value = [mock_response]
+
+        settings = AccountSettings(mock_client)
+        result = settings.generate_api_key(read_only=True)
+
+        body = _last_body(mock_client)
+        assert body["type"] == "r"
+        assert result == "abc123"
+
+    def test_generate_api_key_read_write(self, mock_client):
+        """read_only=Falseはtype="r"以外（"w"）で送られる"""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"newKey": "xyz789"}
+        mock_client.amc_client.request.return_value = [mock_response]
+
+        settings = AccountSettings(mock_client)
+        settings.generate_api_key(read_only=False)
+
+        body = _last_body(mock_client)
+        assert body["type"] != "r"
+
+    def test_toolbars_pref_not_confused_with_managesite(self, mock_client):
+        """saveToolbarsPrefはDashboardSettingsAction向け（ManageSiteActionではない）"""
+        settings = AccountSettings(mock_client)
+        settings.set_toolbars(top=True, bottom=True)
+
+        body = _last_body(mock_client)
+        assert body["action"] == "DashboardSettingsAction"
+        assert body["event"] == "saveToolbarsPref"
+
+    def test_requires_login(self, mock_client):
+        mock_client.is_logged_in = False
+        mock_client.login_check.side_effect = LoginRequiredException("Not logged in")
+
+        settings = AccountSettings(mock_client)
+        with pytest.raises(LoginRequiredException):
+            settings.set_language("ja")
+
+    def test_get_messages_html_uses_ds_prefixed_module(self, mock_client):
+        """再レンダリングに使うのはdashboard/settings/DSMessagesModule"""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"body": "<div>settings</div>"}
+        mock_client.amc_client.request.return_value = [mock_response]
+
+        settings = AccountSettings(mock_client)
+        html = settings.get_messages_html()
+
+        body = _last_body(mock_client)
+        assert body["moduleName"] == "dashboard/settings/DSMessagesModule"
+        assert html == "<div>settings</div>"
+
+
+class TestAccountProfile:
+    """AccountProfileクラスのテスト"""
+
+    def test_change_screen_name(self, mock_client):
+        profile = AccountProfile(mock_client)
+        profile.change_screen_name("new-name")
+
+        body = _last_body(mock_client)
+        assert body["action"] == "DashboardProfileAction"
+        assert body["event"] == "changeScreenName"
+        assert body["screenName"] == "new-name"
+
+    def test_save_about_omits_unset_gender(self, mock_client):
+        profile = AccountProfile(mock_client)
+        profile.save_about(real_name="Test User")
+
+        body = _last_body(mock_client)
+        assert body["real_name"] == "Test User"
+        assert "gender" not in body
+
+    def test_save_forum_signature(self, mock_client):
+        profile = AccountProfile(mock_client)
+        profile.save_forum_signature("my signature")
+
+        body = _last_body(mock_client)
+        assert body["event"] == "saveForumSignature"
+        assert body["source"] == "my signature"
+
+    def test_preview_forum_signature(self, mock_client):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"body": "<p>preview</p>"}
+        mock_client.amc_client.request.return_value = [mock_response]
+
+        profile = AccountProfile(mock_client)
+        result = profile.preview_forum_signature("sig")
+
+        body = _last_body(mock_client)
+        assert body["moduleName"] == "dashboard/settings/DSForumSignaturePreviewModule"
+        assert result == "<p>preview</p>"
+
+    def test_delete_avatar(self, mock_client):
+        profile = AccountProfile(mock_client)
+        profile.delete_avatar()
+
+        body = _last_body(mock_client)
+        assert body["event"] == "deleteAvatar"
+
+    def test_upload_avatar_from_uri(self, mock_client):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "ok", "im48": "u48", "im16": "u16"}
+        mock_client.amc_client.request.return_value = [mock_response]
+
+        profile = AccountProfile(mock_client)
+        result = profile.upload_avatar_from_uri("http://example.com/a.png")
+
+        body = _last_body(mock_client)
+        assert body["uri"] == "http://example.com/a.png"
+        assert result["im48"] == "u48"
+
+    def test_save_profile_visibility_passes_raw_fields(self, mock_client):
+        """未実測フォームは生dictをそのまま送る"""
+        profile = AccountProfile(mock_client)
+        profile.save_profile_visibility({"some_field": "value"})
+
+        body = _last_body(mock_client)
+        assert body["some_field"] == "value"
+
+
+class TestAccountRecentActivity:
+    """AccountRecentActivityクラスのテスト"""
+
+    def test_get_changes_html_uses_own_user_id(self, mock_client):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"body": "<div>changes</div>"}
+        mock_client.amc_client.request.return_value = [mock_response]
+
+        recent = AccountRecentActivity(mock_client)
+        html = recent.get_changes_html()
+
+        body = _last_body(mock_client)
+        assert body["moduleName"] == "userinfo/UserChangesListModule"
+        assert body["userId"] == 99999
+        assert html == "<div>changes</div>"
+
+    def test_get_changes_html_rejects_tags_option(self, mock_client):
+        """UserChangesListModuleのoptionsに"tags"は存在しない"""
+        recent = AccountRecentActivity(mock_client)
+        with pytest.raises(ValueError, match="tags"):
+            recent.get_changes_html(options={"tags": True})
+
+    def test_get_changes_html_accepts_valid_options(self, mock_client):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"body": ""}
+        mock_client.amc_client.request.return_value = [mock_response]
+
+        recent = AccountRecentActivity(mock_client)
+        recent.get_changes_html(options={"source": True, "title": True})
+
+        body = _last_body(mock_client)
+        assert "options" in body
+
+    def test_get_posts_html_uses_own_user_id(self, mock_client):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"body": "<div>posts</div>"}
+        mock_client.amc_client.request.return_value = [mock_response]
+
+        recent = AccountRecentActivity(mock_client)
+        recent.get_posts_html()
+
+        body = _last_body(mock_client)
+        assert body["moduleName"] == "userinfo/UserRecentPostsListModule"
+        assert body["userId"] == 99999
+
+
+class TestClientAccountAccessor:
+    """ClientAccountAccessorクラスのテスト"""
+
+    def test_sub_accessors_initialized(self, mock_client):
+        accessor = ClientAccountAccessor(mock_client)
+
+        assert isinstance(accessor.settings, AccountSettings)
+        assert isinstance(accessor.profile, AccountProfile)
+        assert isinstance(accessor.recent, AccountRecentActivity)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -11,6 +11,7 @@ import pytest
 from wikidot.common.exceptions import LoginRequiredException
 from wikidot.module.client import (
     Client,
+    ClientAccountAccessor,
     ClientPrivateMessageAccessor,
     ClientSiteAccessor,
     ClientUserAccessor,
@@ -114,6 +115,7 @@ class TestClient:
             assert isinstance(client.user, ClientUserAccessor)
             assert isinstance(client.private_message, ClientPrivateMessageAccessor)
             assert isinstance(client.site, ClientSiteAccessor)
+            assert isinstance(client.account, ClientAccountAccessor)
 
 
 class TestClientUserAccessor:
@@ -239,3 +241,175 @@ class TestClientSiteAccessor:
 
                 mock_from_unix_name.assert_called_once_with(client, "scp-wiki")
                 assert result == mock_site
+
+    def test_create_site(self):
+        """サイト作成"""
+        with patch("wikidot.module.client.AjaxModuleConnectorClient"):
+            client = Client()
+            with patch("wikidot.module.client.DashboardSites.create") as mock_create:
+                mock_create.return_value = "new-site"
+
+                result = client.site.create(name="New Site", unixname="new-site")
+
+                mock_create.assert_called_once_with(
+                    client,
+                    name="New Site",
+                    unixname="new-site",
+                    subtitle="",
+                    language="en",
+                    template="standard-template",
+                    privacy="open",
+                    tos=True,
+                )
+                assert result == "new-site"
+
+    def test_my_sites_html(self):
+        """サイト一覧の取得"""
+        with patch("wikidot.module.client.AjaxModuleConnectorClient"):
+            client = Client()
+            with patch("wikidot.module.client.DashboardSites.list_html") as mock_list_html:
+                mock_list_html.return_value = "<div>sites</div>"
+
+                result = client.site.my_sites_html
+
+                mock_list_html.assert_called_once_with(client)
+                assert result == "<div>sites</div>"
+
+    def test_accept_invitation(self):
+        with patch("wikidot.module.client.AjaxModuleConnectorClient"):
+            client = Client()
+            with patch("wikidot.module.client.DashboardSites.accept_invitation") as mock_accept:
+                client.site.accept_invitation(42)
+                mock_accept.assert_called_once_with(client, 42)
+
+    def test_throw_away_invitation(self):
+        with patch("wikidot.module.client.AjaxModuleConnectorClient"):
+            client = Client()
+            with patch("wikidot.module.client.DashboardSites.throw_away_invitation") as mock_throw:
+                client.site.throw_away_invitation(42)
+                mock_throw.assert_called_once_with(client, 42)
+
+    def test_remove_application(self):
+        with patch("wikidot.module.client.AjaxModuleConnectorClient"):
+            client = Client()
+            with patch("wikidot.module.client.DashboardSites.remove_application") as mock_remove:
+                client.site.remove_application(7)
+                mock_remove.assert_called_once_with(client, 7)
+
+    def test_restore_site(self):
+        with patch("wikidot.module.client.AjaxModuleConnectorClient"):
+            client = Client()
+            with patch("wikidot.module.client.DashboardSites.restore_site") as mock_restore:
+                client.site.restore_site(10, "my-site")
+                mock_restore.assert_called_once_with(client, 10, "my-site")
+
+    def test_resign_as_admin(self):
+        with patch("wikidot.module.client.AjaxModuleConnectorClient"):
+            client = Client()
+            with patch("wikidot.module.client.DashboardSites.resign_as_admin") as mock_resign:
+                client.site.resign_as_admin(10)
+                mock_resign.assert_called_once_with(client, 10)
+
+    def test_resign_as_moderator(self):
+        with patch("wikidot.module.client.AjaxModuleConnectorClient"):
+            client = Client()
+            with patch("wikidot.module.client.DashboardSites.resign_as_moderator") as mock_resign:
+                client.site.resign_as_moderator(10)
+                mock_resign.assert_called_once_with(client, 10)
+
+    def test_sign_off_as_member(self):
+        with patch("wikidot.module.client.AjaxModuleConnectorClient"):
+            client = Client()
+            with patch("wikidot.module.client.DashboardSites.sign_off_as_member") as mock_sign_off:
+                client.site.sign_off_as_member(10)
+                mock_sign_off.assert_called_once_with(client, 10)
+
+    def test_set_site_storage_limit(self):
+        with patch("wikidot.module.client.AjaxModuleConnectorClient"):
+            client = Client()
+            with patch("wikidot.module.client.DashboardSites.set_storage_limit") as mock_set_limit:
+                client.site.set_site_storage_limit(10, {"limit": "500"})
+                mock_set_limit.assert_called_once_with(client, 10, {"limit": "500"})
+
+
+class TestClientPrivateMessageAccessorExtensions:
+    """ClientPrivateMessageAccessorの拡張メソッド（P5）のテスト"""
+
+    def test_mark_as_read(self):
+        with patch("wikidot.module.client.AjaxModuleConnectorClient"):
+            client = Client()
+            with patch("wikidot.module.client.PrivateMessageCollection.mark_as_read") as mock_mark:
+                client.private_message.mark_as_read([1, 2])
+                mock_mark.assert_called_once_with(client, [1, 2])
+
+    def test_mark_as_unread(self):
+        with patch("wikidot.module.client.AjaxModuleConnectorClient"):
+            client = Client()
+            with patch("wikidot.module.client.PrivateMessageCollection.mark_as_unread") as mock_mark:
+                client.private_message.mark_as_unread([1, 2])
+                mock_mark.assert_called_once_with(client, [1, 2])
+
+    def test_remove(self):
+        with patch("wikidot.module.client.AjaxModuleConnectorClient"):
+            client = Client()
+            with patch("wikidot.module.client.PrivateMessageCollection.remove_messages") as mock_remove:
+                client.private_message.remove([1, 2])
+                mock_remove.assert_called_once_with(client, [1, 2])
+
+    def test_save_draft(self):
+        with patch("wikidot.module.client.AjaxModuleConnectorClient"):
+            client = Client()
+            with patch("wikidot.module.client.PrivateMessage.save_draft") as mock_save:
+                client.private_message.save_draft("subj", "body")
+                mock_save.assert_called_once_with(client, "subj", "body", None)
+
+    def test_check_can_send(self):
+        with patch("wikidot.module.client.AjaxModuleConnectorClient"):
+            client = Client()
+            with patch("wikidot.module.client.PrivateMessage.check_can_send") as mock_check:
+                mock_user = MagicMock()
+                client.private_message.check_can_send(mock_user)
+                mock_check.assert_called_once_with(client, mock_user)
+
+    def test_preview(self):
+        with patch("wikidot.module.client.AjaxModuleConnectorClient"):
+            client = Client()
+            with patch("wikidot.module.client.PrivateMessage.preview") as mock_preview:
+                mock_preview.return_value = "<p>html</p>"
+                result = client.private_message.preview("subj", "body")
+                mock_preview.assert_called_once_with(client, "subj", "body", None)
+                assert result == "<p>html</p>"
+
+    def test_fetch_reply_form_html(self):
+        with patch("wikidot.module.client.AjaxModuleConnectorClient"):
+            client = Client()
+            with patch("wikidot.module.client.PrivateMessage.fetch_reply_form_html") as mock_fetch:
+                mock_fetch.return_value = "<form></form>"
+                result = client.private_message.fetch_reply_form_html(9)
+                mock_fetch.assert_called_once_with(client, 9)
+                assert result == "<form></form>"
+
+    def test_add_contact(self):
+        with patch("wikidot.module.client.AjaxModuleConnectorClient"):
+            client = Client()
+            with patch("wikidot.module.client.pm.add_contact") as mock_add:
+                mock_user = MagicMock()
+                client.private_message.add_contact(mock_user)
+                mock_add.assert_called_once_with(client, mock_user)
+
+    def test_remove_contact(self):
+        with patch("wikidot.module.client.AjaxModuleConnectorClient"):
+            client = Client()
+            with patch("wikidot.module.client.pm.remove_contact") as mock_remove:
+                mock_user = MagicMock()
+                client.private_message.remove_contact(mock_user)
+                mock_remove.assert_called_once_with(client, mock_user)
+
+    def test_get_invitations_html(self):
+        with patch("wikidot.module.client.AjaxModuleConnectorClient"):
+            client = Client()
+            with patch("wikidot.module.client.pm.get_invitations_html") as mock_get:
+                mock_get.return_value = "<div></div>"
+                result = client.private_message.get_invitations_html()
+                mock_get.assert_called_once_with(client, 1)
+                assert result == "<div></div>"

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -263,17 +263,18 @@ class TestClientSiteAccessor:
                 )
                 assert result == "new-site"
 
-    def test_my_sites_html(self):
+    def test_my_sites(self):
         """サイト一覧の取得"""
         with patch("wikidot.module.client.AjaxModuleConnectorClient"):
             client = Client()
-            with patch("wikidot.module.client.DashboardSites.list_html") as mock_list_html:
-                mock_list_html.return_value = "<div>sites</div>"
+            with patch("wikidot.module.client.DashboardSites.list_sites") as mock_list_sites:
+                mock_sites = [MagicMock()]
+                mock_list_sites.return_value = mock_sites
 
-                result = client.site.my_sites_html
+                result = client.site.my_sites
 
-                mock_list_html.assert_called_once_with(client)
-                assert result == "<div>sites</div>"
+                mock_list_sites.assert_called_once_with(client)
+                assert result == mock_sites
 
     def test_accept_invitation(self):
         with patch("wikidot.module.client.AjaxModuleConnectorClient"):
@@ -413,3 +414,23 @@ class TestClientPrivateMessageAccessorExtensions:
                 result = client.private_message.get_invitations_html()
                 mock_get.assert_called_once_with(client, 1)
                 assert result == "<div></div>"
+
+    def test_get_applications(self):
+        with patch("wikidot.module.client.AjaxModuleConnectorClient"):
+            client = Client()
+            with patch("wikidot.module.client.pm.get_applications") as mock_get:
+                mock_applications = [MagicMock()]
+                mock_get.return_value = mock_applications
+                result = client.private_message.get_applications()
+                mock_get.assert_called_once_with(client)
+                assert result == mock_applications
+
+    def test_get_contacts(self):
+        with patch("wikidot.module.client.AjaxModuleConnectorClient"):
+            client = Client()
+            with patch("wikidot.module.client.pm.get_contacts") as mock_get:
+                mock_contacts = [MagicMock()]
+                mock_get.return_value = mock_contacts
+                result = client.private_message.get_contacts()
+                mock_get.assert_called_once_with(client)
+                assert result == mock_contacts

--- a/tests/unit/test_dashboard_site.py
+++ b/tests/unit/test_dashboard_site.py
@@ -1,0 +1,148 @@
+"""
+Dashboard のサイト操作モジュール（module.dashboard_site）のユニットテスト
+
+DashboardSitesクラスをテストする。
+"""
+
+from unittest.mock import MagicMock, create_autospec
+
+import pytest
+
+from wikidot.common.exceptions import LoginRequiredException
+from wikidot.module.client import Client
+from wikidot.module.dashboard_site import DashboardSites
+
+
+@pytest.fixture
+def mock_client():
+    """モッククライアント（Clientのspec付き）"""
+    client = create_autospec(Client, instance=True)
+    client.is_logged_in = True
+    client.amc_client = MagicMock()
+    return client
+
+
+def _last_body(mock_client):
+    """直前のamc_client.request呼び出しの最初のリクエストボディを取得"""
+    return mock_client.amc_client.request.call_args[0][0][0]
+
+
+class TestDashboardSitesCreate:
+    """DashboardSites.createのテスト"""
+
+    def test_create_success_returns_unix_name(self, mock_client):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "ok", "siteUnixName": "my-new-site"}
+        mock_client.amc_client.request.return_value = [mock_response]
+
+        result = DashboardSites.create(
+            mock_client,
+            name="My Site",
+            unixname="my-new-site",
+        )
+
+        body = _last_body(mock_client)
+        assert body["action"] == "NewSiteAction"
+        assert body["event"] == "createSite"
+        assert body["name"] == "My Site"
+        assert body["unixname"] == "my-new-site"
+        assert body["tos"] == "on"
+        assert result == "my-new-site"
+
+    def test_create_tos_false_omits_key(self, mock_client):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"siteUnixName": "x"}
+        mock_client.amc_client.request.return_value = [mock_response]
+
+        DashboardSites.create(mock_client, name="X", unixname="x", tos=False)
+
+        body = _last_body(mock_client)
+        assert "tos" not in body
+
+    def test_create_requires_login(self, mock_client):
+        mock_client.is_logged_in = False
+        mock_client.login_check.side_effect = LoginRequiredException("Not logged in")
+
+        with pytest.raises(LoginRequiredException):
+            DashboardSites.create(mock_client, name="X", unixname="x")
+
+
+class TestDashboardSitesInvitationsAndApplications:
+    """招待・申請系のテスト"""
+
+    def test_accept_invitation(self, mock_client):
+        DashboardSites.accept_invitation(mock_client, 42)
+
+        body = _last_body(mock_client)
+        assert body["action"] == "DashboardSitesAction"
+        assert body["event"] == "acceptInvitation"
+        assert body["invitation_id"] == 42
+
+    def test_throw_away_invitation(self, mock_client):
+        DashboardSites.throw_away_invitation(mock_client, 42)
+
+        body = _last_body(mock_client)
+        assert body["event"] == "throwAwayInvitation"
+        assert body["invitation_id"] == 42
+
+    def test_remove_application(self, mock_client):
+        DashboardSites.remove_application(mock_client, 7)
+
+        body = _last_body(mock_client)
+        assert body["event"] == "removeApplication"
+        assert body["site_id"] == 7
+
+
+class TestDashboardSitesResignAndRestore:
+    """辞任・復元系のテスト"""
+
+    def test_restore_site(self, mock_client):
+        DashboardSites.restore_site(mock_client, 10, "my-deleted-site")
+
+        body = _last_body(mock_client)
+        assert body["event"] == "restoreSite"
+        assert body["site_id"] == 10
+        assert body["site_name"] == "my-deleted-site"
+
+    def test_resign_as_admin(self, mock_client):
+        DashboardSites.resign_as_admin(mock_client, 10)
+
+        body = _last_body(mock_client)
+        assert body["event"] == "adminResign"
+        assert body["site_id"] == 10
+
+    def test_resign_as_moderator(self, mock_client):
+        DashboardSites.resign_as_moderator(mock_client, 10)
+
+        body = _last_body(mock_client)
+        assert body["event"] == "moderatorResign"
+
+    def test_sign_off_as_member(self, mock_client):
+        DashboardSites.sign_off_as_member(mock_client, 10)
+
+        body = _last_body(mock_client)
+        assert body["event"] == "memberSignOff"
+
+    def test_set_storage_limit_passes_raw_fields(self, mock_client):
+        """未実測フォームは生dictをそのまま送る"""
+        DashboardSites.set_storage_limit(mock_client, 10, {"limit": "500"})
+
+        body = _last_body(mock_client)
+        assert body["event"] == "setStorageLimit"
+        assert body["site_id"] == 10
+        assert body["limit"] == "500"
+
+
+class TestDashboardSitesListHtml:
+    """list_htmlのテスト"""
+
+    def test_list_html_returns_body(self, mock_client):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"body": "<div class='data'>...</div>"}
+        mock_client.amc_client.request.return_value = [mock_response]
+
+        result = DashboardSites.list_html(mock_client)
+
+        body = _last_body(mock_client)
+        assert body["moduleName"] == "dashboard/sites/DSListModule"
+        assert result == "<div class='data'>...</div>"

--- a/tests/unit/test_dashboard_site.py
+++ b/tests/unit/test_dashboard_site.py
@@ -10,7 +10,7 @@ import pytest
 
 from wikidot.common.exceptions import LoginRequiredException
 from wikidot.module.client import Client
-from wikidot.module.dashboard_site import DashboardSites
+from wikidot.module.dashboard_site import DashboardSite, DashboardSites
 
 
 @pytest.fixture
@@ -133,16 +133,92 @@ class TestDashboardSitesResignAndRestore:
         assert body["limit"] == "500"
 
 
-class TestDashboardSitesListHtml:
-    """list_htmlのテスト"""
+#: DSListModule row fixture, based on the 2026-07-29 markup measurement
+#: recorded in 70_account.md ("一覧モジュールの行マークアップ")
+DS_LIST_MODULE_BODY = """
+<div class="site">
+  <a class="thumbnail-site" href="http://foo.wikidot.com">
+    <img class="thumbnail-site" src="http://foo.wikidot.com/local--files/favicon/foo.png" />
+  </a>
+  <div class="name"><a href="http://foo.wikidot.com">Foo Site</a></div>
+  <div class="url">http://foo.wikidot.com</div>
+  <a class="btn" href="/account/sites#/manage/123456">Manage</a>
+  <div class="data">
+    <span class="activity">12</span>
+    <span class="site-id">123456</span>
+    <span class="unix-name">foo</span>
+    <span class="tagline">A test site</span>
+    <span class="occupation">admin</span>
+  </div>
+</div>
+<div class="site">
+  <div class="name"><a href="http://bar.wikidot.com">Bar Site</a></div>
+  <div class="url">http://bar.wikidot.com</div>
+  <div class="data">
+    <span class="activity">0</span>
+    <span class="site-id">654321</span>
+    <span class="unix-name">bar</span>
+    <span class="tagline"></span>
+    <span class="occupation">member</span>
+    <span class="deleted"></span>
+  </div>
+</div>
+"""
 
-    def test_list_html_returns_body(self, mock_client):
+
+class TestDashboardSiteAcquireAll:
+    """DashboardSite.acquire_all / DashboardSites.list_sites のテスト"""
+
+    def test_parses_all_rows(self, mock_client):
         mock_response = MagicMock()
-        mock_response.json.return_value = {"body": "<div class='data'>...</div>"}
+        mock_response.json.return_value = {"body": DS_LIST_MODULE_BODY}
         mock_client.amc_client.request.return_value = [mock_response]
 
-        result = DashboardSites.list_html(mock_client)
+        result = DashboardSites.list_sites(mock_client)
 
         body = _last_body(mock_client)
         assert body["moduleName"] == "dashboard/sites/DSListModule"
-        assert result == "<div class='data'>...</div>"
+        assert len(result) == 2
+
+    def test_active_site_fields(self, mock_client):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"body": DS_LIST_MODULE_BODY}
+        mock_client.amc_client.request.return_value = [mock_response]
+
+        result = DashboardSites.list_sites(mock_client)
+        site = result[0]
+
+        assert isinstance(site, DashboardSite)
+        assert site.site_id == 123456
+        assert site.title == "Foo Site"
+        assert site.url == "http://foo.wikidot.com"
+        assert site.unix_name == "foo"
+        assert site.tagline == "A test site"
+        assert site.role == "admin"
+        assert site.deleted is False
+
+    def test_deleted_site_fields(self, mock_client):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"body": DS_LIST_MODULE_BODY}
+        mock_client.amc_client.request.return_value = [mock_response]
+
+        result = DashboardSites.list_sites(mock_client)
+        site = result[1]
+
+        assert site.site_id == 654321
+        assert site.role == "member"
+        assert site.deleted is True
+
+    def test_row_actions_delegate_to_dashboard_sites(self, mock_client):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"body": DS_LIST_MODULE_BODY}
+        mock_client.amc_client.request.return_value = [mock_response]
+
+        site = DashboardSites.list_sites(mock_client)[0]
+        mock_client.amc_client.request.reset_mock()
+
+        site.resign_as_admin()
+
+        body = _last_body(mock_client)
+        assert body["event"] == "adminResign"
+        assert body["site_id"] == 123456

--- a/tests/unit/test_private_message.py
+++ b/tests/unit/test_private_message.py
@@ -12,15 +12,17 @@ import pytest
 from wikidot.common.exceptions import ForbiddenException, LoginRequiredException
 from wikidot.module.client import Client
 from wikidot.module.private_message import (
+    Contact,
     PrivateMessage,
     PrivateMessageCollection,
     PrivateMessageInbox,
     PrivateMessageSentBox,
+    SiteJoinApplication,
     add_contact,
     add_contact_via_profile,
     get_application_detail_html,
-    get_applications_html,
-    get_contacts_html,
+    get_applications,
+    get_contacts,
     get_contacts_list_html,
     get_invitation_detail_html,
     get_invitations_html,
@@ -356,15 +358,45 @@ class TestInvitationsApplicationsContacts:
         assert call_args["moduleName"] == "dashboard/messages/DMViewInvitationModule"
         assert call_args["item"] == 9
 
-    def test_get_applications_html(self, mock_client):
+    def test_get_applications_parses_rows(self, mock_client):
+        """DMApplicationsModuleの行マークアップ（2026-07-29実測）に基づくfixture"""
         mock_response = MagicMock()
-        mock_response.json.return_value = {"body": "<div>apps</div>"}
+        mock_response.json.return_value = {
+            "body": """
+            <table>
+            <tr>
+                <td>
+                    <span class="from">Foo Site</span>
+                    <span class="subject">Membership application</span>
+                    <span class="preview">Please let me join!</span>
+                    <span class="date"><span class="odate time_1700000000">01 Jan 2024</span></span>
+                </td>
+            </tr>
+            </table>
+            """
+        }
         mock_client.amc_client.request.return_value = [mock_response]
 
-        get_applications_html(mock_client)
+        result = get_applications(mock_client)
 
         call_args = mock_client.amc_client.request.call_args[0][0][0]
         assert call_args["moduleName"] == "dashboard/messages/DMApplicationsModule"
+        assert len(result) == 1
+        application = result[0]
+        assert isinstance(application, SiteJoinApplication)
+        assert application.from_site == "Foo Site"
+        assert application.subject == "Membership application"
+        assert application.preview == "Please let me join!"
+        assert application.submitted_at == datetime.fromtimestamp(1700000000)
+
+    def test_get_applications_skips_rows_without_from(self, mock_client):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"body": "<table><tr><td>no from span here</td></tr></table>"}
+        mock_client.amc_client.request.return_value = [mock_response]
+
+        result = get_applications(mock_client)
+
+        assert result == []
 
     def test_get_application_detail_html(self, mock_client):
         mock_response = MagicMock()
@@ -377,15 +409,56 @@ class TestInvitationsApplicationsContacts:
         assert call_args["moduleName"] == "dashboard/messages/DMViewApplicationModule"
         assert call_args["item"] == 3
 
-    def test_get_contacts_html(self, mock_client):
+    def test_get_contacts_parses_rows(self, mock_client):
+        """DMContactsModuleの行マークアップ（2026-07-29実測）に基づくfixture"""
         mock_response = MagicMock()
-        mock_response.json.return_value = {"body": "<div>contacts</div>"}
+        mock_response.json.return_value = {
+            "body": """
+            <table>
+            <tr>
+                <td>
+                    <span class="printuser avatarhover">
+                        <a href="http://www.wikidot.com/user:info/contact-user"
+                           onclick="WIKIDOT.page.listeners.userInfo(54321); return false;">contact-user</a>
+                    </span>
+                </td>
+                <td><a class="awesome red small" href="#">x</a></td>
+            </tr>
+            </table>
+            """
+        }
         mock_client.amc_client.request.return_value = [mock_response]
 
-        get_contacts_html(mock_client)
+        result = get_contacts(mock_client)
 
         call_args = mock_client.amc_client.request.call_args[0][0][0]
         assert call_args["moduleName"] == "dashboard/messages/DMContactsModule"
+        assert len(result) == 1
+        contact = result[0]
+        assert isinstance(contact, Contact)
+        assert contact.user.id == 54321
+        assert contact.user.name == "contact-user"
+
+    def test_contact_remove_delegates_to_remove_contact(self, mock_client):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "body": """
+            <span class="printuser avatarhover">
+                <a href="http://www.wikidot.com/user:info/contact-user"
+                   onclick="WIKIDOT.page.listeners.userInfo(54321); return false;">contact-user</a>
+            </span>
+            """
+        }
+        mock_client.amc_client.request.return_value = [mock_response]
+        user = MagicMock(id=54321)
+        contact = Contact(client=mock_client, user=user)
+
+        contact.remove()
+
+        call_args = mock_client.amc_client.request.call_args[0][0][0]
+        assert call_args["action"] == "ContactsAction"
+        assert call_args["event"] == "removeContact"
+        assert call_args["userId"] == 54321
 
     def test_get_contacts_list_html(self, mock_client):
         mock_response = MagicMock()

--- a/tests/unit/test_private_message.py
+++ b/tests/unit/test_private_message.py
@@ -16,6 +16,15 @@ from wikidot.module.private_message import (
     PrivateMessageCollection,
     PrivateMessageInbox,
     PrivateMessageSentBox,
+    add_contact,
+    add_contact_via_profile,
+    get_application_detail_html,
+    get_applications_html,
+    get_contacts_html,
+    get_contacts_list_html,
+    get_invitation_detail_html,
+    get_invitations_html,
+    remove_contact,
 )
 
 
@@ -217,3 +226,200 @@ class TestPrivateMessage:
         assert call_args["subject"] == "Test Subject"
         assert call_args["to_user_id"] == mock_user.id
         assert call_args["event"] == "send"
+
+    def test_save_draft_without_recipient_omits_to_user_id(self, mock_client):
+        """recipient未指定時はto_user_idキーが送られない"""
+        PrivateMessage.save_draft(mock_client, "subj", "body")
+
+        call_args = mock_client.amc_client.request.call_args[0][0][0]
+        assert call_args["event"] == "saveDraft"
+        assert "to_user_id" not in call_args
+
+    def test_save_draft_with_recipient(self, mock_client, mock_user):
+        PrivateMessage.save_draft(mock_client, "subj", "body", mock_user)
+
+        call_args = mock_client.amc_client.request.call_args[0][0][0]
+        assert call_args["to_user_id"] == mock_user.id
+
+    def test_check_can_send(self, mock_client, mock_user):
+        PrivateMessage.check_can_send(mock_client, mock_user)
+
+        call_args = mock_client.amc_client.request.call_args[0][0][0]
+        assert call_args["action"] == "DashboardMessageAction"
+        assert call_args["event"] == "checkCan"
+        assert call_args["userId"] == mock_user.id
+
+    def test_preview(self, mock_client):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"body": "<p>preview</p>"}
+        mock_client.amc_client.request.return_value = [mock_response]
+
+        result = PrivateMessage.preview(mock_client, "subj", "body")
+
+        call_args = mock_client.amc_client.request.call_args[0][0][0]
+        assert call_args["moduleName"] == "dashboard/messages/DMPreviewModule"
+        assert result == "<p>preview</p>"
+
+    def test_fetch_reply_form_html(self, mock_client):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"body": "<form></form>"}
+        mock_client.amc_client.request.return_value = [mock_response]
+
+        result = PrivateMessage.fetch_reply_form_html(mock_client, 555)
+
+        call_args = mock_client.amc_client.request.call_args[0][0][0]
+        assert call_args["moduleName"] == "dashboard/messages/DMNewMessageModule"
+        assert call_args["replyMessageId"] == 555
+        assert result == "<form></form>"
+
+    def test_mark_as_read_instance_method(self, sample_message, mock_client):
+        sample_message.client = mock_client
+        sample_message.mark_as_read()
+
+        call_args = mock_client.amc_client.request.call_args[0][0][0]
+        assert call_args["event"] == "setAsReaded"
+        assert call_args["selected"] == [sample_message.id]
+
+    def test_mark_as_unread_instance_method(self, sample_message, mock_client):
+        sample_message.client = mock_client
+        sample_message.mark_as_unread()
+
+        call_args = mock_client.amc_client.request.call_args[0][0][0]
+        assert call_args["event"] == "setAsUnreaded"
+
+    def test_delete_instance_method(self, sample_message, mock_client):
+        sample_message.client = mock_client
+        sample_message.delete()
+
+        call_args = mock_client.amc_client.request.call_args[0][0][0]
+        assert call_args["event"] == "removeMessages"
+        assert call_args["messages"] == [sample_message.id]
+
+
+class TestPrivateMessageCollectionBulkOperations:
+    """PrivateMessageCollectionのメッセージ一括操作のテスト"""
+
+    def test_mark_as_read_uses_selected_key(self, mock_client):
+        """setAsReadedはselected[]で送られる（messages[]ではない）"""
+        PrivateMessageCollection.mark_as_read(mock_client, [1, 2, 3])
+
+        call_args = mock_client.amc_client.request.call_args[0][0][0]
+        assert call_args["action"] == "DashboardMessageAction"
+        assert call_args["event"] == "setAsReaded"
+        assert call_args["selected"] == [1, 2, 3]
+
+    def test_mark_as_unread_uses_selected_key(self, mock_client):
+        PrivateMessageCollection.mark_as_unread(mock_client, [1, 2])
+
+        call_args = mock_client.amc_client.request.call_args[0][0][0]
+        assert call_args["event"] == "setAsUnreaded"
+        assert call_args["selected"] == [1, 2]
+
+    def test_remove_messages_uses_messages_key(self, mock_client):
+        """removeMessagesはmessages[]で送られる（selected[]ではない）"""
+        PrivateMessageCollection.remove_messages(mock_client, [4, 5])
+
+        call_args = mock_client.amc_client.request.call_args[0][0][0]
+        assert call_args["event"] == "removeMessages"
+        assert call_args["messages"] == [4, 5]
+
+    def test_remove_messages_requires_login(self, mock_client):
+        mock_client.is_logged_in = False
+        mock_client.login_check.side_effect = LoginRequiredException("Not logged in")
+
+        with pytest.raises(LoginRequiredException):
+            PrivateMessageCollection.remove_messages(mock_client, [1])
+
+
+class TestInvitationsApplicationsContacts:
+    """招待・申請・連絡先系のモジュール関数のテスト"""
+
+    def test_get_invitations_html(self, mock_client):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"body": "<div>invitations</div>"}
+        mock_client.amc_client.request.return_value = [mock_response]
+
+        result = get_invitations_html(mock_client)
+
+        call_args = mock_client.amc_client.request.call_args[0][0][0]
+        assert call_args["moduleName"] == "dashboard/messages/DMInvitationsModule"
+        assert result == "<div>invitations</div>"
+
+    def test_get_invitation_detail_html(self, mock_client):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"body": "<div>detail</div>"}
+        mock_client.amc_client.request.return_value = [mock_response]
+
+        get_invitation_detail_html(mock_client, 9)
+
+        call_args = mock_client.amc_client.request.call_args[0][0][0]
+        assert call_args["moduleName"] == "dashboard/messages/DMViewInvitationModule"
+        assert call_args["item"] == 9
+
+    def test_get_applications_html(self, mock_client):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"body": "<div>apps</div>"}
+        mock_client.amc_client.request.return_value = [mock_response]
+
+        get_applications_html(mock_client)
+
+        call_args = mock_client.amc_client.request.call_args[0][0][0]
+        assert call_args["moduleName"] == "dashboard/messages/DMApplicationsModule"
+
+    def test_get_application_detail_html(self, mock_client):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"body": "<div>detail</div>"}
+        mock_client.amc_client.request.return_value = [mock_response]
+
+        get_application_detail_html(mock_client, 3)
+
+        call_args = mock_client.amc_client.request.call_args[0][0][0]
+        assert call_args["moduleName"] == "dashboard/messages/DMViewApplicationModule"
+        assert call_args["item"] == 3
+
+    def test_get_contacts_html(self, mock_client):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"body": "<div>contacts</div>"}
+        mock_client.amc_client.request.return_value = [mock_response]
+
+        get_contacts_html(mock_client)
+
+        call_args = mock_client.amc_client.request.call_args[0][0][0]
+        assert call_args["moduleName"] == "dashboard/messages/DMContactsModule"
+
+    def test_get_contacts_list_html(self, mock_client):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"body": "<div>picker</div>"}
+        mock_client.amc_client.request.return_value = [mock_response]
+
+        get_contacts_list_html(mock_client)
+
+        call_args = mock_client.amc_client.request.call_args[0][0][0]
+        assert call_args["moduleName"] == "dashboard/messages/DMContactsListModule"
+
+    def test_add_contact(self, mock_client, mock_user):
+        add_contact(mock_client, mock_user)
+
+        call_args = mock_client.amc_client.request.call_args[0][0][0]
+        assert call_args["action"] == "ContactsAction"
+        assert call_args["event"] == "addContact"
+        assert call_args["userId"] == mock_user.id
+
+    def test_remove_contact(self, mock_client, mock_user):
+        remove_contact(mock_client, mock_user)
+
+        call_args = mock_client.amc_client.request.call_args[0][0][0]
+        assert call_args["action"] == "ContactsAction"
+        assert call_args["event"] == "removeContact"
+
+    def test_add_contact_via_profile(self, mock_client, mock_user):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"body": "<div>added</div>"}
+        mock_client.amc_client.request.return_value = [mock_response]
+
+        result = add_contact_via_profile(mock_client, mock_user)
+
+        call_args = mock_client.amc_client.request.call_args[0][0][0]
+        assert call_args["moduleName"] == "userinfo/UserAddToContactsModule"
+        assert call_args["userId"] == mock_user.id
+        assert result == "<div>added</div>"

--- a/tests/unit/test_private_message.py
+++ b/tests/unit/test_private_message.py
@@ -364,7 +364,7 @@ class TestInvitationsApplicationsContacts:
         mock_response.json.return_value = {
             "body": """
             <table>
-            <tr>
+            <tr class="message" data-href="#/applications/463303">
                 <td>
                     <span class="from">Foo Site</span>
                     <span class="subject">Membership application</span>
@@ -384,6 +384,7 @@ class TestInvitationsApplicationsContacts:
         assert len(result) == 1
         application = result[0]
         assert isinstance(application, SiteJoinApplication)
+        assert application.item_id == 463303
         assert application.from_site == "Foo Site"
         assert application.subject == "Membership application"
         assert application.preview == "Please let me join!"
@@ -391,12 +392,45 @@ class TestInvitationsApplicationsContacts:
 
     def test_get_applications_skips_rows_without_from(self, mock_client):
         mock_response = MagicMock()
-        mock_response.json.return_value = {"body": "<table><tr><td>no from span here</td></tr></table>"}
+        mock_response.json.return_value = {
+            "body": '<table><tr class="message" data-href="#/applications/1"><td>no from span here</td></tr></table>'
+        }
         mock_client.amc_client.request.return_value = [mock_response]
 
         result = get_applications(mock_client)
 
         assert result == []
+
+    def test_get_applications_skips_rows_without_data_href(self, mock_client):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "body": '<table><tr class="message"><td><span class="from">Foo</span></td></tr></table>'
+        }
+        mock_client.amc_client.request.return_value = [mock_response]
+
+        result = get_applications(mock_client)
+
+        assert result == []
+
+    def test_site_join_application_fetch_detail_html(self, mock_client):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"body": "<div>detail</div>"}
+        mock_client.amc_client.request.return_value = [mock_response]
+        application = SiteJoinApplication(
+            client=mock_client,
+            item_id=463303,
+            from_site="Foo Site",
+            subject="Membership application",
+            preview="Please let me join!",
+            submitted_at=datetime.fromtimestamp(1700000000),
+        )
+
+        result = application.fetch_detail_html()
+
+        call_args = mock_client.amc_client.request.call_args[0][0][0]
+        assert call_args["moduleName"] == "dashboard/messages/DMViewApplicationModule"
+        assert call_args["item"] == 463303
+        assert result == "<div>detail</div>"
 
     def test_get_application_detail_html(self, mock_client):
         mock_response = MagicMock()


### PR DESCRIPTION
## Summary

`www.wikidot.com` の Dashboard 操作を `client.account` から扱えるようにする。

> スタック PR。base は `feature/page-operations`。

## Related Issue

なし

## Changes

- PM の既読 / 未読 / 削除 / 下書き / 送信可否確認 / プレビュー
- 招待・参加申請の一覧、連絡先の追加と削除
- アカウント設定（表示名 / パスワード / メール / 言語 / API キー / 各種受信設定）
- プロフィール（自己紹介 / フォーラム署名 / アバター / 公開範囲）
- Dashboard のサイト一覧・作成・復元・辞任、自分の最近の活動

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring
- [x] Test addition/modification
- [ ] CI/CD or build related

## Testing

- [x] `make format` passes
- [x] `make lint` passes
- [x] `make test` passes

## Checklist

- [x] Code follows the project's style guidelines
- [ ] Documentation has been updated as needed
- [x] Tests have been added for the changes (if applicable)

## Additional Information

- 送信先は `www.wikidot.com` で、サイト側の経路とは分けている
- `userId` は `userinfo/UserChangesModule` の hidden から取る。`WIKIREQUEST.info.userId` は `www.wikidot.com` のページには存在しない
- 招待一覧は行マークアップを実測できず（対象アカウントに招待が無いため）生 HTML を返す
- アカウント削除は不可逆のため対象外

README と `llms.txt` は追加した API を反映していない。リリース前にまとめて追随させる。
