### PR TITLE
受信PM本文から返信/削除ボタンのテキストを除去

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wikidot"
-version = "4.5.1"
+version = "4.5.2"
 authors = [{ name = "ukwhatn", email = "ukwhatn@gmail.com" }]
 description = "Wikidot Utility Library"
 readme = "README.md"

--- a/src/wikidot/__init__.py
+++ b/src/wikidot/__init__.py
@@ -13,7 +13,7 @@ import sys
 from .module.client import Client
 
 __all__ = ["Client"]
-__version__ = "4.5.1"
+__version__ = "4.5.2"
 
 
 def _import_submodules() -> None:

--- a/src/wikidot/module/private_message.py
+++ b/src/wikidot/module/private_message.py
@@ -177,14 +177,20 @@ class PrivateMessageCollection(list["PrivateMessage"]):
                 body_element = html.select_one("div.pmessage div.body")
                 odate_element = html.select_one("div.header span.odate")
 
+                # div.body には本文の前に返信/削除ボタン（div.message-actions）が
+                # 埋め込まれている（markup採取 2026-08-05）ため、除去してから抽出する
+                if body_element is not None:
+                    for actions_element in body_element.select("div.message-actions"):
+                        actions_element.decompose()
+
                 messages.append(
                     PrivateMessage(
                         client=client,
                         id=message_id,
                         sender=user_parser(client, sender),
                         recipient=user_parser(client, recipient),
-                        subject=subject_element.get_text() if subject_element else "",
-                        body=body_element.get_text() if body_element else "",
+                        subject=subject_element.get_text().strip() if subject_element else "",
+                        body=body_element.get_text().strip() if body_element else "",
                         created_at=(odate_parser(odate_element) if odate_element else datetime.fromtimestamp(0)),
                     )
                 )

--- a/tests/unit/test_private_message.py
+++ b/tests/unit/test_private_message.py
@@ -650,3 +650,44 @@ class TestFromIdsPartialSuccess:
 
         assert isinstance(result, PrivateMessageInbox)
         assert [failure.id for failure in result.failures] == [2]
+
+
+# 実機採取markup（2026-08-05）の縮約版: div.bodyの内側に返信/削除ボタン
+# （div.message-actions）が本文より前に入っている
+MESSAGE_HTML_WITH_ACTIONS = """
+<div class="pmessage">
+    <div class="header">
+        <span class="printuser"><a href="http://www.wikidot.com/user:info/sender" onclick="WIKIDOT.page.listeners.userInfo(11111); return false;">sender</a></span>
+        <span class="printuser"><a href="http://www.wikidot.com/user:info/recipient" onclick="WIKIDOT.page.listeners.userInfo(22222); return false;">recipient</a></span>
+        <span class="subject">markup test</span>
+        <span class="odate time_1234567890">01 Jan 2023 12:00</span>
+    </div>
+    <div class="body">
+        <div class="message-actions text-center">
+            <div class="btn-group">
+                <a href="javascript:;" class="awesome btn btn-default btn-xs" onclick="WIKIDOT.modules.DMViewMessageModule.replyMessage(1)"><i class="icon-reply"></i> 返信</a>
+                <a href="javascript:;" class="awesome btn btn-default btn-xs" onclick="WIKIDOT.modules.DMViewMessageModule.removeMessage(1, '#/inbox/p1')"><i class="icon-trash"></i> 削除</a>
+            </div>
+        </div>
+<p>1行目の本文です。<br/>
+2行目の本文です。</p>
+    </div>
+</div>
+"""
+
+
+class TestBodyExtraction:
+    """DMViewMessageModuleの本文抽出のテスト"""
+
+    def test_body_excludes_action_buttons(self, mock_client):
+        """本文に返信/削除ボタンのラベルが混入しない（回帰: bug-triggering input）"""
+        mock_client.amc_client.request.return_value = [_ok_response(MESSAGE_HTML_WITH_ACTIONS)]
+
+        result = PrivateMessageCollection.from_ids(mock_client, [1])
+
+        assert len(result) == 1
+        message = result[0]
+        assert message.body == "1行目の本文です。\n2行目の本文です。"
+        assert "返信" not in message.body
+        assert "削除" not in message.body
+        assert message.subject == "markup test"


### PR DESCRIPTION
## Summary

受信 PM の本文に返信/削除ボタンのテキストが混入するバグの修正（wikidot-ts 側と同時修正で機能等価性を維持）。

## Related Issue

なし（wikidot-ts 側: 同名ブランチの PR）

## Changes

- `from_ids()` の本文抽出で `div.body` 内の `div.message-actions`（返信/削除ボタン）を `decompose()` してから `get_text()` する
- `subject` / `body` に `strip()` を追加し wikidot-ts の `trim` 挙動に揃える
- 実機採取 markup（2026-08-05）を回帰テストとして追加、バージョンを 4.5.2 に更新

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring
- [x] Test addition/modification
- [ ] CI/CD or build related

## Testing

- [x] `make format` passes
- [x] `make lint` passes
- [x] `make test` passes

## Checklist

- [x] Code follows the project's style guidelines
- [x] Documentation has been updated as needed
- [x] Tests have been added for the changes (if applicable)

## Additional Information

特になし
