### PR TITLE
PrivateMessageCollection.from_ids を部分成功契約に変更

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -1450,6 +1450,25 @@ Private message operations (login required).
 | `client.private_message.add_contact(user)` / `remove_contact(user)` | `None` | Manage the contact list (`ContactsAction`) |
 | `client.private_message.add_contact_via_profile(user)` | `str` | Add a contact from the user's profile page (a second, module-render-as-action path); returns raw HTML |
 
+### Partial success (`failures`)
+
+`get_messages(ids)` / `inbox` / `sentbox` follow a partial-success
+contract: a message that fails to fetch (per-request transport error,
+missing body, unparseable markup) is skipped instead of failing the whole
+call. The returned collection carries the skipped IDs as
+`failures: list[PrivateMessageFetchFailure]` (`id: int`, `error: Exception`),
+in request order; successful messages keep the input ID order. If every
+message fails, the return value is still a normal (empty) collection with
+all IDs in `failures`. Only systemic failures (login missing, listing-page
+fetch) raise. Callers that persist or delete fetched messages must check
+`failures` to know the fetch was partial.
+
+```python
+inbox = client.private_message.inbox
+for failure in inbox.failures:
+    print(f"Message {failure.id} could not be fetched: {failure.error}")
+```
+
 ### SiteJoinApplication / Contact
 
 `SiteJoinApplication` (`item_id`, `from_site`, `subject`, `preview`,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wikidot"
-version = "4.5.0"
+version = "4.5.1"
 authors = [{ name = "ukwhatn", email = "ukwhatn@gmail.com" }]
 description = "Wikidot Utility Library"
 readme = "README.md"

--- a/src/wikidot/__init__.py
+++ b/src/wikidot/__init__.py
@@ -13,7 +13,7 @@ import sys
 from .module.client import Client
 
 __all__ = ["Client"]
-__version__ = "4.5.0"
+__version__ = "4.5.1"
 
 
 def _import_submodules() -> None:

--- a/src/wikidot/module/private_message.py
+++ b/src/wikidot/module/private_message.py
@@ -5,7 +5,7 @@ This module provides classes and functionality related to Wikidot private messag
 It enables operations such as sending messages, retrieving inbox/sent box, and viewing messages.
 """
 
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Optional
@@ -25,13 +25,46 @@ if TYPE_CHECKING:
     from .user import AbstractUser, User
 
 
+@dataclass
+class PrivateMessageFetchFailure:
+    """
+    A message that could not be fetched, with the ID it was requested by
+
+    Attributes
+    ----------
+    id : int
+        Requested message ID
+    error : Exception
+        The error that made this message unfetchable (transport or parse failure)
+    """
+
+    id: int
+    error: Exception
+
+
 class PrivateMessageCollection(list["PrivateMessage"]):
     """
     Base class representing a collection of private messages
 
     A list extension class for storing multiple private messages and performing batch operations.
     Inherited to represent specific message groups such as inbox or sent box.
+
+    Attributes
+    ----------
+    failures : list[PrivateMessageFetchFailure]
+        Messages that could not be fetched when this collection was built.
+        A single unfetchable message no longer fails the whole fetch: it is
+        skipped and reported here instead, so callers processing the
+        successful messages must check this to know the fetch was partial.
     """
+
+    def __init__(
+        self,
+        messages: "Iterable[PrivateMessage] | None" = None,
+        failures: "list[PrivateMessageFetchFailure] | None" = None,
+    ) -> None:
+        super().__init__(messages if messages is not None else [])
+        self.failures: list[PrivateMessageFetchFailure] = list(failures) if failures is not None else []
 
     def __str__(self) -> str:
         """
@@ -83,6 +116,14 @@ class PrivateMessageCollection(list["PrivateMessage"]):
 
         Batch retrieves messages with the specified IDs and returns them as a collection.
 
+        Partial-success contract: a message that fails to fetch (per-request
+        transport error, missing body, or unparseable markup) is skipped and
+        reported in the returned collection's ``failures``, in request order,
+        so one broken message cannot block the rest. Successful messages keep
+        the input ID order. If every message fails, the return value is still
+        a normal (empty) collection with all IDs in ``failures``. Only
+        systemic failures (login missing) raise.
+
         Parameters
         ----------
         client : Client
@@ -93,14 +134,12 @@ class PrivateMessageCollection(list["PrivateMessage"]):
         Returns
         -------
         PrivateMessageCollection
-            Collection of retrieved messages
+            Collection of retrieved messages (check ``failures`` for skipped IDs)
 
         Raises
         ------
         LoginRequiredException
             If not logged in
-        ForbiddenException
-            If no permission to access the message
         """
         bodies = []
 
@@ -115,36 +154,44 @@ class PrivateMessageCollection(list["PrivateMessage"]):
         responses = client.amc_client.request(bodies, return_exceptions=True)
 
         messages = []
+        failures: list[PrivateMessageFetchFailure] = []
 
         for index, response in enumerate(responses):
-            if isinstance(response, exceptions.WikidotStatusCodeException):
-                if response.status_code == "no_message":
-                    raise exceptions.ForbiddenException(f"Failed to get message: {message_ids[index]}") from response
+            message_id = message_ids[index]
 
-            if isinstance(response, Exception):
-                raise response
+            try:
+                if isinstance(response, exceptions.WikidotStatusCodeException) and response.status_code == "no_message":
+                    raise exceptions.ForbiddenException(f"Failed to get message: {message_id}") from response
 
-            html = BeautifulSoup(require_body(response, "dashboard/messages/DMViewMessageModule"), "lxml")
+                if isinstance(response, Exception):
+                    raise response
 
-            sender, recipient = html.select("div.pmessage div.header span.printuser")
+                html = BeautifulSoup(require_body(response, "dashboard/messages/DMViewMessageModule"), "lxml")
 
-            subject_element = html.select_one("div.pmessage div.header span.subject")
-            body_element = html.select_one("div.pmessage div.body")
-            odate_element = html.select_one("div.header span.odate")
+                printuser_elements = html.select("div.pmessage div.header span.printuser")
+                if len(printuser_elements) < 2:
+                    raise exceptions.ForbiddenException(f"Failed to get message: {message_id}")
+                sender, recipient = printuser_elements[0], printuser_elements[1]
 
-            messages.append(
-                PrivateMessage(
-                    client=client,
-                    id=message_ids[index],
-                    sender=user_parser(client, sender),
-                    recipient=user_parser(client, recipient),
-                    subject=subject_element.get_text() if subject_element else "",
-                    body=body_element.get_text() if body_element else "",
-                    created_at=(odate_parser(odate_element) if odate_element else datetime.fromtimestamp(0)),
+                subject_element = html.select_one("div.pmessage div.header span.subject")
+                body_element = html.select_one("div.pmessage div.body")
+                odate_element = html.select_one("div.header span.odate")
+
+                messages.append(
+                    PrivateMessage(
+                        client=client,
+                        id=message_id,
+                        sender=user_parser(client, sender),
+                        recipient=user_parser(client, recipient),
+                        subject=subject_element.get_text() if subject_element else "",
+                        body=body_element.get_text() if body_element else "",
+                        created_at=(odate_parser(odate_element) if odate_element else datetime.fromtimestamp(0)),
+                    )
                 )
-            )
+            except Exception as error:
+                failures.append(PrivateMessageFetchFailure(id=message_id, error=error))
 
-        return PrivateMessageCollection(messages)
+        return PrivateMessageCollection(messages, failures=failures)
 
     @staticmethod
     @login_required
@@ -214,7 +261,8 @@ class PrivateMessageCollection(list["PrivateMessage"]):
         cls
             Instance of the calling class
         """
-        return cls(PrivateMessageCollection.from_ids(client, message_ids))
+        collection = PrivateMessageCollection.from_ids(client, message_ids)
+        return cls(collection, failures=collection.failures)
 
     @classmethod
     def _factory_acquire(cls, client: "Client", module_name: str) -> Self:
@@ -238,7 +286,8 @@ class PrivateMessageCollection(list["PrivateMessage"]):
         LoginRequiredException
             If not logged in
         """
-        return cls(PrivateMessageCollection._acquire(client, module_name))
+        collection = PrivateMessageCollection._acquire(client, module_name)
+        return cls(collection, failures=collection.failures)
 
     @staticmethod
     @login_required
@@ -504,10 +553,19 @@ class PrivateMessage:
             If not logged in
         ForbiddenException
             If no permission to access the message
-        IndexError
+        NoElementException
             If message not found
         """
-        return PrivateMessageCollection.from_ids(client, [message_id])[0]
+        collection = PrivateMessageCollection.from_ids(client, [message_id])
+        if collection:
+            return collection[0]
+
+        # from_ids is partial-success: a single-message failure comes back
+        # recorded on the collection, not raised, so surface it here
+        for failure in collection.failures:
+            if failure.id == message_id:
+                raise failure.error
+        raise exceptions.NoElementException(f"Message not found: {message_id}")
 
     @staticmethod
     @login_required

--- a/tests/unit/test_private_message.py
+++ b/tests/unit/test_private_message.py
@@ -126,8 +126,8 @@ class TestPrivateMessageCollection:
                 assert len(result) == 1
                 assert result[0].id == 1
 
-    def test_from_ids_forbidden_error(self, mock_client):
-        """from_idsでアクセス権限エラー"""
+    def test_from_ids_no_message_is_recorded_as_failure(self, mock_client):
+        """no_message応答は全体を失敗させずfailuresに記録される"""
         from wikidot.common.exceptions import WikidotStatusCodeException
 
         mock_exception = WikidotStatusCodeException("no_message", "No message found")
@@ -135,8 +135,12 @@ class TestPrivateMessageCollection:
 
         mock_client.amc_client.request.return_value = [mock_exception]
 
-        with pytest.raises(ForbiddenException):
-            PrivateMessageCollection.from_ids(mock_client, [1])
+        result = PrivateMessageCollection.from_ids(mock_client, [1])
+
+        assert len(result) == 0
+        assert len(result.failures) == 1
+        assert result.failures[0].id == 1
+        assert isinstance(result.failures[0].error, ForbiddenException)
 
 
 class TestPrivateMessageInbox:
@@ -530,3 +534,119 @@ class TestInvitationsApplicationsContacts:
         assert call_args["moduleName"] == "userinfo/UserAddToContactsModule"
         assert call_args["userId"] == mock_user.id
         assert result == "<div>added</div>"
+
+
+MESSAGE_HTML = """
+<div class="pmessage">
+    <div class="header">
+        <span class="printuser"><a href="http://www.wikidot.com/user:info/sender" onclick="WIKIDOT.page.listeners.userInfo(11111); return false;">sender</a></span>
+        <span class="printuser"><a href="http://www.wikidot.com/user:info/recipient" onclick="WIKIDOT.page.listeners.userInfo(22222); return false;">recipient</a></span>
+        <span class="subject">Test Subject</span>
+        <span class="odate time_1234567890">01 Jan 2023 12:00</span>
+    </div>
+    <div class="body">Test Body</div>
+</div>
+"""
+
+UNPARSEABLE_HTML = '<div class="pmessage"><div class="header"></div></div>'
+
+
+def _ok_response(body: str = MESSAGE_HTML) -> MagicMock:
+    response = MagicMock()
+    response.json.return_value = {"body": body}
+    return response
+
+
+class TestFromIdsPartialSuccess:
+    """from_idsの部分成功契約のテスト（リリース条件テスト）"""
+
+    def test_parser_failure_is_skipped_and_reported(self, mock_client):
+        """解析不能な1件はスキップされfailuresに記録され、残りは返る"""
+        mock_client.amc_client.request.return_value = [
+            _ok_response(),
+            _ok_response(UNPARSEABLE_HTML),
+            _ok_response(),
+        ]
+
+        result = PrivateMessageCollection.from_ids(mock_client, [1, 2, 3])
+
+        assert [message.id for message in result] == [1, 3]
+        assert [failure.id for failure in result.failures] == [2]
+        assert isinstance(result.failures[0].error, ForbiddenException)
+
+    def test_transport_failure_is_skipped_and_reported(self, mock_client):
+        """個別リクエストのtransport失敗はスキップされfailuresに記録される"""
+        from wikidot.common.exceptions import AMCHttpStatusCodeException
+
+        mock_client.amc_client.request.return_value = [
+            _ok_response(),
+            AMCHttpStatusCodeException("AMC request failed", 500),
+            _ok_response(),
+        ]
+
+        result = PrivateMessageCollection.from_ids(mock_client, [10, 20, 30])
+
+        assert [message.id for message in result] == [10, 30]
+        assert [failure.id for failure in result.failures] == [20]
+        assert isinstance(result.failures[0].error, AMCHttpStatusCodeException)
+
+    def test_all_failed_returns_empty_collection_with_failures(self, mock_client):
+        """全件失敗でも例外にならず空collection + 全failuresを返す"""
+        from wikidot.common.exceptions import AMCHttpStatusCodeException
+
+        mock_client.amc_client.request.return_value = [
+            AMCHttpStatusCodeException("AMC request failed", 500),
+            _ok_response(UNPARSEABLE_HTML),
+        ]
+
+        result = PrivateMessageCollection.from_ids(mock_client, [1, 2])
+
+        assert len(result) == 0
+        assert [failure.id for failure in result.failures] == [1, 2]
+
+    def test_input_order_is_preserved(self, mock_client):
+        """成功分は入力ID順を維持する"""
+        mock_client.amc_client.request.return_value = [
+            _ok_response(),
+            _ok_response(),
+            _ok_response(),
+        ]
+
+        result = PrivateMessageCollection.from_ids(mock_client, [30, 10, 20])
+
+        assert [message.id for message in result] == [30, 10, 20]
+        assert result.failures == []
+
+    def test_missing_body_is_recorded_as_failure(self, mock_client):
+        """body欠落応答はResponseDataExceptionとしてfailuresに記録される"""
+        from wikidot.common.exceptions import ResponseDataException
+
+        response = MagicMock()
+        response.json.return_value = {"status": "ok"}
+        mock_client.amc_client.request.return_value = [response]
+
+        result = PrivateMessageCollection.from_ids(mock_client, [1])
+
+        assert len(result) == 0
+        assert isinstance(result.failures[0].error, ResponseDataException)
+
+    def test_from_id_raises_recorded_failure(self, mock_client):
+        """from_id（単一取得）は記録されたfailureを例外として送出する"""
+        mock_client.amc_client.request.return_value = [_ok_response(UNPARSEABLE_HTML)]
+
+        with pytest.raises(ForbiddenException):
+            PrivateMessage.from_id(mock_client, 42)
+
+    def test_inbox_factory_propagates_failures(self, mock_client):
+        """PrivateMessageInbox.from_idsはfailuresを伝播する"""
+        from wikidot.module.private_message import PrivateMessageFetchFailure
+
+        inner = PrivateMessageCollection(
+            [],
+            failures=[PrivateMessageFetchFailure(id=2, error=ForbiddenException("Failed to get message: 2"))],
+        )
+        with patch.object(PrivateMessageCollection, "from_ids", return_value=inner):
+            result = PrivateMessageInbox.from_ids(mock_client, [2])
+
+        assert isinstance(result, PrivateMessageInbox)
+        assert [failure.id for failure in result.failures] == [2]


### PR DESCRIPTION
## Summary

`PrivateMessageCollection.from_ids()` を部分成功契約に変更する。wikidot-ts の同名修正（ukwhatn/wikidot-ts#103）との機能等価性を維持する対の PR。

## Related Issue

なし（panopticon のサイトメンバーDM機能の前提修正）

## Changes

- `from_ids()` で失敗したメッセージ（transport エラー・`body` 欠落・解析不能マークアップ）をスキップし、`collection.failures`（`PrivateMessageFetchFailure`: 失敗IDとエラー）にリクエスト順で記録する
- printuser 解析はアンパク例外任せをやめ、要素数 < 2 の明示チェックで `ForbiddenException` を記録（従来は 1 件の `ValueError` で全体死）
- 成功分は入力ID順を維持。全件失敗でも空 collection + failures を返し、raise はログイン欠如等のシステム的失敗のみ
- `PrivateMessageInbox` / `PrivateMessageSentBox` のファクトリに failures を伝播
- `from_id()`（単一取得）は記録された failure を再送出。メッセージ不在は `IndexError` から `NoElementException` に変更
- `llms.txt` に部分成功契約を追記、バージョンを 4.5.1 に更新

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring
- [x] Test addition/modification
- [ ] CI/CD or build related

## Testing

- [x] `make format` passes
- [x] `make lint` passes
- [x] `make test` passes

## Checklist

- [x] Code follows the project's style guidelines
- [x] Documentation has been updated as needed
- [x] Tests have been added for the changes (if applicable)

## Additional Information

- 従来は受信箱に解析不能なメッセージが 1 件あると `inbox` 取得が例外で全滅し、該当メッセージが残る限り復旧不能だった
- 「取得できていたケースが例外にならなくなる」挙動変化はあるが、既存の raise 経路（システム的失敗）は維持しており non-breaking として 4.5.1 とした
- リリース条件テスト（正常・失敗混在 / 全件失敗 / parser 失敗 / transport 失敗 / 順序維持）を `tests/unit/test_private_message.py` に追加。wikidot-ts#103 と同一観点
